### PR TITLE
Refactor integration tabs for future extensibility

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -22,9 +22,9 @@ import { Products } from "./containers/products";
 import { Stores } from "./containers/stores";
 import { Languages } from "./containers/languages";
 import { Currencies } from "./containers/currencies";
-import { AmazonProductTypes } from "./containers/amazon-product-types";
-import { AmazonProperties } from "./containers/amazon-properties";
-import { AmazonPropertySelectValues } from "./containers/amazon-property-select-values";
+import { Rules } from "./containers/rules";
+import { Properties } from "./containers/properties";
+import { PropertySelectValues } from "./containers/property-select-values";
 import { Imports } from "./containers/imports";
 import { refreshSalesChannelWebsitesMutation } from "../../../../shared/api/mutations/salesChannels";
 import {Toast} from "../../../../shared/modules/toast";
@@ -226,19 +226,19 @@ const pullData = async () => {
             <Imports v-if="salesChannelId && integrationId" :id="id" :sales-channel-id="salesChannelId" />
           </template>
 
-          <!-- Product Rules Tab (Amazon only) -->
+          <!-- Rules Tab -->
           <template #productRules>
-            <AmazonProductTypes v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
+            <Rules v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" :type="type" @pull-data="pullData()" />
           </template>
 
-          <!-- Properties Tab (Amazon only) -->
+          <!-- Properties Tab -->
           <template #properties>
-            <AmazonProperties v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
+            <Properties v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" :type="type" @pull-data="pullData()" />
           </template>
 
-          <!-- Property Select Values Tab (Amazon only) -->
+          <!-- Property Select Values Tab -->
           <template #propertySelectValues>
-            <AmazonPropertySelectValues v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
+            <PropertySelectValues v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" :type="type" @pull-data="pullData()" />
           </template>
         </Tabs>
       </Card>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/Properties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/Properties.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { IntegrationTypes } from '../../../integrations';
+import { AmazonProperties } from '../amazon-properties';
+
+const props = defineProps<{ id: string; salesChannelId: string; type: string }>();
+const emit = defineEmits(['pull-data']);
+
+const currentComponent = computed(() => {
+  switch (props.type) {
+    case IntegrationTypes.Amazon:
+      return AmazonProperties;
+    default:
+      return null;
+  }
+});
+</script>
+
+<template>
+  <component
+    v-if="currentComponent"
+    :is="currentComponent"
+    :id="id"
+    :sales-channel-id="salesChannelId"
+    @pull-data="emit('pull-data')"
+  />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/index.ts
@@ -1,0 +1,1 @@
+export { default as Properties } from './Properties.vue';

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/PropertySelectValues.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/PropertySelectValues.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { IntegrationTypes } from '../../../integrations';
+import { AmazonPropertySelectValues } from '../amazon-property-select-values';
+
+const props = defineProps<{ id: string; salesChannelId: string; type: string }>();
+const emit = defineEmits(['pull-data']);
+
+const currentComponent = computed(() => {
+  switch (props.type) {
+    case IntegrationTypes.Amazon:
+      return AmazonPropertySelectValues;
+    default:
+      return null;
+  }
+});
+</script>
+
+<template>
+  <component
+    v-if="currentComponent"
+    :is="currentComponent"
+    :id="id"
+    :sales-channel-id="salesChannelId"
+    @pull-data="emit('pull-data')"
+  />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/index.ts
@@ -1,0 +1,1 @@
+export { default as PropertySelectValues } from './PropertySelectValues.vue';

--- a/src/core/integrations/integrations/integrations-show/containers/rules/Rules.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/Rules.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { IntegrationTypes } from '../../../integrations';
+import { AmazonProductTypes } from '../amazon-product-types';
+
+const props = defineProps<{ id: string; salesChannelId: string; type: string }>();
+const emit = defineEmits(['pull-data']);
+
+const currentComponent = computed(() => {
+  switch (props.type) {
+    case IntegrationTypes.Amazon:
+      return AmazonProductTypes;
+    default:
+      return null;
+  }
+});
+</script>
+
+<template>
+  <component
+    v-if="currentComponent"
+    :is="currentComponent"
+    :id="id"
+    :sales-channel-id="salesChannelId"
+    @pull-data="emit('pull-data')"
+  />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/index.ts
@@ -1,0 +1,1 @@
+export { default as Rules } from './Rules.vue';


### PR DESCRIPTION
## Summary
- wrap Amazon-specific tabs in generic components
- update `IntegrationsShowController` to use new wrappers
- prepare for future integrations like eBay

## Testing
- `npm run build` *(fails: TS2322 errors in configs)*

------
https://chatgpt.com/codex/tasks/task_e_685189320594832e807aef5da47c7a32