### PR TITLE
Add Amazon integration type

### DIFF
--- a/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
+++ b/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
@@ -10,16 +10,25 @@ import {
   IntegrationCreateWizardForm,
   IntegrationTypes,
   getMagentoDefaultFields,
-  AuthenticationMethod, MagentoChannelInfo, ShopifyChannelInfo, getDefaultFields, getShopifyDefaultFields
+  AuthenticationMethod,
+  MagentoChannelInfo,
+  ShopifyChannelInfo,
+  AmazonChannelInfo,
+  getDefaultFields,
+  getShopifyDefaultFields,
+  getAmazonDefaultFields
 } from "../integrations";
 import { TypeStep } from "./containers/type-step";
 import { GeneralInfoStep } from "./containers/general-info-step";
 import { SalesChannelStep } from "./containers/sales-channel-step";
 import { MagentoChannelInfoStep } from "./containers/integration-specific-step/magento";
 import { ShopifyChannelInfoStep } from "./containers/integration-specific-step/shopify";
+import { AmazonChannelInfoStep } from "./containers/integration-specific-step/amazon";
 import {
   createMagentoSalesChannelMutation,
-  createShopifySalesChannelMutation, getShopifyRedirectUrlMutation
+  createShopifySalesChannelMutation,
+  createAmazonSalesChannelMutation,
+  getShopifyRedirectUrlMutation
 } from "../../../../shared/api/mutations/salesChannels.js";
 import { Toast } from "../../../../shared/modules/toast";
 import { processGraphQLErrors } from "../../../../shared/utils";
@@ -58,7 +67,7 @@ const form = reactive<IntegrationCreateWizardForm>({
     importOrders: true,
   }
 });
