### PR TITLE
Adjust Amazon integration hostname handling

### DIFF
--- a/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
+++ b/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
@@ -142,10 +142,12 @@ const allowNextStep = computed(() => {
     if (!hostname || hostname.trim() === '') {
       return false;
     }
-    // This regex checks for an optional protocol (http/https) and a basic hostname pattern.
-    const urlPattern = /^(https?:\/\/)?([\w\-]+\.)+[\w\-]+(\/[\w\-./?%&=]*)?$/;
-    if (!urlPattern.test(hostname)) {
-      return false;
+    if (selectedIntegrationType.value !== IntegrationTypes.Amazon) {
+      // This regex checks for an optional protocol (http/https) and a basic hostname pattern.
+      const urlPattern = /^(https?:\/\/)?([\w\-]+\.)+[\w\-]+(\/[\w\-./?%&=]*)?$/;
+      if (!urlPattern.test(hostname)) {
+        return false;
+      }
     }
   }
 
@@ -382,6 +384,7 @@ const handleSalesChannelSuccess = async (channelData: any, integrationType: stri
         <template #generalInfoStep>
           <GeneralInfoStep
               :general-info="form.generalInfo"
+              :integration-type="selectedIntegrationType"
               :max-requests-per-minute="selectedIntegrationType === IntegrationTypes.Shopify ? 120 : undefined"
               :show-ssl="selectedIntegrationType !== IntegrationTypes.Shopify"
           />

--- a/src/core/integrations/integrations/integrations-create/containers/general-info-step/GeneralInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/general-info-step/GeneralInfoStep.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
-import { defineProps, defineEmits } from 'vue';
+import { defineProps, defineEmits, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { TextInput } from "../../../../../../shared/components/atoms/input-text";
 import { Label } from "../../../../../../shared/components/atoms/label";
 import { Toggle } from "../../../../../../shared/components/atoms/toggle";
-import { IntegrationGeneralInfo } from "../../../integrations";
+import { IntegrationGeneralInfo, IntegrationTypes } from "../../../integrations";
 import {Accordion} from "../../../../../../shared/components/atoms/accordion";
 
 const props = defineProps<{
   generalInfo: IntegrationGeneralInfo,
   maxRequestsPerMinute: number | undefined,
-  showSsl: boolean
+  showSsl: boolean,
+  integrationType: IntegrationTypes
 }>();
 
 const { t } = useI18n();
@@ -18,6 +19,18 @@ const { t } = useI18n();
 const accordionItems = [
   { name: 'throttling', label: t('integrations.show.sections.throttling'), icon: 'gauge' }
 ];
+
+const hostnameLabel = computed(() => {
+  return props.integrationType === IntegrationTypes.Amazon
+    ? t('shared.labels.name')
+    : t('integrations.labels.hostname');
+});
+
+const hostnamePlaceholder = computed(() => {
+  return props.integrationType === IntegrationTypes.Amazon
+    ? t('shared.placeholders.name')
+    : 'https://example.com';
+});
 
 </script>
 
@@ -32,11 +45,11 @@ const accordionItems = [
             <Flex vertical class="gap-2">
               <FlexCell>
                 <Label class="font-semibold block text-sm leading-6 text-gray-900">
-                  {{ t('integrations.labels.hostname') }}*
+                  {{ hostnameLabel }}*
                 </Label>
               </FlexCell>
               <FlexCell>
-                <TextInput class="w-96" v-model="generalInfo.hostname" placeholder="https://example.com" />
+                <TextInput class="w-96" v-model="generalInfo.hostname" :placeholder="hostnamePlaceholder" />
               </FlexCell>
             </Flex>
           </FlexCell>


### PR DESCRIPTION
## Summary
- allow GeneralInfoStep to accept integration type
- render `hostname` field as a plain name for Amazon integrations
- skip URL validation when Amazon is selected

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853d8164d68832e91dfdcd888107a9a