### PR TITLE
Add WooCommerce import wizard

### DIFF
--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/woocommerce/WoocommerceChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/woocommerce/WoocommerceChannelInfoStep.vue
@@ -1,12 +1,25 @@
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import { defineProps, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Label } from "../../../../../../../shared/components/atoms/label";
 import { TextInput } from "../../../../../../../shared/components/atoms/input-text";
+import { Icon } from "../../../../../../../shared/components/atoms/icon";
+import { Modal } from "../../../../../../../shared/components/atoms/modal";
+import { Card } from "../../../../../../../shared/components/atoms/card";
 import type { WoocommerceChannelInfo } from '../../../../integrations';
 
 const props = defineProps<{ channelInfo: WoocommerceChannelInfo }>();
 const { t } = useI18n();
+
+const showWooCommerceInfoModal = ref(false);
+
+const onModalOpen = () => {
+  showWooCommerceInfoModal.value = true;
+};
+
+const closeModal = () => {
+  showWooCommerceInfoModal.value = false;
+};
 </script>
 
 <template>
@@ -16,6 +29,16 @@ const { t } = useI18n();
     </h1>
     <hr />
     <Flex vertical>
+      <!-- Info Icon with Modal -->
+      <FlexCell>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Icon class="text-gray-500 cursor-pointer" @click="onModalOpen" name="circle-info" size="lg" />
+          </FlexCell>
+        </Flex>
+      </FlexCell>
+
+      <!-- API Key Field -->
       <FlexCell>
         <Flex class="mt-4 gap-4" center>
           <FlexCell center>
@@ -36,6 +59,8 @@ const { t } = useI18n();
           </FlexCell>
         </Flex>
       </FlexCell>
+
+      <!-- API Secret Field -->
       <FlexCell>
         <Flex class="mt-4 gap-4" center>
           <FlexCell center>
@@ -57,5 +82,50 @@ const { t } = useI18n();
         </Flex>
       </FlexCell>
     </Flex>
+
+    <!-- WooCommerce Info Modal -->
+    <Modal v-model="showWooCommerceInfoModal">
+      <Card>
+        <template #header>
+          <h3 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.title') }}</h3>
+        </template>
+        <template #body>
+          <div class="space-y-6">
+            <!-- Integration Section -->
+            <div>
+              <h4 class="font-semibold mb-2">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationTitle') }}</h4>
+              <p class="mb-4">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationDescription') }}</p>
+              <ol class="list-decimal list-inside space-y-2">
+                <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationStep1') }}</li>
+                <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationStep2') }}</li>
+                <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationStep3') }}</li>
+              </ol>
+            </div>
+
+            <!-- API Settings Section -->
+            <div>
+              <h4 class="font-semibold mb-2">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.apiSettingsTitle') }}</h4>
+              <p class="mb-4">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.apiSettingsDescription') }}</p>
+              <ul class="list-disc list-inside space-y-2">
+                <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.apiSetting1') }}</li>
+                <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.apiSetting2') }}</li>
+              </ul>
+            </div>
+
+            <!-- Import Section -->
+            <div>
+              <h4 class="font-semibold mb-2">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.importTitle') }}</h4>
+              <p>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.importRecommendation') }}</p>
+            </div>
+
+            <!-- EAN Codes Section -->
+            <div>
+              <h4 class="font-semibold mb-2">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.eanTitle') }}</h4>
+              <p>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.eanDescription') }}</p>
+            </div>
+          </div>
+        </template>
+      </Card>
+    </Modal>
   </div>
 </template>

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
@@ -20,6 +20,7 @@ const { t } = useI18n();
 
 const selectedType = ref(props.type);
 const showMagentoInfoModal = ref(false);
