### PR TITLE
bugfix/409_currency_rounding_not_applied

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodeInput.vue
+++ b/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodeInput.vue
@@ -36,7 +36,7 @@ const lastSavedEanCode = ref(props.initialEanCode?.ean || '');
 const defaultSwalOptions = {
   title: t('products.eanCodes.invalidEanCodeAlert.title'),
   text: t('products.eanCodes.invalidEanCodeAlert.text'),
-  confirmButtonText: t('shared.alert.mutationAlert.confirmButtonText'),
+  confirmButtonText: t('shared.alert.mutationAlert.confirmButtonTextSimpleYes'),
   cancelButtonText: t('shared.alert.mutationAlert.cancelButtonText'),
   icon: 'warning',
   showCancelButton: true,

--- a/src/core/settings/currencies/configs.ts
+++ b/src/core/settings/currencies/configs.ts
@@ -97,14 +97,14 @@ export const getNonDefaultFields = (t): FormField[] => {
       name: 'exchangeRate',
       label: t('settings.currencies.labels.exchangeRate'),
       placeholder: t('settings.currencies.placeholders.exchangeRate'),
-      number: true,
+      float: true,
     },
     {
       type: FieldType.Text,
       name: 'roundPricesUpTo',
       label: t('settings.currencies.labels.roundPricesUpTo'),
       placeholder: t('settings.currencies.placeholders.roundPricesUpTo'),
-      number: true,
+      float: true,
     },
   ];
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -241,6 +241,7 @@
         "title": "Are you sure?",
         "text": "You won't be able to revert this!",
         "confirmButtonText": "Yes, delete it!",
+        "confirmButtonTextSimpleYes": "Yes, continue!",
         "cancelButtonText": "No, cancel!"
       },
       "toast": {


### PR DESCRIPTION
Fix rounding not correctly being saved.

## Summary by Sourcery

Fix currency configuration and EAN code input form validation settings

Bug Fixes:
- Corrected field type for exchange rate and price rounding to use float instead of number
- Updated confirmation button text in EAN code input validation