### PR TITLE
Add Amazon mapping components

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -22,6 +22,9 @@ import { Products } from "./containers/products";
 import { Stores } from "./containers/stores";
 import { Languages } from "./containers/languages";
 import { Currencies } from "./containers/currencies";
+import { AmazonProductTypes } from "./containers/amazon-product-types";
+import { AmazonProperties } from "./containers/amazon-properties";
+import { AmazonPropertySelectValues } from "./containers/amazon-property-select-values";
 import { Imports } from "./containers/imports";
 import { refreshSalesChannelWebsitesMutation } from "../../../../shared/api/mutations/salesChannels";
 import {Toast} from "../../../../shared/modules/toast";
@@ -225,17 +228,17 @@ const pullData = async () => {
 
           <!-- Product Rules Tab (Amazon only) -->
           <template #productRules>
-            <div />
+            <AmazonProductTypes v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
           </template>
 
           <!-- Properties Tab (Amazon only) -->
           <template #properties>
-            <div />
+            <AmazonProperties v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
           </template>
 
           <!-- Property Select Values Tab (Amazon only) -->
           <template #propertySelectValues>
-            <div />
+            <AmazonPropertySelectValues v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
           </template>
         </Tabs>
       </Card>

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-product-types/AmazonProductTypes.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-product-types/AmazonProductTypes.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import GeneralTemplate from "../../../../../../shared/templates/GeneralTemplate.vue";
+import { GeneralListing } from "../../../../../../shared/components/organisms/general-listing";
+import { Button } from "../../../../../../shared/components/atoms/button";
+import { amazonProductTypesSearchConfigConstructor, amazonProductTypesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const emit = defineEmits(['pull-data']);
+const { t } = useI18n();
+
+const searchConfig = amazonProductTypesSearchConfigConstructor(t);
+const listingConfig = amazonProductTypesListingConfigConstructor(t, props.id);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:buttons>
+      <Button type="button" class="btn btn-primary" @click="$emit('pull-data')">
+        {{ t('integrations.labels.pullData') }}
+      </Button>
+    </template>
+
+    <template v-slot:content>
+      <GeneralListing
+        :search-config="searchConfig"
+        :config="listingConfig"
+        :query="listingQuery"
+        :query-key="listingQueryKey"
+        :fixed-filter-variables="{'salesChannel': {'id': {exact: salesChannelId}}}"
+      />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-product-types/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-product-types/configs.ts
@@ -1,0 +1,93 @@
+import { FieldType } from "../../../../../../shared/utils/constants";
+import { amazonProductTypesQuery, getAmazonProductTypeQuery } from "../../../../../../shared/api/queries/salesChannels.js";
+import { productPropertiesRulesListingQuery } from "../../../../../../shared/api/queries/properties.js";
+import { updateAmazonProductTypeMutation } from "../../../../../../shared/api/mutations/salesChannels.js";
+import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { FormConfig, FormType } from '../../../../../../shared/components/organisms/general-form/formConfig';
+import { SearchConfig } from "../../../../../../shared/components/organisms/general-search/searchConfig";
+
+export const amazonProductTypeEditFormConfigConstructor = (
+  t: Function,
+  type: string,
+  productTypeId: string,
+  integrationId: string
+): FormConfig => ({
+  cols: 1,
+  type: FormType.EDIT,
+  mutation: updateAmazonProductTypeMutation,
+  mutationKey: "updateAmazonProductType",
+  query: getAmazonProductTypeQuery,
+  queryVariables: { id: productTypeId },
+  queryDataKey: "amazonProductType",
+  submitUrl: { name: 'integrations.integrations.show', params: { type: type, id: integrationId }, query: { tab: 'productRules' } },
+  fields: [
+    {
+      type: FieldType.Hidden,
+      name: 'id',
+      value: productTypeId
+    },
+    {
+      type: FieldType.Text,
+      label: t('integrations.show.productRules.labels.productTypeCode'),
+      name: 'productTypeCode',
+      disabled: true
+    },
+    {
+      type: FieldType.Text,
+      label: t('shared.labels.name'),
+      name: 'name',
+      disabled: true
+    },
+    {
+      type: FieldType.Query,
+      name: 'localInstance',
+      label: t('properties.rule.title'),
+      labelBy: 'productType.value',
+      valueBy: 'id',
+      query: productPropertiesRulesListingQuery,
+      dataKey: 'productPropertiesRules',
+      isEdge: true,
+      multiple: false,
+      filterable: true,
+    }
+  ]
+});
+
+export const amazonProductTypesSearchConfigConstructor = (t: Function): SearchConfig => ({
+  search: true,
+  orderKey: "sort",
+  filters: [
+    { type: FieldType.Boolean, name: 'mappedLocally', label: t('integrations.show.mapping.mappedLocally'), addLookup: true, strict: true },
+    { type: FieldType.Boolean, name: 'mappedRemotely', label: t('integrations.show.mapping.mappedRemotely'), addLookup: true, strict: true },
+  ],
+  orders: []
+});
+
+export const amazonProductTypesListingConfigConstructor = (t: Function, specificIntegrationId): ListingConfig => ({
+  headers: [
+    t('shared.labels.name'),
+    t('integrations.show.productRules.labels.productTypeCode'),
+    t('integrations.show.mapping.mappedLocally'),
+    t('integrations.show.mapping.mappedRemotely'),
+    t('properties.rule.title')
+  ],
+  fields: [
+    { name: 'name', type: FieldType.Text },
+    { name: 'productTypeCode', type: FieldType.Text },
+    { name: 'mappedLocally', type: FieldType.Boolean },
+    { name: 'mappedRemotely', type: FieldType.Boolean },
+    { name: 'localInstance', type: FieldType.NestedText, keys: ['productType','value'], showLabel: true }
+  ],
+  identifierKey: 'id',
+  urlQueryParams: {integrationId: specificIntegrationId },
+  addActions: true,
+  addEdit: true,
+  addShow: true,
+  editUrlName: 'integrations.amazonProductTypes.edit',
+  showUrlName: 'integrations.amazonProductTypes.edit',
+  addDelete: false,
+  addPagination: true,
+});
+
+export const listingQueryKey = 'amazonProductTypes';
+export const listingQuery = amazonProductTypesQuery;

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
+import { Breadcrumbs } from "../../../../../../../shared/components/molecules/breadcrumbs";
+import { GeneralForm } from "../../../../../../../shared/components/organisms/general-form";
+import { useRoute } from "vue-router";
+import { amazonProductTypeEditFormConfigConstructor } from "../configs";
+
+const { t } = useI18n();
+const route = useRoute();
+
+const productTypeId = ref(String(route.params.id));
+const type = ref(String(route.params.type));
+const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
+
+const formConfig = amazonProductTypeEditFormConfigConstructor(t, type.value, productTypeId.value, integrationId);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:breadcrumbs>
+      <Breadcrumbs
+        :links="[
+          { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
+          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'productRules'} }, name: t('integrations.show.title') }
+        ]" />
+    </template>
+    <template v-slot:content>
+      <GeneralForm :config="formConfig" />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-product-types/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-product-types/index.ts
@@ -1,0 +1,1 @@
+export { default as AmazonProductTypes } from './AmazonProductTypes.vue';

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-properties/AmazonProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-properties/AmazonProperties.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import GeneralTemplate from "../../../../../../shared/templates/GeneralTemplate.vue";
+import { GeneralListing } from "../../../../../../shared/components/organisms/general-listing";
+import { Button } from "../../../../../../shared/components/atoms/button";
+import { amazonPropertiesSearchConfigConstructor, amazonPropertiesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const emit = defineEmits(['pull-data']);
+const { t } = useI18n();
+
+const searchConfig = amazonPropertiesSearchConfigConstructor(t);
+const listingConfig = amazonPropertiesListingConfigConstructor(t, props.id);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:buttons>
+      <Button type="button" class="btn btn-primary" @click="$emit('pull-data')">
+        {{ t('integrations.labels.pullData') }}
+      </Button>
+    </template>
+
+    <template v-slot:content>
+      <GeneralListing
+        :search-config="searchConfig"
+        :config="listingConfig"
+        :query="listingQuery"
+        :query-key="listingQueryKey"
+        :fixed-filter-variables="{'salesChannel': {'id': {exact: salesChannelId}}}"
+      />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-properties/configs.ts
@@ -1,0 +1,83 @@
+import { FieldType } from "../../../../../../shared/utils/constants";
+import { amazonPropertiesQuery, getAmazonPropertyQuery } from "../../../../../../shared/api/queries/salesChannels.js";
+import { propertiesQuery } from "../../../../../../shared/api/queries/properties.js";
+import { updateAmazonPropertyMutation } from "../../../../../../shared/api/mutations/salesChannels.js";
+import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { FormConfig, FormType } from '../../../../../../shared/components/organisms/general-form/formConfig';
+import { SearchConfig } from "../../../../../../shared/components/organisms/general-search/searchConfig";
+
+export const amazonPropertyEditFormConfigConstructor = (
+  t: Function,
+  type: string,
+  propertyId: string,
+  integrationId: string
+): FormConfig => ({
+  cols: 1,
+  type: FormType.EDIT,
+  mutation: updateAmazonPropertyMutation,
+  mutationKey: "updateAmazonProperty",
+  query: getAmazonPropertyQuery,
+  queryVariables: { id: propertyId },
+  queryDataKey: "amazonProperty",
+  submitUrl: { name: 'integrations.integrations.show', params: { type: type, id: integrationId }, query: { tab: 'properties' } },
+  fields: [
+    { type: FieldType.Hidden, name: 'id', value: propertyId },
+    { type: FieldType.Text, name: 'code', label: t('integrations.show.properties.labels.code'), disabled: true },
+    { type: FieldType.Text, name: 'name', label: t('shared.labels.name'), disabled: true },
+    { type: FieldType.Text, name: 'type', label: t('integrations.show.properties.labels.type'), disabled: true },
+    { type: FieldType.Boolean, name: 'allowsUnmappedValues', label: t('integrations.show.properties.labels.allowsUnmappedValues'), disabled: true },
+    {
+      type: FieldType.Query,
+      name: 'localInstance',
+      label: t('properties.properties.title'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: propertiesQuery,
+      dataKey: 'properties',
+      isEdge: true,
+      multiple: false,
+      filterable: true,
+    }
+  ]
+});
+
+export const amazonPropertiesSearchConfigConstructor = (t: Function): SearchConfig => ({
+  search: true,
+  orderKey: "sort",
+  filters: [
+    { type: FieldType.Boolean, name: 'mappedLocally', label: t('integrations.show.mapping.mappedLocally'), addLookup: true, strict: true },
+    { type: FieldType.Boolean, name: 'mappedRemotely', label: t('integrations.show.mapping.mappedRemotely'), addLookup: true, strict: true },
+    { type: FieldType.Boolean, name: 'allowsUnmappedValues', label: t('integrations.show.properties.labels.allowsUnmappedValues'), addLookup: true, strict: true },
+    { type: FieldType.Text, name: 'type', label: t('integrations.show.properties.labels.type') }
+  ],
+  orders: []
+});
+
+export const amazonPropertiesListingConfigConstructor = (t: Function, specificIntegrationId): ListingConfig => ({
+  headers: [
+    t('shared.labels.name'),
+    t('integrations.show.properties.labels.code'),
+    t('integrations.show.mapping.mappedLocally'),
+    t('integrations.show.mapping.mappedRemotely'),
+    t('properties.properties.title')
+  ],
+  fields: [
+    { name: 'name', type: FieldType.Text },
+    { name: 'code', type: FieldType.Text },
+    { name: 'mappedLocally', type: FieldType.Boolean },
+    { name: 'mappedRemotely', type: FieldType.Boolean },
+    { name: 'localInstance', type: FieldType.NestedText, keys: ['name'], showLabel: true }
+  ],
+  identifierKey: 'id',
+  urlQueryParams: {integrationId: specificIntegrationId },
+  addActions: true,
+  addEdit: true,
+  addShow: true,
+  editUrlName: 'integrations.amazonProperties.edit',
+  showUrlName: 'integrations.amazonProperties.edit',
+  addDelete: false,
+  addPagination: true,
+});
+
+export const listingQueryKey = 'amazonProperties';
+export const listingQuery = amazonPropertiesQuery;

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
+import { Breadcrumbs } from "../../../../../../../shared/components/molecules/breadcrumbs";
+import { GeneralForm } from "../../../../../../../shared/components/organisms/general-form";
+import { useRoute } from "vue-router";
+import { amazonPropertyEditFormConfigConstructor } from "../configs";
+
+const { t } = useI18n();
+const route = useRoute();
+
+const propertyId = ref(String(route.params.id));
+const type = ref(String(route.params.type));
+const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
+
+const formConfig = amazonPropertyEditFormConfigConstructor(t, type.value, propertyId.value, integrationId);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:breadcrumbs>
+      <Breadcrumbs
+        :links="[
+          { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
+          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'properties'} }, name: t('integrations.show.title') }
+        ]" />
+    </template>
+    <template v-slot:content>
+      <GeneralForm :config="formConfig" />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-properties/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-properties/index.ts
@@ -1,0 +1,1 @@
+export { default as AmazonProperties } from './AmazonProperties.vue';

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import GeneralTemplate from "../../../../../../shared/templates/GeneralTemplate.vue";
+import { GeneralListing } from "../../../../../../shared/components/organisms/general-listing";
+import { Button } from "../../../../../../shared/components/atoms/button";
+import { amazonPropertySelectValuesSearchConfigConstructor, amazonPropertySelectValuesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const emit = defineEmits(['pull-data']);
+const { t } = useI18n();
+
+const searchConfig = amazonPropertySelectValuesSearchConfigConstructor(t);
+const listingConfig = amazonPropertySelectValuesListingConfigConstructor(t, props.id);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:buttons>
+      <Button type="button" class="btn btn-primary" @click="$emit('pull-data')">
+        {{ t('integrations.labels.pullData') }}
+      </Button>
+    </template>
+
+    <template v-slot:content>
+      <GeneralListing
+        :search-config="searchConfig"
+        :config="listingConfig"
+        :query="listingQuery"
+        :query-key="listingQueryKey"
+        :fixed-filter-variables="{'salesChannel': {'id': {exact: salesChannelId}}}"
+      />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-property-select-values/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-property-select-values/configs.ts
@@ -1,0 +1,87 @@
+import { FieldType } from "../../../../../../shared/utils/constants";
+import { amazonPropertySelectValuesQuery, getAmazonPropertySelectValueQuery } from "../../../../../../shared/api/queries/salesChannels.js";
+import { propertySelectValuesQuery } from "../../../../../../shared/api/queries/properties.js";
+import { updateAmazonPropertySelectValueMutation } from "../../../../../../shared/api/mutations/salesChannels.js";
+import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { FormConfig, FormType } from '../../../../../../shared/components/organisms/general-form/formConfig';
+import { SearchConfig } from "../../../../../../shared/components/organisms/general-search/searchConfig";
+
+export const amazonPropertySelectValueEditFormConfigConstructor = (
+  t: Function,
+  type: string,
+  valueId: string,
+  integrationId: string
+): FormConfig => ({
+  cols: 1,
+  type: FormType.EDIT,
+  mutation: updateAmazonPropertySelectValueMutation,
+  mutationKey: "updateAmazonPropertySelectValue",
+  query: getAmazonPropertySelectValueQuery,
+  queryVariables: { id: valueId },
+  queryDataKey: "amazonPropertySelectValue",
+  submitUrl: { name: 'integrations.integrations.show', params: { type: type, id: integrationId }, query: { tab: 'propertySelectValues' } },
+  fields: [
+    { type: FieldType.Hidden, name: 'id', value: valueId },
+    { type: FieldType.Text, name: 'remoteName', label: t('integrations.show.propertySelectValues.labels.remoteName'), disabled: true },
+    { type: FieldType.Text, name: 'remoteValue', label: t('integrations.show.propertySelectValues.labels.remoteValue'), disabled: true },
+    { type: FieldType.NestedText, name: 'amazonProperty', label: t('integrations.show.propertySelectValues.labels.amazonProperty'), keys: ['name'], disabled: true, showLabel: true },
+    { type: FieldType.NestedText, name: 'marketplace', label: t('integrations.show.propertySelectValues.labels.marketplace'), keys: ['name'], disabled: true, showLabel: true },
+    {
+      type: FieldType.Query,
+      name: 'localInstance',
+      label: t('properties.values.title'),
+      labelBy: 'value',
+      valueBy: 'id',
+      query: propertySelectValuesQuery,
+      dataKey: 'propertySelectValues',
+      isEdge: true,
+      multiple: false,
+      filterable: true,
+    }
+  ]
+});
+
+export const amazonPropertySelectValuesSearchConfigConstructor = (t: Function): SearchConfig => ({
+  search: true,
+  orderKey: "sort",
+  filters: [
+    { type: FieldType.Boolean, name: 'mappedLocally', label: t('integrations.show.mapping.mappedLocally'), addLookup: true, strict: true },
+    { type: FieldType.Boolean, name: 'mappedRemotely', label: t('integrations.show.mapping.mappedRemotely'), addLookup: true, strict: true },
+    { type: FieldType.Text, name: 'amazonProperty', label: t('integrations.show.propertySelectValues.labels.amazonProperty') },
+    { type: FieldType.Text, name: 'marketplace', label: t('integrations.show.propertySelectValues.labels.marketplace') }
+  ],
+  orders: []
+});
+
+export const amazonPropertySelectValuesListingConfigConstructor = (t: Function, specificIntegrationId): ListingConfig => ({
+  headers: [
+    t('integrations.show.propertySelectValues.labels.remoteName'),
+    t('integrations.show.propertySelectValues.labels.remoteValue'),
+    t('integrations.show.propertySelectValues.labels.amazonProperty'),
+    t('integrations.show.propertySelectValues.labels.marketplace'),
+    t('integrations.show.mapping.mappedLocally'),
+    t('integrations.show.mapping.mappedRemotely'),
+    t('properties.values.title')
+  ],
+  fields: [
+    { name: 'remoteName', type: FieldType.Text },
+    { name: 'remoteValue', type: FieldType.Text },
+    { name: 'amazonProperty', type: FieldType.NestedText, keys: ['name'], showLabel: true },
+    { name: 'marketplace', type: FieldType.NestedText, keys: ['name'], showLabel: true },
+    { name: 'mappedLocally', type: FieldType.Boolean },
+    { name: 'mappedRemotely', type: FieldType.Boolean },
+    { name: 'localInstance', type: FieldType.NestedText, keys: ['value'], showLabel: true }
+  ],
+  identifierKey: 'id',
+  urlQueryParams: {integrationId: specificIntegrationId },
+  addActions: true,
+  addEdit: true,
+  addShow: true,
+  editUrlName: 'integrations.amazonPropertySelectValues.edit',
+  showUrlName: 'integrations.amazonPropertySelectValues.edit',
+  addDelete: false,
+  addPagination: true,
+});
+
+export const listingQueryKey = 'amazonPropertySelectValues';
+export const listingQuery = amazonPropertySelectValuesQuery;

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
+import { Breadcrumbs } from "../../../../../../../shared/components/molecules/breadcrumbs";
+import { GeneralForm } from "../../../../../../../shared/components/organisms/general-form";
+import { useRoute } from "vue-router";
+import { amazonPropertySelectValueEditFormConfigConstructor } from "../configs";
+
+const { t } = useI18n();
+const route = useRoute();
+
+const valueId = ref(String(route.params.id));
+const type = ref(String(route.params.type));
+const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
+
+const formConfig = amazonPropertySelectValueEditFormConfigConstructor(t, type.value, valueId.value, integrationId);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:breadcrumbs>
+      <Breadcrumbs
+        :links="[
+          { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
+          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'propertySelectValues'} }, name: t('integrations.show.title') }
+        ]" />
+    </template>
+    <template v-slot:content>
+      <GeneralForm :config="formConfig" />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/amazon-property-select-values/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/amazon-property-select-values/index.ts
@@ -1,0 +1,1 @@
+export { default as AmazonPropertySelectValues } from './AmazonPropertySelectValues.vue';