+const showWooCommerceInfoModal = ref(false);
 
 watch(selectedType, (newVal) => {
   emit('update:type', newVal);
@@ -38,12 +39,17 @@ const typeChoices = [
   { name: IntegrationTypes.Woocommerce, disabled: false }
 ];
 
-const onModalOpen = () => {
+const onMagentoModalOpen = () => {
   showMagentoInfoModal.value = true;
+}
+
+const onWooCommerceModalOpen = () => {
+  showWooCommerceInfoModal.value = true;
 }
 
 const closeModal = () => {
   showMagentoInfoModal.value = false;
+  showWooCommerceInfoModal.value = false;
 }
 
 </script>
@@ -53,6 +59,8 @@ const closeModal = () => {
     <h1 class="text-2xl text-center mb-2">
       {{ t('integrations.create.wizard.step1.content') }}
     </h1>
+    
+    <!-- Magento Info Modal -->
     <Modal v-if="showMagentoInfoModal" v-model="showMagentoInfoModal" @closed="showMagentoInfoModal = false">
       <Card class="modal-content w-[80%] px-10 pt-10">
         <div class="mb-6">
@@ -110,8 +118,66 @@ const closeModal = () => {
         </div>
       </Card>
     </Modal>
+
+    <!-- WooCommerce Info Modal -->
+    <Modal v-if="showWooCommerceInfoModal" v-model="showWooCommerceInfoModal" @closed="showWooCommerceInfoModal = false">
+      <Card class="modal-content w-[80%] px-10 pt-10">
+        <div class="mb-6">
+          <h3 class="text-xl font-semibold leading-7 text-gray-900">
+            {{ t('integrations.create.wizard.step1.woocommerceInfoModal.title') }}
+          </h3>
+        </div>
+        <div class="space-y-6 pr-2 mb=4 overflow-y-auto max-h-96">
+          <!-- Integration Section -->
+          <div>
+            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationTitle') }}</h4>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationDescription') }}
+            </p>
+            <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
+              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationStep1') }}</li>
+              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationStep2') }}</li>
+              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.integrationStep3') }}</li>
+            </ul>
+          </div>
+
+          <!-- API Settings Section -->
+          <div>
+            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.apiSettingsTitle') }}</h4>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.woocommerceInfoModal.apiSettingsDescription') }}
+            </p>
+            <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
+              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.apiSetting1') }}</li>
+              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.apiSetting2') }}</li>
+            </ul>
+          </div>
+
+          <!-- Import Section -->
+          <div>
+            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.importTitle') }}</h4>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.woocommerceInfoModal.importRecommendation') }}
+            </p>
+          </div>
+
+          <!-- EAN Codes Section -->
+          <div>
+            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.woocommerceInfoModal.eanTitle') }}</h4>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.woocommerceInfoModal.eanDescription') }}
+            </p>
+          </div>
+        </div>
+
+        <hr/>
+        <div class="flex justify-end gap-4 mt-4">
+          <Button class="btn btn-outline-dark" @click="closeModal">{{ t('shared.button.cancel') }}</Button>
+        </div>
+      </Card>
+    </Modal>
+
     <hr />
-    <!-- OptionSelector uses v-model bound to our local selectedType and the choices array -->
     <OptionSelector v-model="selectedType" :choices="typeChoices">
       <template #magento>
         <div>