-const specificChannelInfo = ref<ShopifyChannelInfo | MagentoChannelInfo | {}>({});
+const specificChannelInfo = ref<ShopifyChannelInfo | MagentoChannelInfo | AmazonChannelInfo | {}>({});
 
 if (isExternalInstall.value && selectedIntegrationType.value === IntegrationTypes.Shopify) {
 
@@ -101,6 +110,8 @@ watch(selectedIntegrationType, (newType) => {
     Object.assign(specificChannelInfo.value, getShopifyDefaultFields());
   } else if (newType === IntegrationTypes.Magento) {
     Object.assign(specificChannelInfo.value, getMagentoDefaultFields());
+  } else if (newType === IntegrationTypes.Amazon) {
+    Object.assign(specificChannelInfo.value, getAmazonDefaultFields());
   } else {
     specificChannelInfo.value = {};
   }
@@ -114,6 +125,10 @@ const stepFourLabel = computed(() => {
 
   if (selectedIntegrationType.value === IntegrationTypes.Shopify) {
     return t('integrations.create.wizard.step4.shopify.title');
+  }
+
+  if (selectedIntegrationType.value === IntegrationTypes.Amazon) {
+    return t('integrations.create.wizard.step4.amazon.title');
   }
 
   return t('integrations.create.wizard.step4.title');
@@ -193,6 +208,9 @@ const getIntegrationComponent = () => {
   if (selectedIntegrationType.value === IntegrationTypes.Shopify) {
     return ShopifyChannelInfoStep;
   }
+  if (selectedIntegrationType.value === IntegrationTypes.Amazon) {
+    return AmazonChannelInfoStep;
+  }
   return null;
 };
 
@@ -203,6 +221,8 @@ const getIntegrationMutation = () => {
       return createMagentoSalesChannelMutation;
     case IntegrationTypes.Shopify:
       return createShopifySalesChannelMutation;
+    case IntegrationTypes.Amazon:
+      return createAmazonSalesChannelMutation;
     default:
       return null;
   }
@@ -214,6 +234,8 @@ const getIntegrationMutationKey = () => {
       return 'createMagentoSalesChannel';
     case IntegrationTypes.Shopify:
       return 'createShopifySalesChannel';
+    case IntegrationTypes.Amazon:
+      return 'createAmazonSalesChannel';
     default:
       return '';
   }

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/amazon/AmazonChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/amazon/AmazonChannelInfoStep.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Label } from "../../../../../../../shared/components/atoms/label";
+import { Selector } from "../../../../../../../shared/components/atoms/selector";
+import type { AmazonChannelInfo } from '../../../../integrations';
+
+const props = defineProps<{
+  channelInfo: AmazonChannelInfo
+}>();
+
+const { t } = useI18n();
+
+const regionChoices = [
+  { id: 'NORTH_AMERICA', text: t('integrations.regions.northAmerica') },
+  { id: 'EUROPE', text: t('integrations.regions.europe') },
+  { id: 'FAR_EAST', text: t('integrations.regions.farEast') },
+];
+</script>
+
+<template>
+  <div>
+    <h1 class="text-2xl text-center mb-2">
+      {{ t('integrations.create.wizard.step4.amazon.content') }}
+    </h1>
+    <hr />
+    <Flex vertical>
+      <FlexCell>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.region') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <div class="w-96">
+                  <Selector
+                    class="w-full"
+                    v-model="channelInfo.region"
+                    :options="regionChoices"
+                    value-by="id"
+                    label-by="text"
+                    :removable="false"
+                  />
+                </div>
+              </FlexCell>
+            </Flex>
+          </FlexCell>
+        </Flex>
+      </FlexCell>
+    </Flex>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/amazon/index.ts
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/amazon/index.ts
@@ -1,0 +1,1 @@
+export { default as AmazonChannelInfoStep } from './AmazonChannelInfoStep.vue';

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
@@ -5,6 +5,7 @@ import { IntegrationTypes } from "../../../integrations";
 import magentoType from "../../../../../../assets/images/integration-types/magento.png";
 import shopifyType from "../../../../../../assets/images/integration-types/shopify.png";
 import woocomerceType from "../../../../../../assets/images/integration-types/woo-commerce.jpg";
+import amazonType from "../../../../../../assets/images/integration-types/amazon.png";
 import { OptionSelector } from "../../../../../../shared/components/molecules/option-selector";
 import { Image } from "../../../../../../shared/components/atoms/image";
 import { Icon } from "../../../../../../shared/components/atoms/icon";
@@ -35,6 +36,7 @@ watch(
 const typeChoices = [
   { name: IntegrationTypes.Magento, disabled: false },
   { name: IntegrationTypes.Shopify, disabled: false, banner: t('shared.labels.beta') },
+  { name: IntegrationTypes.Amazon, disabled: false, banner: t('shared.labels.beta') },
   { name: IntegrationTypes.Woocommerce, disabled: true }
 ];
 
@@ -132,6 +134,13 @@ const closeModal = () => {
           <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.shopifyTitle') }}</h3>
           <p class="mb-4">{{ t('integrations.create.wizard.step1.shopifyExample') }}</p>
           <Image :source="shopifyType" alt="Shopify" class="w-full max-h-[35rem]" />
+        </div>
+      </template>
+      <template #amazon>
+        <div>
+          <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.amazonTitle') }}</h3>
+          <p class="mb-4">{{ t('integrations.create.wizard.step1.amazonExample') }}</p>
+          <Image :source="amazonType" alt="Amazon" class="w-full max-h-[35rem]" />
         </div>
       </template>
       <template #woocommerce>

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -6,6 +6,12 @@ export enum IntegrationTypes {
   None = 'none',
 }
 
+export enum AmazonRegions {
+  NORTH_AMERICA = 'NORTH_AMERICA',
+  EUROPE = 'EUROPE',
+  FAR_EAST = 'FAR_EAST',
+}
+
 export enum AuthenticationMethod {
   TOKEN = 'TOK',
   PASSWORD = 'PAS'
@@ -58,6 +64,10 @@ export interface ShopifyChannelInfo extends SpecificChannelInfo {
   isExternalInstall?: boolean;
 }
 
+export interface AmazonChannelInfo extends SpecificChannelInfo {
+  region: string | null;
+}
+
 
 /**
  * The complete integration create wizard form.
@@ -83,12 +93,20 @@ export function getShopifyDefaultFields(): ShopifyChannelInfo {
   };
 }
 
+export function getAmazonDefaultFields(): AmazonChannelInfo {
+  return {
+    region: null,
+  };
+}
+
 export const getDefaultFields = (type: IntegrationTypes) => {
   switch (type) {
     case IntegrationTypes.Magento:
       return getMagentoDefaultFields();
     case IntegrationTypes.Shopify:
       return getShopifyDefaultFields();
+    case IntegrationTypes.Amazon:
+      return getAmazonDefaultFields();
     default:
       return {};
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2150,6 +2150,8 @@
           "magentoExample": "Integrate with Magento to manage your online store seamlessly.",
           "shopifyTitle": "Shopify",
           "shopifyExample": "Shopify integration to manage your products in seconds.",
+          "amazonTitle": "Amazon",
+          "amazonExample": "Amazon integration to manage your marketplace listings.",
           "woocommerceTitle": "Woocommerce",
           "woocommerceExample": "Woocommerce integration is coming soon.",
           "magentoInfoModal": {
@@ -2189,6 +2191,10 @@
             "title": "Shopify Channel Details",
             "content": "Provide Shopify-specific configuration to connect your store."
           },
+          "amazon": {
+            "title": "Amazon Channel Details",
+            "content": "Provide Amazon-specific configuration to connect your marketplace."
+          },
           "title": "Specific Channel Info"
         }
       }
@@ -2210,6 +2216,7 @@
       "attributeSetSkeletonId": "Attribute Set Skeleton ID",
       "eanCodeAttribute": "EAN Code Attribute",
       "vendorProperty": "Vendor Property",
+      "region": "Region",
       "pullData": "Pull Data"
     },
     "placeholders": {
@@ -2217,6 +2224,11 @@
       "hostApiKey": "Enter Access Token",
       "attributeSetSkeletonId": "Enter attribute set skeleton ID",
       "eanCodeAttribute": "Enter EAN code attribute"
+    },
+    "regions": {
+      "northAmerica": "North America",
+      "europe": "Europe",
+      "farEast": "Far East"
     },
     "salesChannel": {
       "shopify": {

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -39,6 +39,24 @@ export const updateShopifySalesChannelMutation = gql`
   }
 `;
 
+export const createAmazonSalesChannelMutation = gql`
+  mutation createAmazonSalesChannel($data: AmazonSalesChannelInput!) {
+    createAmazonSalesChannel(data: $data) {
+      id
+      hostname
+    }
+  }
+`;
+
+export const updateAmazonSalesChannelMutation = gql`
+  mutation updateAmazonSalesChannel($data: AmazonSalesChannelPartialInput!) {
+    updateAmazonSalesChannel(data: $data) {
+      id
+      hostname
+    }
+  }
+`;
+
 
 // Sales Channel Mutations
 export const createSalesChannelMutation = gql`


### PR DESCRIPTION
## Summary
- support Amazon integrations
- include Amazon region selector in integration wizard
- add Amazon mutations and wizard logic
- document Amazon strings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68403ea1d194832ea1b142c6f5dfd5a7

## Summary by Sourcery

Add Amazon as a supported integration type by introducing its data model, UI components in the creation wizard, and corresponding GraphQL mutations

New Features:
- Support Amazon integration in the creation wizard
- Introduce Amazon region selector as a dedicated wizard step
- Add GraphQL mutations for creating and updating Amazon sales channels
- Add Amazon integration option in the type-selection UI with localized strings

Enhancements:
- Define AmazonChannelInfo interface, AmazonRegions enum, and default fields function

Documentation:
- Add localization keys and text for Amazon integration UI