### PR TITLE
Add alias product creation link

### DIFF
--- a/src/core/products/products/product-create/ProductCreateController.vue
+++ b/src/core/products/products/product-create/ProductCreateController.vue
@@ -35,6 +35,7 @@ const step = ref(0);
 const loading = ref(false);
 
 const productTypePropertyValueId = ref(route.query.productTypePropertyValueId ? route.query.productTypePropertyValueId.toString() : null);
+const aliasProductParentId = ref(route.query.aliasProductParentId ? route.query.aliasProductParentId.toString() : null);
 
 const form: FormType = reactive({
   type: '',
@@ -66,6 +67,11 @@ const additionalFieldsForm: AdditonalFormFields = reactive({
       }
     }
 });
+
+if (aliasProductParentId.value) {
+  form.type = ProductType.Alias;
+  form.aliasParentProduct.id = aliasProductParentId.value;
+}
 
 watch(
   () => form.aliasParentProduct.id,
@@ -138,15 +144,16 @@ watch(
       console.error("Failed to fetch alias parent product:", error);
     }
   }
-);
+, { immediate: aliasProductParentId.value !== null });
 
 
 
 
 const wizardSteps = computed(() => {
-  let steps = [
-    { title: t('products.products.labels.type.title'), name: 'typeStep' }
-  ];
+  let steps = [];
+  if (!aliasProductParentId.value) {
+    steps.push({ title: t('products.products.labels.type.title'), name: 'typeStep' });
+  }
 
   if (form.type === ProductType.Alias) {
     steps.push({ title: t('products.products.create.wizard.stepAlias.title'), name: 'aliasOptionsStep' });
@@ -400,7 +407,11 @@ const allowNextStep = computed(() => {
         </template>
 
         <template #aliasOptionsStep>
-          <AliasOptionsStep :form="form" />
+          <AliasOptionsStep
+            :form="form"
+            :preselected-parent-id="aliasProductParentId"
+            :disable-parent-selector="aliasProductParentId !== null"
+          />
         </template>
 
         <template #generalInfoStep>

--- a/src/core/products/products/product-create/containers/alias-options-step/AliasOptionsStep.vue
+++ b/src/core/products/products/product-create/containers/alias-options-step/AliasOptionsStep.vue
@@ -9,7 +9,7 @@ import { FieldQuery } from "../../../../../../shared/components/organisms/genera
 import { productsQuery } from "../../../../../../shared/api/queries/products.js";
 import { QueryFormField } from "../../../../../../shared/components/organisms/general-form/formConfig";
 
-const props = defineProps<{ form: FormType }>();
+const props = defineProps<{ form: FormType, preselectedParentId?: string | null, disableParentSelector?: boolean }>();
 const { t } = useI18n();
 
 const aliasParentProductField = computed<QueryFormField>(() => ({
@@ -23,10 +23,17 @@ const aliasParentProductField = computed<QueryFormField>(() => ({
   isEdge: true,
   multiple: false,
   filterable: true,
+  disabled: props.disableParentSelector,
   queryVariables: {
     filter: { NOT: { type: { exact: ProductType.Alias } } }
   }
 }));
+
+onMounted(() => {
+  if (props.preselectedParentId) {
+    props.form.aliasParentProduct.id = props.preselectedParentId;
+  }
+});
 
 </script>
 

--- a/src/core/products/products/product-show/containers/tabs/alias-parents/AliasProductsView.vue
+++ b/src/core/products/products/product-show/containers/tabs/alias-parents/AliasProductsView.vue
@@ -3,6 +3,8 @@ import { Product } from "../../../../configs";
 import { useI18n } from "vue-i18n";
 import TabContentTemplate from "../TabContentTemplate.vue";
 import { AliasParentsList } from "./containers/alias-parents-list";
+import { Button } from "../../../../../../shared/components/atoms/button";
+import { Link } from "../../../../../../shared/components/atoms/link";
 
 const { t } = useI18n();
 
@@ -12,6 +14,13 @@ const props = defineProps<{ product: Product }>();
 
 <template>
   <TabContentTemplate>
+    <template #buttons>
+      <Link :path="{ name: 'products.products.create', query: { aliasProductParentId: product.id } }">
+        <Button type="button" class="btn btn-primary">
+          {{ t('products.products.create.title') }}
+        </Button>
+      </Link>
+    </template>
     <template #content>
       <AliasParentsList :products="product.aliasProducts" />
     </template>


### PR DESCRIPTION
## Summary
- add create alias product button on alias parent view
- support preselecting alias parent in AliasOptionsStep
- skip type step when creating alias from parent product

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f28f7cf0832e9f00cd7b9b0bec94

## Summary by Sourcery

Add a button for creating alias products directly in the alias parents view and streamline the alias creation wizard by preselecting the parent and omitting the type selection step when invoked from a parent.

New Features:
- Introduce a Create Alias Product button on the alias parents tab that navigates to the creation wizard with the parent context.
- Preselect and lock the alias parent in the AliasOptionsStep based on the query parameter.
- Skip the product type selection step when creating an alias product from a parent.