### PR TITLE
Refactor Amazon property select value form

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
-import {onMounted, ref} from 'vue';
+import { onMounted, ref, reactive } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter, RouterLink } from 'vue-router';
 import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
-import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
+import { TextInput } from "../../../../../../../../../shared/components/atoms/input-text";
+import { Label } from "../../../../../../../../../shared/components/atoms/label";
+import { Flex, FlexCell } from "../../../../../../../../../shared/components/layouts/flex";
+import { FieldQuery } from "../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
+import { SubmitButtons } from "../../../../../../../../../shared/components/organisms/general-form/containers/submit-buttons";
+import { FormConfig, getEnhancedConfig, FormConfigDefaultTranslations, QueryFormField } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
+import { FieldType } from "../../../../../../../../../shared/utils/constants";
+import { propertySelectValuesQuery } from "../../../../../../../../../shared/api/queries/properties.js";
 import { useRoute } from "vue-router";
 import { amazonPropertySelectValueEditFormConfigConstructor, listingQuery } from "../configs";
 import { getAmazonPropertySelectValueQuery, getAmazonPropertyQuery } from "../../../../../../../../../shared/api/queries/salesChannels";
@@ -26,7 +33,38 @@ const amazonPropertyId = ref<string | null>(null);
 const localPropertyId = ref<string | null>(null);
 const propertyMapped = ref(true);
 