--- a/src/core/integrations/routes.ts
+++ b/src/core/integrations/routes.ts
@@ -37,6 +37,24 @@ export const routes = [
     component: () => import('./integrations/integrations-show/containers/currencies/containers/IntegrationsCurrencyEditController.vue'),
   },
   {
+    path: '/integrations/:type/product-type/:id',
+    name: 'integrations.amazonProductTypes.edit',
+    meta: { title: 'integrations.show.productRules.title' },
+    component: () => import('./integrations/integrations-show/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue'),
+  },
+  {
+    path: '/integrations/:type/amazon-property/:id',
+    name: 'integrations.amazonProperties.edit',
+    meta: { title: 'integrations.show.properties.title' },
+    component: () => import('./integrations/integrations-show/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue'),
+  },
+  {
+    path: '/integrations/:type/amazon-property-value/:id',
+    name: 'integrations.amazonPropertySelectValues.edit',
+    meta: { title: 'integrations.show.propertySelectValues.title' },
+    component: () => import('./integrations/integrations-show/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue'),
+  },
+  {
     path: '/integrations/:type/import/:integrationId',
     name: 'integrations.imports.create',
     meta: { title: 'integrations.imports.create.title' },

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2138,6 +2138,33 @@
         "labels": {
           "remoteCode": "Remote Currency Code"
         }
+      },
+      "productRules": {
+        "title": "Amazon Rules",
+        "labels": {
+          "productTypeCode": "Product Type Code"
+        }
+      },
+      "properties": {
+        "title": "Amazon Properties",
+        "labels": {
+          "code": "Code",
+          "type": "Type",
+          "allowsUnmappedValues": "Allow Unmapped Values"
+        }
+      },
+      "propertySelectValues": {
+        "title": "Amazon Property Values",
+        "labels": {
+          "remoteName": "Remote Name",
+          "remoteValue": "Remote Value",
+          "amazonProperty": "Amazon Property",
+          "marketplace": "Marketplace"
+        }
+      },
+      "mapping": {
+        "mappedLocally": "Mapped Locally",
+        "mappedRemotely": "Mapped Remotely"
       }
     },
     "create": {


### PR DESCRIPTION
## Summary
- integrate Amazon mapping components and editing routes
- create configs and listing components for Amazon product types, properties and select values
- wire these into `IntegrationsShowController`
- extend integration routes and translations

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685172e8396c832ea17dffd40d25c799

## Summary by Sourcery

Add support for Amazon mapping in the Integrations UI by introducing listing and edit flows for Amazon product types, properties, and property select values.

New Features:
- Register new routes for editing Amazon product types, properties, and property select values under the integrations module
- Integrate AmazonProductTypes, AmazonProperties, and AmazonPropertySelectValues components into the IntegrationsShowController tabs
- Implement listing and search components along with corresponding edit controllers for Amazon mapping entities
- Define form, listing, and search configurations for Amazon product types, properties, and property select values

Enhancements:
- Extend translation keys and integration routing to cover new Amazon mapping tabs

Documentation:
- Add locale entries for new Amazon mapping labels and titles