### PR TITLE
Add URL defaults for property creation

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -15,8 +15,13 @@ const route = useRoute();
 const propertyId = ref(String(route.params.id));
 const type = ref(String(route.params.type));
 const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
+const formData = ref<Record<string, any>>({});
 
 const formConfig = amazonPropertyEditFormConfigConstructor(t, type.value, propertyId.value, integrationId);
+
+const handleFormUpdate = (form) => {
+  formData.value = form;
+};
 </script>
 
 <template>
@@ -30,7 +35,7 @@ const formConfig = amazonPropertyEditFormConfigConstructor(t, type.value, proper
     </template>
     <template v-slot:buttons>
         <div>
-          <Link :path="{ name: 'properties.properties.create', query: { amazonRuleId: `${propertyId}__${integrationId}` } }">
+          <Link :path="{ name: 'properties.properties.create', query: { amazonRuleId: `${propertyId}__${integrationId}`, name: formData.name, type: formData.type } }">
             <Button type="button" class="btn btn-primary">
                 {{  t('properties.properties.create.title') }}
             </Button>
@@ -38,7 +43,7 @@ const formConfig = amazonPropertyEditFormConfigConstructor(t, type.value, proper
       </div>
     </template>
     <template v-slot:content>
-      <GeneralForm :config="formConfig" />
+      <GeneralForm :config="formConfig" @form-updated="handleFormUpdate" />
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -18,6 +18,7 @@ const productTypeId = ref(String(route.params.id));
 const type = ref(String(route.params.type));
 const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
 const propertyProductTypeId = ref<string | null>(null);
+const formData = ref<Record<string, any>>({});
 
 const formConfig = amazonProductTypeEditFormConfigConstructor(t, type.value, productTypeId.value, integrationId);
 
@@ -34,6 +35,10 @@ const fetchProductType = async () => {
 
 onMounted(fetchProductType);
 
+const handleFormUpdate = (form) => {
+  formData.value = form;
+};
+
 </script>
 
 <template>
@@ -48,7 +53,7 @@ onMounted(fetchProductType);
 
     <template v-slot:buttons>
         <div>
-          <Link :path="{ name: 'properties.values.create', query: { propertyId: propertyProductTypeId, isRule: '1', amazonRuleId: `${productTypeId}__${integrationId}` } }">
+          <Link :path="{ name: 'properties.values.create', query: { propertyId: propertyProductTypeId, isRule: '1', amazonRuleId: `${productTypeId}__${integrationId}`, value: formData.name } }">
             <Button type="button" class="btn btn-primary">
                 {{  t('properties.rule.create.title') }}
             </Button>
@@ -57,7 +62,7 @@ onMounted(fetchProductType);
     </template>
 
     <template v-slot:content>
-      <GeneralForm :config="formConfig" />
+      <GeneralForm :config="formConfig" @form-updated="handleFormUpdate" />
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/properties/properties/properties-create/PropertiesCreateController.vue
+++ b/src/core/properties/properties/properties-create/PropertiesCreateController.vue
@@ -26,6 +26,8 @@ const router = useRouter();
 const { t } = useI18n();
 const route = useRoute();
 const amazonRuleId = route.query.amazonRuleId ? route.query.amazonRuleId.toString() : null;
+const nameFromUrl = route.query.name ? route.query.name.toString() : '';
+const typeFromUrl = route.query.type ? route.query.type.toString() : '';
 const wizardRef = ref();
 const step = ref(0);
 const loading = ref(false);
@@ -52,18 +54,21 @@ const preview = reactive({
 });
 
 const form: PropertyForm = reactive({
-  name: '',
-  type: '',
+  name: nameFromUrl,
+  type: typeFromUrl,
   isPublicInformation: true,
   addToFilters: false,
   hasImage: false,
 });
 
 const wizardSteps = computed(() => {
-  return [
-    {title: t('properties.properties.create.wizard.stepOne.title'), name: 'generalStep'},
-    {title: t('properties.properties.create.wizard.stepTwo.title'), name: 'typeStep'},
+  const steps = [
+    {title: t('properties.properties.create.wizard.stepOne.title'), name: 'generalStep'}
   ];
+  if (!typeFromUrl) {
+    steps.push({title: t('properties.properties.create.wizard.stepTwo.title'), name: 'typeStep'});
+  }
+  return steps;
 });
 
 const typeChoices = [

--- a/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
+++ b/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
@@ -14,6 +14,7 @@ import { getPropertyQuery } from "../../../../shared/api/queries/properties.js";
 const { t } = useI18n();
 const route = useRoute();
 const formConfig = ref<FormConfig | null>(null);
+const defaultValue = route.query.value ? route.query.value.toString() : '';
 
 onMounted(async () => {
   let addImage = false;
@@ -41,6 +42,13 @@ onMounted(async () => {
     isRule !== null,
     amazonRuleId
   );
+
+  if (defaultValue && formConfig.value) {
+    const valueField = formConfig.value.fields.find(field => field.name === 'value');
+    if (valueField) {
+      valueField.default = defaultValue;
+    }
+  }
 });
 
 </script>


### PR DESCRIPTION
## Summary
- preset default value in PropertySelectValuesCreateController from URL param
- allow setting default name and type in property create wizard from URL
- pass selected values when opening create screens from integration edit forms

## Testing
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852778dc8e4832ea2673d5e6e297af4