### PR TITLE
Implement mapping wizard for Amazon tables

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/AmazonProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/AmazonProperties.vue
@@ -1,13 +1,49 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import { ref, onMounted } from 'vue';
 import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { GeneralListing } from "../../../../../../../../shared/components/organisms/general-listing";
 import { Button } from "../../../../../../../../shared/components/atoms/button";
 import { amazonPropertiesSearchConfigConstructor, amazonPropertiesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
+import apolloClient from "../../../../../../../../apollo-client";
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const emit = defineEmits(['pull-data']);
 const { t } = useI18n();
+const router = useRouter();
+
+const canStartMapping = ref(false);
+
+const fetchFirstUnmapped = async () => {
+  const { data } = await apolloClient.query({
+    query: listingQuery,
+    variables: {
+      first: 1,
+      filter: {
+        salesChannel: { id: { exact: props.salesChannelId } },
+        mappedLocally: { exact: false },
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+  const edges = data?.amazonProperties?.edges || [];
+  canStartMapping.value = edges.length > 0;
+  return edges.length > 0 ? edges[0].node.id : null;
+};
+
+onMounted(fetchFirstUnmapped);
+
+const startMapping = async () => {
+  const id = await fetchFirstUnmapped();
+  if (id) {
+    router.push({
+      name: 'integrations.amazonProperties.edit',
+      params: { type: props.id, id },
+      query: { integrationId: props.id, salesChannelId: props.salesChannelId, wizard: '1' },
+    });
+  }
+};
 
 const searchConfig = amazonPropertiesSearchConfigConstructor(t);
 const listingConfig = amazonPropertiesListingConfigConstructor(t, props.id);
@@ -18,6 +54,9 @@ const listingConfig = amazonPropertiesListingConfigConstructor(t, props.id);
     <template v-slot:buttons>
       <Button type="button" class="btn btn-primary" @click="$emit('pull-data')">
         {{ t('integrations.labels.pullData') }}
+      </Button>
+      <Button type="button" class="btn btn-secondary" :disabled="!canStartMapping" @click="startMapping">
+        {{ t('integrations.show.mapping.startMapping') }}
       </Button>
     </template>
 

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -1,20 +1,62 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
 import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
 import { useRoute } from "vue-router";
-import { amazonPropertyEditFormConfigConstructor } from "../configs";
+import { amazonPropertyEditFormConfigConstructor, listingQuery } from "../configs";
+import apolloClient from "../../../../../../../../../../apollo-client";
+import { Toast } from "../../../../../../../../../shared/modules/toast";
 
 const { t } = useI18n();
 const route = useRoute();
+const router = useRouter();
 
 const propertyId = ref(String(route.params.id));
 const type = ref(String(route.params.type));
 const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
+const salesChannelId = route.query.salesChannelId ? route.query.salesChannelId.toString() : '';
+const isWizard = route.query.wizard === '1';
 
 const formConfig = amazonPropertyEditFormConfigConstructor(t, type.value, propertyId.value, integrationId);
+
+if (isWizard) {
+  formConfig.submitUrl = undefined;
+  formConfig.submitLabel = t('integrations.show.mapping.saveAndMapNext');
+}
+
+const fetchNextUnmapped = async () => {
+  const { data } = await apolloClient.query({
+    query: listingQuery,
+    variables: {
+      first: 1,
+      filter: {
+        salesChannel: { id: { exact: salesChannelId } },
+        mappedLocally: { exact: false },
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+  const edges = data?.amazonProperties?.edges || [];
+  return edges.length > 0 ? edges[0].node.id : null;
+};
+
+const handleSubmit = async () => {
+  if (!isWizard) return;
+  const nextId = await fetchNextUnmapped();
+  if (nextId) {
+    router.replace({
+      name: 'integrations.amazonProperties.edit',
+      params: { type: type.value, id: nextId },
+      query: { integrationId, salesChannelId, wizard: '1' },
+    });
+  } else {
+    Toast.success(t('integrations.show.mapping.allMappedSuccess'));
+    router.push({ name: 'integrations.integrations.show', params: { type: type.value, id: integrationId }, query: { tab: 'properties' } });
+  }
+};
 </script>
 
 <template>
@@ -27,7 +69,7 @@ const formConfig = amazonPropertyEditFormConfigConstructor(t, type.value, proper
         ]" />
     </template>
     <template v-slot:content>
-      <GeneralForm :config="formConfig" />
+      <GeneralForm :config="formConfig" @submit="handleSubmit" />
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -1,20 +1,63 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
 import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
 import { useRoute } from "vue-router";
-import { amazonPropertySelectValueEditFormConfigConstructor } from "../configs";
+import { amazonPropertySelectValueEditFormConfigConstructor, listingQuery } from "../configs";
+import apolloClient from "../../../../../../../../../../apollo-client";
+import { Toast } from "../../../../../../../../../shared/modules/toast";
 
 const { t } = useI18n();
 const route = useRoute();
+const router = useRouter();
 
 const valueId = ref(String(route.params.id));
 const type = ref(String(route.params.type));
 const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
+const salesChannelId = route.query.salesChannelId ? route.query.salesChannelId.toString() : '';
+const isWizard = route.query.wizard === '1';
 
 const formConfig = amazonPropertySelectValueEditFormConfigConstructor(t, type.value, valueId.value, integrationId);
+
+if (isWizard) {
+  formConfig.submitUrl = undefined;
+  formConfig.submitLabel = t('integrations.show.mapping.saveAndMapNext');
+}
+
+const fetchNextUnmapped = async () => {
+  const { data } = await apolloClient.query({
+    query: listingQuery,
+    variables: {
+      first: 1,
+      filter: {
+        salesChannel: { id: { exact: salesChannelId } },
+        mappedLocally: { exact: false },
+        amazonProperty: { mappedLocally: { exact: true } },
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+  const edges = data?.amazonPropertySelectValues?.edges || [];
+  return edges.length > 0 ? edges[0].node.id : null;
+};
+
+const handleSubmit = async () => {
+  if (!isWizard) return;
+  const nextId = await fetchNextUnmapped();
+  if (nextId) {
+    router.replace({
+      name: 'integrations.amazonPropertySelectValues.edit',
+      params: { type: type.value, id: nextId },
+      query: { integrationId, salesChannelId, wizard: '1' },
+    });
+  } else {
+    Toast.success(t('integrations.show.mapping.allMappedSuccess'));
+    router.push({ name: 'integrations.integrations.show', params: { type: type.value, id: integrationId }, query: { tab: 'propertySelectValues' } });
+  }
+};
 </script>
 
 <template>
@@ -27,7 +70,7 @@ const formConfig = amazonPropertySelectValueEditFormConfigConstructor(t, type.va
         ]" />
     </template>
     <template v-slot:content>
-      <GeneralForm :config="formConfig" />
+      <GeneralForm :config="formConfig" @submit="handleSubmit" />
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/AmazonProductTypes.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/AmazonProductTypes.vue
@@ -1,13 +1,49 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import { ref, onMounted } from 'vue';
 import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { GeneralListing } from "../../../../../../../../shared/components/organisms/general-listing";
 import { Button } from "../../../../../../../../shared/components/atoms/button";
 import { amazonProductTypesSearchConfigConstructor, amazonProductTypesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
+import apolloClient from "../../../../../../../../apollo-client";
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const emit = defineEmits(['pull-data']);
 const { t } = useI18n();
+const router = useRouter();
+
+const canStartMapping = ref(false);
+
+const fetchFirstUnmapped = async () => {
+  const { data } = await apolloClient.query({
+    query: listingQuery,
+    variables: {
+      first: 1,
+      filter: {
+        salesChannel: { id: { exact: props.salesChannelId } },
+        mappedLocally: { exact: false },
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+  const edges = data?.amazonProductTypes?.edges || [];
+  canStartMapping.value = edges.length > 0;
+  return edges.length > 0 ? edges[0].node.id : null;
+};
+
+onMounted(fetchFirstUnmapped);
+
+const startMapping = async () => {
+  const id = await fetchFirstUnmapped();
+  if (id) {
+    router.push({
+      name: 'integrations.amazonProductTypes.edit',
+      params: { type: props.id, id },
+      query: { integrationId: props.id, salesChannelId: props.salesChannelId, wizard: '1' },
+    });
+  }
+};
 
 const searchConfig = amazonProductTypesSearchConfigConstructor(t);
 const listingConfig = amazonProductTypesListingConfigConstructor(t, props.id);
@@ -18,6 +54,9 @@ const listingConfig = amazonProductTypesListingConfigConstructor(t, props.id);
     <template v-slot:buttons>
       <Button type="button" class="btn btn-primary" @click="$emit('pull-data')">
         {{ t('integrations.labels.pullData') }}
+      </Button>
+      <Button type="button" class="btn btn-secondary" :disabled="!canStartMapping" @click="startMapping">
+        {{ t('integrations.show.mapping.startMapping') }}
       </Button>
     </template>
 

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -1,25 +1,66 @@
 <script setup lang="ts">
 import {onMounted, ref} from 'vue';
+import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
 import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
 import { useRoute } from "vue-router";
-import { amazonProductTypeEditFormConfigConstructor } from "../configs";
+import { amazonProductTypeEditFormConfigConstructor, listingQuery } from "../configs";
 import apolloClient from "../../../../../../../../../../apollo-client";
 import {propertiesQuery} from "../../../../../../../../../shared/api/queries/properties";
 import {Link} from "../../../../../../../../../shared/components/atoms/link";
 import {Button} from "../../../../../../../../../shared/components/atoms/button";
+import { Toast } from "../../../../../../../../../shared/modules/toast";
 
 const { t } = useI18n();
 const route = useRoute();
+const router = useRouter();
 
 const productTypeId = ref(String(route.params.id));
 const type = ref(String(route.params.type));
 const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
+const salesChannelId = route.query.salesChannelId ? route.query.salesChannelId.toString() : '';
+const isWizard = route.query.wizard === '1';
 const propertyProductTypeId = ref<string | null>(null);
 
 const formConfig = amazonProductTypeEditFormConfigConstructor(t, type.value, productTypeId.value, integrationId);
+
+if (isWizard) {
+  formConfig.submitUrl = undefined;
+  formConfig.submitLabel = t('integrations.show.mapping.saveAndMapNext');
+}
+
+const fetchNextUnmapped = async () => {
+  const { data } = await apolloClient.query({
+    query: listingQuery,
+    variables: {
+      first: 1,
+      filter: {
+        salesChannel: { id: { exact: salesChannelId } },
+        mappedLocally: { exact: false },
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+  const edges = data?.amazonProductTypes?.edges || [];
+  return edges.length > 0 ? edges[0].node.id : null;
+};
+
+const handleSubmit = async () => {
+  if (!isWizard) return;
+  const nextId = await fetchNextUnmapped();
+  if (nextId) {
+    router.replace({
+      name: 'integrations.amazonProductTypes.edit',
+      params: { type: type.value, id: nextId },
+      query: { integrationId, salesChannelId, wizard: '1' },
+    });
+  } else {
+    Toast.success(t('integrations.show.mapping.allMappedSuccess'));
+    router.push({ name: 'integrations.integrations.show', params: { type: type.value, id: integrationId }, query: { tab: 'productRules' } });
+  }
+};
 
 const fetchProductType = async () => {
     const {data} = await apolloClient.query({
@@ -57,7 +98,7 @@ onMounted(fetchProductType);
     </template>
 
     <template v-slot:content>
-      <GeneralForm :config="formConfig" />
+      <GeneralForm :config="formConfig" @submit="handleSubmit" />
     </template>
   </GeneralTemplate>
 </template>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2167,7 +2167,10 @@
       },
       "mapping": {
         "mappedLocally": "Mapped Locally",
-        "mappedRemotely": "Mapped Remotely"
+        "mappedRemotely": "Mapped Remotely",
+        "startMapping": "Start Mapping",
+        "saveAndMapNext": "Save & Map Next",
+        "allMappedSuccess": "You mapped all the values"
       }
     },
     "create": {


### PR DESCRIPTION
## Summary
- add "Start Mapping" wizard button to Amazon listings
- detect first unmapped entry and open editor in wizard mode
- after saving an entry, automatically open the next unmapped item
- show toast when all values are mapped
- add English locale texts for wizard

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ccecfb98832ea1c08ed9d80a7f5e

## Summary by Sourcery

Introduce a mapping wizard for Amazon integrations that lets users sequentially map unmapped entries via a start button, auto-progress through items on save, and notify on completion.

New Features:
- Add "Start Mapping" button to Amazon Properties, Property Select Values, and Product Types listings to launch the mapping wizard
- Implement wizard mode in Amazon edit controllers to open and save entries in sequence

Enhancements:
- Query GraphQL for the next unmapped item and auto-navigate after each save
- Show success toast and redirect back when all items are mapped

Documentation:
- Add English locale strings for wizard labels and success messages