### PR TITLE
Fix Amazon rule value redirect

### DIFF
--- a/src/core/properties/property-select-values/configs.ts
+++ b/src/core/properties/property-select-values/configs.ts
@@ -28,16 +28,13 @@ export const baseFormConfigConstructor = (
     propertyId: string | null = null,
     addImage: boolean = true,
     redirectToRules: boolean = false,
+    amazonRuleId: string | null = null,
 ): FormConfig => ({
     cols: 1,
     type: type,
     mutation: mutation,
     mutationKey: mutationKey,
-      submitUrl: redirectToRules
-        ? { name: 'properties.rule.list' }
-        : propertyId !== null
-          ? { name: 'properties.properties.show', params: { id: propertyId }, query: { tab: 'values' } }
-          : { name: 'properties.values.list' },
+    submitUrl: getSubmitUrl(redirectToRules, propertyId, amazonRuleId),
     submitAndContinueUrl: {name: 'properties.values.edit'},
     deleteMutation: deletePropertySelectValueMutation,
     fields: [
@@ -56,6 +53,26 @@ export const baseFormConfigConstructor = (
         } as FormField] : [])
     ],
 });
+
+const getSubmitUrl = (
+    redirectToRules: boolean,
+    propertyId: string | null,
+    amazonRuleId: string | null,
+) => {
+    if (redirectToRules && amazonRuleId) {
+        return { name: 'integrations.amazonProductTypes.edit', params: { type: 'amazon', id: amazonRuleId } };
+    }
+
+    if (redirectToRules) {
+        return { name: 'properties.rule.list' };
+    }
+
+    if (propertyId !== null) {
+        return { name: 'properties.properties.show', params: { id: propertyId }, query: { tab: 'values' } };
+    }
+
+    return { name: 'properties.values.list' };
+};
 
 export const selectValueOnTheFlyConfig = (t: Function, propertyId): CreateOnTheFly => ({
     config: {

--- a/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
+++ b/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
@@ -19,6 +19,7 @@ onMounted(async () => {
   let addImage = false;
   const propertyId = route.query.propertyId ? route.query.propertyId.toString() : null;
   const isRule = route.query.isRule ? route.query.isRule.toString() : null;
+  const amazonRuleId = route.query.amazonRuleId ? route.query.amazonRuleId.toString() : null;
 
   if (propertyId) {
     const { data } = await apolloClient.query({
@@ -37,7 +38,8 @@ onMounted(async () => {
     'createPropertySelectValue',
     propertyId,
     addImage,
-    isRule !== null
+    isRule !== null,
+    amazonRuleId
   );
 });
 


### PR DESCRIPTION
## Summary
- add Amazon rule id support in property value create page
- compute submit URL via helper method to handle rule redirects

## Testing
- `npm install`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851b80b7910832eb384e2f76f83cfa0

## Summary by Sourcery

Support Amazon rule based redirects in property select value creation by introducing an amazonRuleId parameter and centralizing submit URL logic into a helper

New Features:
- Add amazonRuleId parameter to property select value creation to support Amazon rule redirects

Bug Fixes:
- Ensure property value creation redirects to the Amazon rule edit page when amazonRuleId is provided

Enhancements:
- Refactor submitUrl determination in baseFormConfigConstructor into a dedicated getSubmitUrl helper for clarity