### PR TITLE
Add Amazon property GraphQL constants

### DIFF
--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -469,3 +469,96 @@ export const validateAmazonAuthMutation = gql`
     }
   }
 `;
+
+// Amazon Property Mutations
+export const createAmazonPropertyMutation = gql`
+  mutation createAmazonProperty($data: AmazonPropertyInput!) {
+    createAmazonProperty(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+export const createAmazonPropertiesMutation = gql`
+  mutation createAmazonProperties($data: [AmazonPropertyInput!]!) {
+    createAmazonProperties(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+export const updateAmazonPropertyMutation = gql`
+  mutation updateAmazonProperty($data: AmazonPropertyPartialInput!) {
+    updateAmazonProperty(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+// Amazon Property Select Value Mutations
+export const createAmazonPropertySelectValueMutation = gql`
+  mutation createAmazonPropertySelectValue($data: AmazonPropertySelectValueInput!) {
+    createAmazonPropertySelectValue(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+export const createAmazonPropertySelectValuesMutation = gql`
+  mutation createAmazonPropertySelectValues($data: [AmazonPropertySelectValueInput!]!) {
+    createAmazonPropertySelectValues(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+export const updateAmazonPropertySelectValueMutation = gql`
+  mutation updateAmazonPropertySelectValue($data: AmazonPropertySelectValuePartialInput!) {
+    updateAmazonPropertySelectValue(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+// Amazon Product Type Mutations
+export const createAmazonProductTypeMutation = gql`
+  mutation createAmazonProductType($data: AmazonProductTypeInput!) {
+    createAmazonProductType(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+export const createAmazonProductTypesMutation = gql`
+  mutation createAmazonProductTypes($data: [AmazonProductTypeInput!]!) {
+    createAmazonProductTypes(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+export const updateAmazonProductTypeMutation = gql`
+  mutation updateAmazonProductType($data: AmazonProductTypePartialInput!) {
+    updateAmazonProductType(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -483,3 +483,144 @@ export const magentoRemoteAttributeSetsQuery = gql`
     }
   }
 `;
+
+// Amazon Property Queries
+export const amazonPropertiesQuery = gql`
+  query AmazonProperties(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: AmazonPropertyOrder
+    $filter: AmazonPropertyFilter
+  ) {
+    amazonProperties(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filter
+    ) {
+      edges {
+        node {
+          id
+          mappedLocally
+          mappedRemotely
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getAmazonPropertyQuery = gql`
+  query getAmazonProperty($id: GlobalID!) {
+    amazonProperty(id: $id) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+// Amazon Property Select Value Queries
+export const amazonPropertySelectValuesQuery = gql`
+  query AmazonPropertySelectValues(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: AmazonPropertySelectValueOrder
+    $filter: AmazonPropertySelectValueFilter
+  ) {
+    amazonPropertySelectValues(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filter
+    ) {
+      edges {
+        node {
+          id
+          mappedLocally
+          mappedRemotely
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getAmazonPropertySelectValueQuery = gql`
+  query getAmazonPropertySelectValue($id: GlobalID!) {
+    amazonPropertySelectValue(id: $id) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+// Amazon Product Type Queries
+export const amazonProductTypesQuery = gql`
+  query AmazonProductTypes(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: AmazonProductTypeOrder
+    $filter: AmazonProductTypeFilter
+  ) {
+    amazonProductTypes(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filter
+    ) {
+      edges {
+        node {
+          id
+          mappedLocally
+          mappedRemotely
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getAmazonProductTypeQuery = gql`
+  query getAmazonProductType($id: GlobalID!) {
+    amazonProductType(id: $id) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;

--- a/src/shared/api/subscriptions/salesChannels.js
+++ b/src/shared/api/subscriptions/salesChannels.js
@@ -42,3 +42,36 @@ export const salesChannelViewAssignSubscription = gql`
     }
   }
 `;
+
+// Amazon Property Subscription
+export const getAmazonPropertySubscription = gql`
+  subscription getAmazonPropertySubscription($pk: String!) {
+    amazonProperty(pk: $pk) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+// Amazon Property Select Value Subscription
+export const getAmazonPropertySelectValueSubscription = gql`
+  subscription getAmazonPropertySelectValueSubscription($pk: String!) {
+    amazonPropertySelectValue(pk: $pk) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
+// Amazon Product Type Subscription
+export const getAmazonProductTypeSubscription = gql`
+  subscription getAmazonProductTypeSubscription($pk: String!) {
+    amazonProductType(pk: $pk) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- extend `salesChannels` GraphQL API files with Amazon property, select value and product type operations

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515bc3f5dc832e92ee53176bdb7b3e

## Summary by Sourcery

New Features:
- Add GraphQL queries, mutations, and subscriptions for AmazonProperty, AmazonPropertySelectValue, and AmazonProductType entities