### PR TITLE
Fix Amazon product type wizard mapping flow

### DIFF
--- a/src/core/properties/property-select-values/configs.ts
+++ b/src/core/properties/property-select-values/configs.ts
@@ -61,10 +61,16 @@ const getSubmitUrl = (
     amazonRuleId: string | null,
 ) => {
     if (redirectToRules && amazonRuleId) {
-        const [ruleId, integrationId] = amazonRuleId.split('__');
+        const [ruleId, integrationId, salesChannelId, wizard] = amazonRuleId.split('__');
         const url: any = { name: 'integrations.amazonProductTypes.edit', params: { type: 'amazon', id: ruleId } };
         if (integrationId) {
-            url.query = { integrationId };
+            url.query = { integrationId } as any;
+            if (salesChannelId) {
+                url.query.salesChannelId = salesChannelId;
+            }
+            if (wizard) {
+                url.query.wizard = wizard;
+            }
         }
         return url;
     }


### PR DESCRIPTION
## Summary
- update Amazon properties edit wizard logic to support last item
- overhaul Amazon product type edit flow with wizard support and add return parameters
- preserve wizard info when creating select values

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fd348924832ead77f83bc97d6a33

## Summary by Sourcery

Overhaul Amazon product type and property edit flows to support multi-step mapping wizards by chaining ‘Save and map next’ actions, detecting last items, and preserving wizard context across navigations and value creation.

Enhancements:
- Extend fetchNextUnmapped to return both nextId and last flag by querying two items and skipping the current item.
- Refactor AmazonProductType and AmazonProperty edit controllers to initialize nextWizardId, disable addSubmitAndContinue, and configure submitUrl and submitLabel dynamically based on wizard state and last step.
- Remove separate handleSubmit function and inline wizard navigation logic into onMounted formConfig setup.
- Enhance property select value URL generation to parse and include salesChannelId and wizard flag from amazonRuleId for proper redirect context.