@@ -120,7 +186,7 @@ const closeModal = () => {
               <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.magentoTitle') }}</h3>
             </FlexCell>
             <FlexCell center>
-              <Icon class="text-gray-500" @click.stop="onModalOpen" name="circle-info" size="lg" />
+              <Icon class="text-gray-500 cursor-pointer" @click.stop="onMagentoModalOpen" name="circle-info" size="lg" />
             </FlexCell>
           </Flex>
           <p class="mb-4">{{ t('integrations.create.wizard.step1.magentoExample') }}</p>
@@ -136,7 +202,14 @@ const closeModal = () => {
       </template>
       <template #woocommerce>
         <div>
-          <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.woocommerceTitle') }}</h3>
+          <Flex gap="2">
+            <FlexCell center>
+              <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.woocommerceTitle') }}</h3>
+            </FlexCell>
+            <FlexCell center>
+              <Icon class="text-gray-500 cursor-pointer" @click.stop="onWooCommerceModalOpen" name="circle-info" size="lg" />
+            </FlexCell>
+          </Flex>
           <p class="mb-4">{{ t('integrations.create.wizard.step1.woocommerceExample') }}</p>
           <Image :source="woocommerceType" alt="woocommerce" class="w-full max-h-[35rem]" />
         </div>

--- a/src/core/integrations/integrations/integrations-show/containers/general/woocommerce-general-tab/WoocommerceGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/woocommerce-general-tab/WoocommerceGeneralInfoTab.vue
@@ -11,6 +11,7 @@ import { Toast } from "../../../../../../../shared/modules/toast";
 import { processGraphQLErrors } from "../../../../../../../shared/utils";
 import { useRouter } from "vue-router";
 import { updateWoocommerceSalesChannelMutation } from "../../../../../../../shared/api/mutations/salesChannels.js";
+import { Accordion } from "../../../../../../../shared/components/atoms/accordion";
 
 interface EditWoocommerceForm {
   id: string;
@@ -35,6 +36,11 @@ const fieldErrors = ref<Record<string, string>>({});
 const router = useRouter();
 const submitButtonRef = ref();
 const submitContinueButtonRef = ref();
+
+const accordionItems = [
+  { name: 'throttling', label: t('integrations.show.sections.throttling'), icon: 'gauge' },
+  { name: 'sync', label: t('integrations.show.sections.syncPreferences'), icon: 'sync' }
+];
 
 watch(() => props.data, (newData) => {
   formData.value = { ...newData };
@@ -96,6 +102,58 @@ const handleSubmitAndContinueDone = () => Toast.success(t('shared.alert.toast.su
         <TextInput v-model="formData.apiSecret" class="w-full" :placeholder="t('integrations.placeholders.apiSecret')" />
       </div>
     </div>
+
+    <Accordion class="mt-8" :items="accordionItems">
+      <!-- Throttling -->
+      <template #throttling>
+        <div class="grid grid-cols-12 gap-4">
+          <div class="md:col-span-6 col-span-12">
+            <Label class="font-semibold block text-sm text-gray-900 mb-1">
+              {{ t('integrations.labels.requestsPerMinute') }}
+            </Label>
+            <TextInput v-model="formData.requestsPerMinute" :number="true" :min-number="1" :max-number="60" placeholder="60" class="w-full" />
+            <div class="mt-1 text-sm leading-6 text-gray-400">
+              <p class="text-red-500" v-if="fieldErrors['requestsPerMinute']">{{ fieldErrors['requestsPerMinute'] }}</p>
+              <p>{{ t('integrations.salesChannel.helpText.requestsPerMinute') }}</p>
+            </div>
+          </div>
+
+          <div class="md:col-span-6 col-span-12">
+            <Label class="font-semibold text-sm text-gray-900 mb-1">
+              {{ t('integrations.labels.maxRetries') }}
+            </Label>
+            <TextInput v-model="formData.maxRetries" :number="true" :min-number="1" :max-number="20" placeholder="3" class="w-full" />
+            <div class="mt-1 text-sm leading-6 text-gray-400">
+              <p class="text-red-500" v-if="fieldErrors['maxRetries']">{{ fieldErrors['maxRetries'] }}</p>
+              <p>{{ t('integrations.salesChannel.helpText.maxRetries') }}</p>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- Sync -->
+      <template #sync>
+        <div class="space-y-4">
+          <div class="grid grid-cols-12 items-center" v-for="toggleField in ['useConfigurableName', 'syncContents', 'syncEanCodes', 'syncPrices', 'importOrders']" :key="toggleField">
+            <div class="md:col-span-4 col-span-12">
+              <Flex gap="2">
+                <FlexCell>
+                  <Label class="font-semibold text-sm text-gray-900 mb-1">
+                    {{ t(`integrations.labels.${toggleField}`) }}
+                  </Label>
+                </FlexCell>
+                <FlexCell>
+                  <Toggle v-model="formData[toggleField]" />
+                </FlexCell>
+              </Flex>
+            </div>
+            <div class="md:col-span-8 col-span-12 text-sm text-gray-400">
+              {{ t(`integrations.salesChannel.helpText.${toggleField}`) }}
+            </div>
+          </div>
+        </div>
+      </template>
+    </Accordion>
 
     <div class="flex items-center justify-end gap-x-3 border-t border-gray-900/10 px-4 py-4 sm:px-8">
       <RouterLink :to="{ name: 'integrations.integrations.list' }">

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/ImportCreateController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/ImportCreateController.vue
@@ -5,8 +5,9 @@ import { useRoute, useRouter } from 'vue-router';
 import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../../shared/components/molecules/breadcrumbs";
 import { MagentoImporter } from "./containers/magento/magento-importer";
-import {IntegrationTypes} from "../../../../../integrations";
+import { IntegrationTypes } from "../../../../../integrations";
 import { ShopifyImporter } from "./containers/shopify/shopify-importer";
+import { WoocommerceImporter } from "./containers/woocommerce/woocommerce-importer";
 
 
 const { t } = useI18n();
@@ -32,6 +33,7 @@ const type = ref(String(route.params.type));
     <template #content>
       <MagentoImporter v-if="type == IntegrationTypes.Magento" :integration-id="integrationId" :type="type" />
       <ShopifyImporter v-else-if="type == IntegrationTypes.Shopify" :integration-id="integrationId" :type="type" />
+      <WoocommerceImporter v-else-if="type == IntegrationTypes.Woocommerce" :integration-id="integrationId" :type="type" />
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/woocommerce/woocommerce-importer/WoocommerceImporter.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/woocommerce/woocommerce-importer/WoocommerceImporter.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+
+
+import {Wizard} from "../../../../../../../../../../../shared/components/molecules/wizard";
+import {LanguagesAndCurrenciesStep} from "../../general/languages-and-currencies";
+import {computed, onMounted, ref} from "vue";
+import { RemoteCurrency, RemoteLanguage } from "../../../../../configs";
+import apolloClient from "../../../../../../../../../../../../apollo-client";
+import { getWoocommerceChannelQuery } from "../../../../../../../../../../../shared/api/queries/salesChannels";
+import {
+  bulkUpdateRemoteCurrenciesMutation,
+  bulkUpdateRemoteLanguagesMutation,
+  createSalesChannelImportMutation
+} from "../../../../../../../../../../../shared/api/mutations/salesChannels";
+import {Toast} from "../../../../../../../../../../../shared/modules/toast";
+import {useI18n} from "vue-i18n";
+import {useRoute, useRouter} from "vue-router";
+import {processGraphQLErrors} from "../../../../../../../../../../../shared/utils";
+
+const props = defineProps<{ integrationId: string; type: string }>();
+
+const salesChannelId = ref(null);
+const step = ref(0);
+const loading = ref(false);
+const finishLoading = ref(false);
+const currentFinishStep = ref<number | null>(null);
+
+const { t } = useI18n();
+const route = useRoute();
+const router = useRouter();
+
+const mappedData = ref<{
+  languages: RemoteLanguage[];
+  currencies: RemoteCurrency[];
+}>({
+  languages: [],
+  currencies: [],
+});
+
+const allowNextStep = computed(() => {
+  if (step.value === 0) {
+    const langsValid = mappedData.value.languages.length > 0 &&
+      mappedData.value.languages.every((l) => l.localInstance);
+    const currenciesValid = mappedData.value.currencies.length > 0 &&
+      mappedData.value.currencies.every((c) => c.localInstance);
+
+    return langsValid && currenciesValid;
+  }
+
+  return true;
+});
+
+
+const updateMappedData = (data) => {
+  mappedData.value = data;
+};
+
+const wizardSteps = [
+  { title: t('integrations.imports.create.wizard.step1.title'), name: 'generalStep' },
+];
+
+const updateStep = (val) => {
+  step.value = val;
+};
+
+const fetchIntegrationData = async () => {
+  try {
+    loading.value = true;
+    const { data } = await apolloClient.query({
+      query: getWoocommerceChannelQuery,
+      variables: { id: props.integrationId },
+      fetchPolicy: 'network-only'
+    });
+    const { __typename, integrationPtr, saleschannelPtr,  ...cleanData } = data['woocommerceChannel'];
+
+    salesChannelId.value = saleschannelPtr.id
+  } catch (error) {
+    console.error("Error fetching integration data:", error);
+  } finally {
+     loading.value = false;
+  }
+};
+
+
+onMounted(async () => {
+  await fetchIntegrationData();
+});
+
+
+const bulkUpdateRemoteLanguages = async () => {
+  try {
+    const data = mappedData.value.languages.map((language) => ({
+      id: language.id,
+      remoteCode: language.remoteCode,
+      localInstance: language.localInstance,
+    }));
+
+    const { data: result } = await apolloClient.mutate({
+      mutation: bulkUpdateRemoteLanguagesMutation,
+      variables: { data },
+    });
+
+  } catch (err) {
+    console.error('Error updating languages', err);
+    throw err;
+  }
+};
+
+
+const bulkUpdateRemoteCurrencies = async () => {
+  try {
+    const data = mappedData.value.currencies.map((currency) => ({
+      id: currency.id,
+      remoteCode: currency.remoteCode,
+      localInstance: { id: currency.localInstance } ,
+    }));
+
+    const { data: result } = await apolloClient.mutate({
+      mutation: bulkUpdateRemoteCurrenciesMutation,
+      variables: { data },
+    });
+
+  } catch (err) {
+    console.error('Error updating currencies', err);
+    throw err;
+  }
+};
+
+
+const createImport = async () => {
+  try {
+    const { data } = await apolloClient.mutate({
+      mutation: createSalesChannelImportMutation,
+      variables: {
+        data: {
+          salesChannel: { id: salesChannelId.value },
+          status: 'pending',
+        },
+      },
+    });
+
+  } catch (err) {
+    const validationErrors = processGraphQLErrors(err, t);
+    if (validationErrors['__all__']) {
+      Toast.error(validationErrors['__all__']);
+    }
+  }
+};
+
+const steps = [
+  { key: 'languages', action: bulkUpdateRemoteLanguages },
+  { key: 'currencies', action: bulkUpdateRemoteCurrencies },
+  { key: 'import', action: createImport },
+];
+
+const currentFinishStepName = computed(() =>
+  currentFinishStep.value !== null ? t(`integrations.imports.create.wizard.finish.steps.${steps[currentFinishStep.value].key}`) : ''
+);
+
+const handleFinish = async () => {
+  finishLoading.value = true;
+  currentFinishStep.value = null;
+
+  try {
+    for (let i = 0; i < steps.length; i++) {
+      currentFinishStep.value = i;
+      await steps[i].action();
+    }
+
+    Toast.success(t('integrations.imports.create.wizard.finish.successMessage'));
+    router.push({ name: 'integrations.integrations.show', params: { id: props.integrationId, type: props.type }, query: { tab: 'imports' } });
+  } catch (err) {
+    console.error(`Error at step "${currentFinishStepName.value}":`, err);
+    Toast.error(
+      t('integrations.imports.create.wizard.finish.errorMessage', {
+        step: currentFinishStepName.value
+      })
+    );
+  } finally {
+    finishLoading.value = false;
+    currentFinishStep.value = null;
+  }
+};
+
+
+</script>
+
+<template>
+  <div>
+    <div v-if="loading" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+        <div class="text-center">
+          <svg class="animate-spin h-10 w-10 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+          </svg>
+        </div>
+    </div>
+
+    <div v-if="finishLoading" class="fixed inset-0 z-50 flex items-center justify-center">
+      <div class="absolute inset-0 bg-black opacity-50"></div>
+        <div class="relative bg-white dark:bg-[#191e3a] rounded-lg p-6 w-96 shadow-lg z-50 flex flex-col items-center gap-4">
+          <h2 class="text-lg font-semibold text-center text-dark dark:text-white-light">
+            {{ t('integrations.imports.create.wizard.finish.title') }}
+          </h2>
+          <p class="text-sm text-gray-500 dark:text-white-light text-center">{{ currentFinishStepName }}</p>
+          <div class="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+            <div
+              class="h-full bg-primary transition-all"
+              :style="{ width: ((currentFinishStep !== null ? (currentFinishStep + 1) / steps.length : 0) * 100) + '%' }"
+            ></div>
+          </div>
+        </div>
+    </div>
+
+    <Wizard :steps="wizardSteps" :allow-next-step="allowNextStep" :show-buttons="true" @on-finish="handleFinish" @update-current-step="updateStep">
+        <template #generalStep>
+          <LanguagesAndCurrenciesStep v-if="salesChannelId" :sales-channel-id="salesChannelId" @update:mappedData="updateMappedData" />
+        </template>
+      </Wizard>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/woocommerce/woocommerce-importer/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/woocommerce/woocommerce-importer/index.ts
@@ -1,0 +1,1 @@
+export { default as WoocommerceImporter } from "./WoocommerceImporter.vue";

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -182,7 +182,7 @@
         },
         "setProductPropertyValue": {
           "title": "Set Product Property Value",
-          "details": "Assign the correct value to your product’s property. For example, set 'Brand' to 'Parker' for your pen."
+          "details": "Assign the correct value to your product's property. For example, set 'Brand' to 'Parker' for your pen."
         },
         "product": {
           "title": "Create a Simple Product",
@@ -413,7 +413,7 @@
         "aiBulkTranslator": {
           "button": "AI Translate",
           "title": "Translate {count} {type}",
-          "description": "This tool uses AI to auto-translate the selected entities. You’ll be able to preview and confirm translations in the next step (coming soon).",
+          "description": "This tool uses AI to auto-translate the selected entities. You'll be able to preview and confirm translations in the next step (coming soon).",
           "startButton": "Start Translation",
           "sourceLanguage": "Source Language",
           "targetLanguages": "Target Language(s)",
@@ -2153,7 +2153,7 @@
           "woocommerceTitle": "Woocommerce",
           "woocommerceExample": "WooCommerce integration to manage your products.",
           "magentoInfoModal": {
-          "title": "How to connect your Magento store",
+            "title": "How to connect your Magento store",
             "section": {
               "integrationTitle": "Create an integration in Magento",
               "integrationDescription": "Before connecting your store, make sure to create and activate an integration in your Magento Admin Panel.",
@@ -2170,11 +2170,27 @@
               "eanTitle": "EAN codes support",
               "eanDescription": "If you want to sync EAN codes, make sure you have an attribute with global scope in Magento. Don't worry, missing ones can also be created during the import process."
             }
+          },
+          "woocommerceInfoModal": {
+            "title": "How to connect your WooCommerce store",
+            "integrationTitle": "Create API credentials in WooCommerce",
+            "integrationDescription": "Before connecting your store, you need to create API credentials in your WooCommerce admin panel.",
+            "integrationStep1": "Go to WooCommerce → Settings → Advanced → REST API",
+            "integrationStep2": "Click 'Add Key' and create a new API key",
+            "integrationStep3": "Set the permissions to 'Read/Write'",
+            "apiSettingsTitle": "Configure your WooCommerce API settings",
+            "apiSettingsDescription": "Ensure your WooCommerce store has the following settings:",
+            "apiSetting1": "Enable REST API access",
+            "apiSetting2": "Configure SSL if using HTTPS",
+            "importTitle": "Perform an initial import",
+            "importRecommendation": "After setting up the integration, we recommend performing an import to bring your existing WooCommerce data into our system.",
+            "eanTitle": "EAN codes support",
+            "eanDescription": "If you want to sync EAN codes, make sure you have a custom field or attribute set up in WooCommerce for EAN codes."
           }
         },
         "step2": {
           "title": "General Information",
-          "content": "Enter your integration’s hostname and connection settings."
+          "content": "Enter your integration's hostname and connection settings."
         },
         "step3": {
           "title": "Sales Channel Preferences",


### PR DESCRIPTION
## Summary
- support WooCommerce in the import creation flow by adding a WooCommerce importer
- show WooCommerce importer when opening create import

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e65d4e0c8322980562861114b989

## Summary by Sourcery

Add support for WooCommerce imports by creating a dedicated importer wizard and exposing it in the import creation UI.

New Features:
- Introduce a WooCommerce importer component with a multi-step wizard for mapping languages, currencies, and initiating imports.
- Integrate WooCommerce as an option in the import creation flow alongside existing Magento and Shopify importers.