### PR TITLE
Add Amazon integration tabs

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -25,7 +25,6 @@ import { Currencies } from "./containers/currencies";
 import { Imports } from "./containers/imports";
 import { refreshSalesChannelWebsitesMutation } from "../../../../shared/api/mutations/salesChannels";
 import {Toast} from "../../../../shared/modules/toast";
-import {ProductType} from "../../../../shared/utils/constants";
 
 const router = useRouter();
 const route = useRoute();
@@ -49,6 +48,14 @@ const tabItems = ref([
   { name: 'currencies', label: t('settings.currencies.title'), icon: 'money-bill' },
   { name: 'imports', label: t('shared.tabs.imports'), icon: 'file-import' }
 ]);
+
+if (type.value === IntegrationTypes.Amazon) {
+  tabItems.value.push(
+    { name: 'productRules', label: t('properties.rule.title'), icon: 'cog' },
+    { name: 'properties', label: t('properties.title'), icon: 'screwdriver-wrench' },
+    { name: 'propertySelectValues', label: t('properties.values.title'), icon: 'sitemap' }
+  );
+}
 
 const getIntegrationQuery = () => {
   switch (type.value) {
@@ -214,6 +221,21 @@ const pullData = async () => {
           <!-- Imports Tab -->
           <template #imports>
             <Imports v-if="salesChannelId && integrationId" :id="id" :sales-channel-id="salesChannelId" />
+          </template>
+
+          <!-- Product Rules Tab (Amazon only) -->
+          <template #productRules>
+            <div />
+          </template>
+
+          <!-- Properties Tab (Amazon only) -->
+          <template #properties>
+            <div />
+          </template>
+
+          <!-- Property Select Values Tab (Amazon only) -->
+          <template #propertySelectValues>
+            <div />
           </template>
         </Tabs>
       </Card>

--- a/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
@@ -15,6 +15,7 @@ import { updateAmazonSalesChannelMutation } from "../../../../../../../shared/ap
 import { processGraphQLErrors } from "../../../../../../../shared/utils";
 import { AmazonRegions, AmazonCountries } from "../../../../integrations";
 import {FieldDate} from "../../../../../../../shared/components/organisms/general-show/containers/field-date";
+import { FieldType } from "../../../../../../../shared/utils/constants";
 
 interface EditAmazonForm {
   id: string;
@@ -166,7 +167,7 @@ useShiftBackspaceKeyboardListener(goBack);
           {{ t('integrations.labels.refreshTokenExpiration') }}
         </Label>
         <div class="flex items-center gap-4">
-          <FieldDate :class="refreshClass" :field="{ name: 'refreshTokenExpiration' }" :model-value="formData.refreshTokenExpiration" />
+          <FieldDate :class="refreshClass" :field="{ name: 'refreshTokenExpiration', type: FieldType.Date }" :model-value="formData.refreshTokenExpiration || ''" />
           <PrimaryButton @click="handleRefresh">{{ t('shared.button.refresh') }}</PrimaryButton>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add Amazon-only tab items without content
- remove placeholder components for management tabs
- set field type on Amazon refresh token date

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684184018f38832eb3f9a31cd6daca32

## Summary by Sourcery

Add Amazon-specific tabs to the integrations detail view and correct the refresh token expiration field type for Amazon integrations.

New Features:
- Add three Amazon-only tabs (Product Rules, Properties, Property Select Values) with placeholder content in the integration detail view.

Bug Fixes:
- Set the FieldDate component for Amazon refresh token expiration to use a date type and supply a default value.

Enhancements:
- Remove unused ProductType import from IntegrationsShowController.