-const formConfig = amazonPropertySelectValueEditFormConfigConstructor(t, type.value, valueId.value, integrationId);
+const formConfig: FormConfig = amazonPropertySelectValueEditFormConfigConstructor(t, type.value, valueId.value, integrationId);
+const defaultTranslations: FormConfigDefaultTranslations = {
+  submitLabel: t('shared.button.save'),
+  cancelLabel: t('shared.button.back'),
+  submitAndContinueLabel: t('shared.button.saveAndContinue'),
+  deleteLabel: t('shared.button.delete'),
+  showLabel: t('shared.button.show'),
+};
+const enhancedConfig = ref<FormConfig>(getEnhancedConfig(formConfig, defaultTranslations));
+
+const form = reactive({
+  id: valueId.value,
+  amazonProperty: '',
+  marketplace: '',
+  remoteValue: '',
+  remoteName: '',
+  localInstance: { id: null as string | null },
+});
+
+const localInstanceField = ref<QueryFormField>({
+  type: FieldType.Query,
+  name: 'localInstance',
+  label: t('properties.values.title'),
+  labelBy: 'value',
+  valueBy: 'id',
+  query: propertySelectValuesQuery,
+  dataKey: 'propertySelectValues',
+  isEdge: true,
+  multiple: false,
+  filterable: true,
+  formMapIdentifier: 'id',
+});
 
 onMounted(async () => {
   const { data } = await apolloClient.query({
@@ -37,7 +75,12 @@ onMounted(async () => {
 
   const valueData = data?.amazonPropertySelectValue;
   amazonPropertyId.value = valueData?.amazonProperty?.id || null;
-  formConfig.queryData = { amazonPropertySelectValue: { ...valueData, amazonProperty: valueData?.amazonProperty?.name, marketplace: valueData?.marketplace?.name } };
+
+  form.amazonProperty = valueData?.amazonProperty?.name || '';
+  form.marketplace = valueData?.marketplace?.name || '';
+  form.remoteValue = valueData?.remoteValue || '';
+  form.remoteName = valueData?.remoteName || '';
+  form.localInstance.id = valueData?.localInstance?.id || null;
 
   if (amazonPropertyId.value) {
     const { data: propData } = await apolloClient.query({
@@ -47,10 +90,9 @@ onMounted(async () => {
     });
     propertyMapped.value = propData?.amazonProperty?.mappedLocally ?? true;
     localPropertyId.value = propData?.amazonProperty?.localInstance?.id || null;
-    const field = formConfig.fields.find(f => f.name === 'localInstance');
-    if (field && localPropertyId.value) {
-      field.queryVariables = { filter: { property: { id: { exact: localPropertyId.value } } } };
-      field.createOnFlyConfig = selectValueOnTheFlyConfig(t, localPropertyId.value);
+    if (localPropertyId.value) {
+      localInstanceField.value.queryVariables = { filter: { property: { id: { exact: localPropertyId.value } } } };
+      localInstanceField.value.createOnFlyConfig = selectValueOnTheFlyConfig(t, localPropertyId.value);
     }
   }
 });
@@ -106,7 +148,67 @@ const handleSubmit = async () => {
           {{ t('integrations.show.propertySelectValues.notMappedBanner.content') }}
         </RouterLink>
       </div>
-      <GeneralForm :config="formConfig" @submit="handleSubmit" />
+      <div class="space-y-10 divide-y divide-gray-900/10 mt-4">
+        <div class="grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3">
+          <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
+            <div class="px-4 py-6 sm:p-8">
+              <div class="grid max-w grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-6">
+                <div class="col-span-full">
+                  <Flex vertical>
+                    <FlexCell>
+                      <Label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('integrations.show.propertySelectValues.labels.amazonProperty') }}</Label>
+                    </FlexCell>
+                    <FlexCell>
+                      <TextInput v-model="form.amazonProperty" disabled class="w-full" />
+                    </FlexCell>
+                  </Flex>
+                </div>
+                <div class="col-span-full">
+                  <Flex vertical>
+                    <FlexCell>
+                      <Label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('integrations.show.propertySelectValues.labels.marketplace') }}</Label>
+                    </FlexCell>
+                    <FlexCell>
+                      <TextInput v-model="form.marketplace" disabled class="w-full" />
+                    </FlexCell>
+                  </Flex>
+                </div>
+                <div class="col-span-full">
+                  <Flex vertical>
+                    <FlexCell>
+                      <Label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('integrations.show.propertySelectValues.labels.remoteValue') }}</Label>
+                    </FlexCell>
+                    <FlexCell>
+                      <TextInput v-model="form.remoteValue" disabled class="w-full" />
+                    </FlexCell>
+                  </Flex>
+                </div>
+                <div class="col-span-full">
+                  <Flex vertical>
+                    <FlexCell>
+                      <Label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('shared.labels.name') }}</Label>
+                    </FlexCell>
+                    <FlexCell>
+                      <TextInput v-model="form.remoteName" class="w-full" />
+                    </FlexCell>
+                  </Flex>
+                </div>
+                <div class="col-span-full">
+                  <Flex vertical>
+                    <FlexCell>
+                      <Label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('properties.values.title') }}</Label>
+                    </FlexCell>
+                    <FlexCell>
+                      <FieldQuery :field="localInstanceField as QueryFormField" v-model="form.localInstance.id" @update:modelValue="form.localInstance.id = $event" />
+                    </FlexCell>
+                  </Flex>
+                </div>
+              </div>
+            </div>
+            <SubmitButtons :config="enhancedConfig" :form="form" @submit="handleSubmit" />
+          </div>
+        </div>
+      </div>
     </template>
   </GeneralTemplate>
 </template>


### PR DESCRIPTION
## Summary
- refactor amazon property select value edit page to use reactive form
- render individual fields with Flex layout
- keep wizard submit logic

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685321aef240832e9e7a8b61808238ac

## Summary by Sourcery

Refactor the Amazon property select value edit controller to use a reactive form and manual field rendering while preserving existing submission logic

Enhancements:
- Replace GeneralForm with individually rendered fields using Flex layout and atomic components (TextInput, Label, FieldQuery, SubmitButtons)
- Introduce a reactive form object to manage form state and initialize values in onMounted
- Create a reactive localInstanceField for dynamic query configuration and filtering
- Add enhanced form configuration with default translation labels for submit actions