### PR TITLE
Add Amazon country selector

### DIFF
--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/amazon/AmazonChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/amazon/AmazonChannelInfoStep.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import { defineProps, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Label } from "../../../../../../../shared/components/atoms/label";
 import { Selector } from "../../../../../../../shared/components/atoms/selector";
-import { AmazonChannelInfo, AmazonRegions } from '../../../../integrations';
+import { AmazonChannelInfo, AmazonRegions, AmazonCountries } from '../../../../integrations';
 
 const props = defineProps<{
   channelInfo: AmazonChannelInfo
@@ -16,6 +16,52 @@ const regionChoices = [
   { id: AmazonRegions.EUROPE, text: t('integrations.regions.europe') },
   { id: AmazonRegions.FAR_EAST, text: t('integrations.regions.farEast') },
 ];
+
+const countryChoices = computed(() => {
+  switch (props.channelInfo.region) {
+    case AmazonRegions.NORTH_AMERICA:
+      return [
+        { id: AmazonCountries.CANADA, text: t('integrations.countries.canada') },
+        { id: AmazonCountries.UNITED_STATES, text: t('integrations.countries.unitedStates') },
+        { id: AmazonCountries.MEXICO, text: t('integrations.countries.mexico') },
+        { id: AmazonCountries.BRAZIL, text: t('integrations.countries.brazil') },
+      ];
+    case AmazonRegions.EUROPE:
+      return [
+        { id: AmazonCountries.IRELAND, text: t('integrations.countries.ireland') },
+        { id: AmazonCountries.SPAIN, text: t('integrations.countries.spain') },
+        { id: AmazonCountries.UNITED_KINGDOM, text: t('integrations.countries.unitedKingdom') },
+        { id: AmazonCountries.FRANCE, text: t('integrations.countries.france') },
+        { id: AmazonCountries.BELGIUM, text: t('integrations.countries.belgium') },
+        { id: AmazonCountries.NETHERLANDS, text: t('integrations.countries.netherlands') },
+        { id: AmazonCountries.GERMANY, text: t('integrations.countries.germany') },
+        { id: AmazonCountries.ITALY, text: t('integrations.countries.italy') },
+        { id: AmazonCountries.SWEDEN, text: t('integrations.countries.sweden') },
+        { id: AmazonCountries.SOUTH_AFRICA, text: t('integrations.countries.southAfrica') },
+        { id: AmazonCountries.POLAND, text: t('integrations.countries.poland') },
+        { id: AmazonCountries.EGYPT, text: t('integrations.countries.egypt') },
+        { id: AmazonCountries.TURKEY, text: t('integrations.countries.turkey') },
+        { id: AmazonCountries.SAUDI_ARABIA, text: t('integrations.countries.saudiArabia') },
+        { id: AmazonCountries.UNITED_ARAB_EMIRATES, text: t('integrations.countries.unitedArabEmirates') },
+        { id: AmazonCountries.INDIA, text: t('integrations.countries.india') },
+      ];
+    case AmazonRegions.FAR_EAST:
+      return [
+        { id: AmazonCountries.SINGAPORE, text: t('integrations.countries.singapore') },
+        { id: AmazonCountries.AUSTRALIA, text: t('integrations.countries.australia') },
+        { id: AmazonCountries.JAPAN, text: t('integrations.countries.japan') },
+      ];
+    default:
+      return [];
+  }
+});
+
+watch(
+  () => props.channelInfo.region,
+  () => {
+    props.channelInfo.country = null;
+  }
+);
 </script>
 
 <template>
@@ -40,6 +86,32 @@ const regionChoices = [
                     class="w-full"
                     v-model="channelInfo.region"
                     :options="regionChoices"
+                    value-by="id"
+                    label-by="text"
+                    :removable="false"
+                  />
+                </div>
+              </FlexCell>
+            </Flex>
+          </FlexCell>
+        </Flex>
+      </FlexCell>
+
+      <FlexCell>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.country') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <div class="w-96">
+                  <Selector
+                    class="w-full"
+                    v-model="channelInfo.country"
+                    :options="countryChoices"
                     value-by="id"
                     label-by="text"
                     :removable="false"

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -12,6 +12,32 @@ export enum AmazonRegions {
   FAR_EAST = 'FE',
 }
 
+export enum AmazonCountries {
+  CANADA = 'CA',
+  UNITED_STATES = 'US',
+  MEXICO = 'MX',
+  BRAZIL = 'BR',
+  IRELAND = 'IE',
+  SPAIN = 'ES',
+  UNITED_KINGDOM = 'GB',
+  FRANCE = 'FR',
+  BELGIUM = 'BE',
+  NETHERLANDS = 'NL',
+  GERMANY = 'DE',
+  ITALY = 'IT',
+  SWEDEN = 'SE',
+  SOUTH_AFRICA = 'ZA',
+  POLAND = 'PL',
+  EGYPT = 'EG',
+  TURKEY = 'TR',
+  SAUDI_ARABIA = 'SA',
+  UNITED_ARAB_EMIRATES = 'AE',
+  INDIA = 'IN',
+  SINGAPORE = 'SG',
+  AUSTRALIA = 'AU',
+  JAPAN = 'JP',
+}
+
 export enum AuthenticationMethod {
   TOKEN = 'TOK',
   PASSWORD = 'PAS'
@@ -66,6 +92,7 @@ export interface ShopifyChannelInfo extends SpecificChannelInfo {
 
 export interface AmazonChannelInfo extends SpecificChannelInfo {
   region: string | null;
+  country: string | null;
 }
 
 
@@ -96,6 +123,7 @@ export function getShopifyDefaultFields(): ShopifyChannelInfo {
 export function getAmazonDefaultFields(): AmazonChannelInfo {
   return {
     region: null,
+    country: null,
   };
 }
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2217,6 +2217,7 @@
       "eanCodeAttribute": "EAN Code Attribute",
       "vendorProperty": "Vendor Property",
       "region": "Region",
+      "country": "Country",
       "pullData": "Pull Data"
     },
     "placeholders": {
@@ -2229,6 +2230,31 @@
       "northAmerica": "North America",
       "europe": "Europe",
       "farEast": "Far East"
+    },
+    "countries": {
+      "canada": "Canada",
+      "unitedStates": "United States",
+      "mexico": "Mexico",
+      "brazil": "Brazil",
+      "ireland": "Ireland",
+      "spain": "Spain",
+      "unitedKingdom": "United Kingdom",
+      "france": "France",
+      "belgium": "Belgium",
+      "netherlands": "Netherlands",
+      "germany": "Germany",
+      "italy": "Italy",
+      "sweden": "Sweden",
+      "southAfrica": "South Africa",
+      "poland": "Poland",
+      "egypt": "Egypt",
+      "turkey": "Turkey",
+      "saudiArabia": "Saudi Arabia",
+      "unitedArabEmirates": "United Arab Emirates",
+      "india": "India",
+      "singapore": "Singapore",
+      "australia": "Australia",
+      "japan": "Japan"
     },
     "salesChannel": {
       "shopify": {


### PR DESCRIPTION
## Summary
- add AmazonCountries enum to central integrator constants
- use AmazonCountries instead of raw codes in AmazonChannelInfoStep

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684075f4d7c4832e9d45e30b49ac9df2