### PR TITLE
Enhance Amazon property workflow

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/configs.ts
@@ -67,6 +67,19 @@ export const amazonPropertiesSearchConfigConstructor = (t: Function): SearchConf
       options: getPropertyTypeOptions(t),
       addLookup: true
     },
+    {
+      type: FieldType.Query,
+      name: 'localInstance',
+      label: t('properties.properties.title'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: propertiesQuery,
+      dataKey: 'properties',
+      filterable: true,
+      isEdge: true,
+      addLookup: true,
+      lookupKeys: ['id']
+    },
   ],
   orders: []
 });

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -26,6 +26,15 @@ const formConfig = amazonPropertyEditFormConfigConstructor(t, type.value, proper
           { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'properties'} }, name: t('integrations.show.amazon.title') }
         ]" />
     </template>
+    <template v-slot:buttons>
+        <div>
+          <Link :path="{ name: 'properties.properties.create', query: { amazonRuleId: `${propertyId}__${integrationId}` } }">
+            <Button type="button" class="btn btn-primary">
+                {{  t('properties.properties.create.title') }}
+            </Button>
+          </Link>
+      </div>
+    </template>
     <template v-slot:content>
       <GeneralForm :config="formConfig" />
     </template>

--- a/src/core/properties/properties/properties-create/PropertiesCreateController.vue
+++ b/src/core/properties/properties/properties-create/PropertiesCreateController.vue
@@ -25,6 +25,7 @@ import {processGraphQLErrors} from "../../../../shared/utils";
 const router = useRouter();
 const { t } = useI18n();
 const route = useRoute();
+const amazonRuleId = route.query.amazonRuleId ? route.query.amazonRuleId.toString() : null;
 const wizardRef = ref();
 const step = ref(0);
 const loading = ref(false);
@@ -133,7 +134,16 @@ const handleFinish = async () => {
 
     if (data && data.createProperty) {
       Toast.success(t('shared.alert.toast.submitSuccessUpdate'));
-      router.push({name: 'properties.properties.edit', params: { id: data.createProperty.id}, query: {tab: 'translations'}})
+      if (amazonRuleId) {
+        const [ruleId, integrationId] = amazonRuleId.split('__');
+        const url: any = { name: 'integrations.amazonProperties.edit', params: { type: 'amazon', id: ruleId } };
+        if (integrationId) {
+          url.query = { integrationId };
+        }
+        router.push(url);
+      } else {
+        router.push({name: 'properties.properties.edit', params: { id: data.createProperty.id}, query: {tab: 'translations'}})
+      }
     }
   } catch (err) {
     const graphqlError = err as { graphQLErrors: Array<{ message: string }> };


### PR DESCRIPTION
## Summary
- filter Amazon properties by local instance
- add creation shortcut on Amazon property edit
- allow returning to Amazon property after creating a new property

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851cbf3b13c832e99a28b63da1aac3d