### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run the application locally, you need to start both the frontend and the back
 
 ### Starting the Frontend
 
-1. In a new terminal window, navigate to the OneSila Frontend director
+1. In a new terminal window, navigate to the OneSila Frontend directory
 2. Run the following command to start the frontend service:
 
 ```bash


### PR DESCRIPTION
## Summary
- fix a typo in the README so the instructions correctly reference a directory

## Testing
- `grep -n "directory" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_683ffbf89e48832e9d644e26f82f0a6c