### PR TITLE
Add return path to Amazon property mapping

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -23,6 +23,7 @@ const integrationId = route.query.integrationId?.toString() || '';
 const salesChannelId = route.query.salesChannelId?.toString() || '';
 const isWizard = route.query.wizard == '1';
 const propertyId = route.query.propertyId?.toString() || null;
+const amazonCreateValue = route.query.amazonCreateValue?.toString() || null;
 const formConfig = ref<FormConfig | null>(null);
 const formData = ref<Record<string, any>>({});
 const nextWizardId = ref<string | null>(null);
@@ -54,6 +55,15 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
 
 onMounted(async () => {
   formConfig.value = amazonPropertyEditFormConfigConstructor(t, type.value, amazonPropertyId.value, integrationId, propertyId);
+
+  if (amazonCreateValue) {
+    formConfig.value.submitUrl = {
+      name: 'integrations.amazonPropertySelectValues.edit',
+      params: { type: type.value, id: amazonCreateValue },
+      query: { integrationId, salesChannelId, ...(isWizard ? { wizard: '1' } : {}) },
+    };
+    return;
+  }
 
   if (!isWizard) return;
 

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -190,7 +190,7 @@ const handleSubmit = async () => {
                   <span class="font-medium flex items-center gap-1">
                     ⚠️ {{ t('integrations.show.propertySelectValues.notMappedBanner.title') }}
                   </span>
-                  <Link :path="{ name: 'integrations.amazonProperties.edit', params: { type: type, id: amazonPropertyId }, query: { integrationId } }" class="underline">
+                  <Link :path="{ name: 'integrations.amazonProperties.edit', params: { type: type, id: amazonPropertyId }, query: { integrationId, salesChannelId, amazonCreateValue: valueId } }" class="underline">
                     {{ t('integrations.show.propertySelectValues.notMappedBanner.content') }}
                   </Link>
                 </div>


### PR DESCRIPTION
## Summary
- include `amazonCreateValue` in property mapping link
- redirect back to value edit view when `amazonCreateValue` is set

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685328e533b0832ea30a4a40e538b57d

## Summary by Sourcery

Add return path to Amazon property mapping flow by passing an `amazonCreateValue` query parameter and adjusting controllers and links to redirect back to the value edit view after creating a new property value.

Enhancements:
- Detect `amazonCreateValue` in the Amazon property edit controller and override its submit URL to return to the value edit view.
- Include `amazonCreateValue` and `salesChannelId` query parameters in the property-select-values edit link for proper redirection after creating a new value.