### PR TITLE
Refactor Amazon property select value forms

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
@@ -1,6 +1,7 @@
 import { FieldType } from "../../../../../../../../shared/utils/constants";
 import { amazonPropertySelectValuesQuery, getAmazonPropertySelectValueQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
 import { propertySelectValuesQuery } from "../../../../../../../../shared/api/queries/properties.js";
+import { selectValueOnTheFlyConfig } from "../../../../../../../properties/property-select-values/configs";
 import { updateAmazonPropertySelectValueMutation } from "../../../../../../../../shared/api/mutations/salesChannels.js";
 import { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { FormConfig, FormType } from '../../../../../../../../shared/components/organisms/general-form/formConfig';
@@ -10,7 +11,8 @@ export const amazonPropertySelectValueEditFormConfigConstructor = (
   t: Function,
   type: string,
   valueId: string,
-  integrationId: string
+  integrationId: string,
+  propertyId: string | null = null
 ): FormConfig => ({
   cols: 1,
   type: FormType.EDIT,
@@ -22,10 +24,10 @@ export const amazonPropertySelectValueEditFormConfigConstructor = (
   submitUrl: { name: 'integrations.integrations.show', params: { type: type, id: integrationId }, query: { tab: 'propertySelectValues' } },
   fields: [
     { type: FieldType.Hidden, name: 'id', value: valueId },
-    { type: FieldType.Text, name: 'remoteName', label: t('integrations.show.propertySelectValues.labels.remoteName'), disabled: true },
+    { type: FieldType.Text, name: 'amazonProperty', label: t('integrations.show.propertySelectValues.labels.amazonProperty'), disabled: true },
+    { type: FieldType.Text, name: 'marketplace', label: t('integrations.show.propertySelectValues.labels.marketplace'), disabled: true },
     { type: FieldType.Text, name: 'remoteValue', label: t('integrations.show.propertySelectValues.labels.remoteValue'), disabled: true },
-    { type: FieldType.NestedText, name: 'amazonProperty', label: t('integrations.show.propertySelectValues.labels.amazonProperty'), keys: ['name'], disabled: true, showLabel: true },
-    { type: FieldType.NestedText, name: 'marketplace', label: t('integrations.show.propertySelectValues.labels.marketplace'), keys: ['name'], disabled: true, showLabel: true },
+    { type: FieldType.Text, name: 'remoteName', label: t('shared.labels.name') },
     {
       type: FieldType.Query,
       name: 'localInstance',
@@ -37,6 +39,8 @@ export const amazonPropertySelectValueEditFormConfigConstructor = (
       isEdge: true,
       multiple: false,
       filterable: true,
+      formMapIdentifier: 'id',
+      ...(propertyId ? { queryVariables: { filter: { property: { id: { exact: propertyId } } } }, createOnFlyConfig: selectValueOnTheFlyConfig(t, propertyId) } : {}),
     }
   ]
 });
@@ -66,11 +70,11 @@ export const amazonPropertySelectValuesListingConfigConstructor = (t: Function, 
   fields: [
     { name: 'remoteName', type: FieldType.Text },
     { name: 'remoteValue', type: FieldType.Text },
-    { name: 'amazonProperty', type: FieldType.NestedText, keys: ['name'], showLabel: true },
-    { name: 'marketplace', type: FieldType.NestedText, keys: ['name'], showLabel: true },
+    { name: 'amazonProperty', type: FieldType.NestedText, keys: ['name'], showLabel: true, clickable: true, clickIdentifiers: [{id: ['id']}], clickUrl: { name: 'integrations.amazonProperties.edit' } },
+    { name: 'marketplace', type: FieldType.NestedText, keys: ['name'], showLabel: true, clickable: true, clickIdentifiers: [{id: ['id']}], clickUrl: { name: 'integrations.stores.edit' } },
     { name: 'mappedLocally', type: FieldType.Boolean },
     { name: 'mappedRemotely', type: FieldType.Boolean },
-    { name: 'localInstance', type: FieldType.NestedText, keys: ['value'], showLabel: true }
+    { name: 'localInstance', type: FieldType.NestedText, keys: ['value'], showLabel: true, clickable: true, clickIdentifiers: [{id: ['id']}], clickUrl: { name: 'properties.values.show' } }
   ],
   identifierKey: 'id',
   urlQueryParams: {integrationId: specificIntegrationId },

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useRouter } from 'vue-router';
+import { useRouter, RouterLink } from 'vue-router';
 import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
 import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
 import { useRoute } from "vue-router";
 import { amazonPropertySelectValueEditFormConfigConstructor, listingQuery } from "../configs";
+import { getAmazonPropertySelectValueQuery, getAmazonPropertyQuery } from "../../../../../../../../../shared/api/queries/salesChannels";
+import { selectValueOnTheFlyConfig } from "../../../../../../../../properties/property-select-values/configs";
 import apolloClient from "../../../../../../../../../../apollo-client";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 
@@ -20,12 +22,43 @@ const integrationId = route.query.integrationId ? route.query.integrationId.toSt
 const salesChannelId = route.query.salesChannelId ? route.query.salesChannelId.toString() : '';
 const isWizard = route.query.wizard === '1';
 
+const amazonPropertyId = ref<string | null>(null);
+const localPropertyId = ref<string | null>(null);
+const propertyMapped = ref(true);
+
 const formConfig = amazonPropertySelectValueEditFormConfigConstructor(t, type.value, valueId.value, integrationId);
 
 if (isWizard) {
   formConfig.submitUrl = undefined;
   formConfig.submitLabel = t('integrations.show.mapping.saveAndMapNext');
 }
+
+onMounted(async () => {
+  const { data } = await apolloClient.query({
+    query: getAmazonPropertySelectValueQuery,
+    variables: { id: valueId.value },
+    fetchPolicy: 'network-only'
+  });
+
+  const valueData = data?.amazonPropertySelectValue;
+  amazonPropertyId.value = valueData?.amazonProperty?.id || null;
+  formConfig.queryData = { amazonPropertySelectValue: { ...valueData, amazonProperty: valueData?.amazonProperty?.name, marketplace: valueData?.marketplace?.name } };
+
+  if (amazonPropertyId.value) {
+    const { data: propData } = await apolloClient.query({
+      query: getAmazonPropertyQuery,
+      variables: { id: amazonPropertyId.value },
+      fetchPolicy: 'network-only'
+    });
+    propertyMapped.value = propData?.amazonProperty?.mappedLocally ?? true;
+    localPropertyId.value = propData?.amazonProperty?.localInstance?.id || null;
+    const field = formConfig.fields.find(f => f.name === 'localInstance');
+    if (field && localPropertyId.value) {
+      field.queryVariables = { filter: { property: { id: { exact: localPropertyId.value } } } };
+      field.createOnFlyConfig = selectValueOnTheFlyConfig(t, localPropertyId.value);
+    }
+  }
+});
 
 const fetchNextUnmapped = async () => {
   const { data } = await apolloClient.query({
@@ -70,6 +103,14 @@ const handleSubmit = async () => {
         ]" />
     </template>
     <template v-slot:content>
+      <div v-if="!propertyMapped" class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400" role="alert">
+        <span class="font-medium flex items-center gap-1">
+          ⚠️ {{ t('integrations.show.propertySelectValues.notMappedBanner.title') }}
+        </span>
+        <RouterLink :to="{ name: 'integrations.amazonProperties.edit', params: { type: type, id: amazonPropertyId }, query: { integrationId } }" class="underline">
+          {{ t('integrations.show.propertySelectValues.notMappedBanner.content') }}
+        </RouterLink>
+      </div>
       <GeneralForm :config="formConfig" @submit="handleSubmit" />
     </template>
   </GeneralTemplate>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2163,6 +2163,10 @@
           "remoteValue": "Remote Value",
           "amazonProperty": "Amazon Property",
           "marketplace": "Marketplace"
+        },
+        "notMappedBanner": {
+          "title": "Amazon property not mapped",
+          "content": "Map the Amazon property first before mapping values."
         }
       },
       "mapping": {


### PR DESCRIPTION
## Summary
- refine Amazon property select value edit form with proper field types
- enable listing links to related entities
- warn when Amazon property isn't mapped and guide user to map it
- support on-the-fly creation of select values
- add English locale strings for the new banner

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530cf73a6c832ea8744a9bb6fcdb42

## Summary by Sourcery

Refactor the Amazon property select value forms to improve data handling, user feedback, and navigation.

Enhancements:
- Fetch select value and property mapping data on component mount and populate the edit form dynamically
- Display a warning banner linking to the mapping page when an Amazon property is not locally mapped
- Allow on-the-fly creation of local select values from the edit form
- Make related entities in the listing view (Amazon property, marketplace, and local instance) clickable to navigate directly to their edit pages

Documentation:
- Add English locale strings for the new unmapped-property warning banner