### PR TITLE
Set cancelUrl on amazon wizard edit forms

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -71,6 +71,11 @@ onMounted(async () => {
   nextWizardId.value = nextId;
 
   formConfig.value.addSubmitAndContinue = false;
+  formConfig.value.cancelUrl = {
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: 'properties' }
+  };
 
   if (nextId) {
     formConfig.value.submitUrl = {

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -110,6 +110,11 @@ onMounted(async () => {
   nextWizardId.value = nextId;
 
   enhancedConfig.value.addSubmitAndContinue = false;
+  enhancedConfig.value.cancelUrl = {
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: 'propertySelectValues' }
+  };
 
   if (nextId) {
     enhancedConfig.value.submitUrl = {

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -110,6 +110,11 @@ onMounted(async () => {
   nextWizardId.value = nextId;
 
   formConfig.value.addSubmitAndContinue = false;
+  formConfig.value.cancelUrl = {
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: 'productRules' }
+  };
 
   if (nextId) {
     formConfig.value.submitUrl = {


### PR DESCRIPTION
## Summary
- keep back button path to listing page in Amazon wizard forms

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533b3ba364832ebbd23449004927dd

## Summary by Sourcery

Enhancements:
- Add cancelUrl configuration to Amazon wizard edit controllers to preserve back navigation to the integrations listing page