### PR TITLE
Add help texts for Amazon select value mapping

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -186,6 +186,9 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                     <FlexCell>
                       <TextInput v-model="form.amazonProperty" disabled class="w-full" />
                     </FlexCell>
+                    <FlexCell>
+                      <p class="mt-1 text-sm leading-6 text-gray-400">{{ t('integrations.show.propertySelectValues.help.amazonProperty') }}</p>
+                    </FlexCell>
                   </Flex>
                 </div>
                 <div class="col-span-full">
@@ -195,6 +198,9 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                     </FlexCell>
                     <FlexCell>
                       <TextInput v-model="form.marketplace" disabled class="w-full" />
+                    </FlexCell>
+                    <FlexCell>
+                      <p class="mt-1 text-sm leading-6 text-gray-400">{{ t('integrations.show.propertySelectValues.help.marketplace') }}</p>
                     </FlexCell>
                   </Flex>
                 </div>
@@ -206,6 +212,9 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                     <FlexCell>
                       <TextInput v-model="form.remoteValue" disabled class="w-full" />
                     </FlexCell>
+                    <FlexCell>
+                      <p class="mt-1 text-sm leading-6 text-gray-400">{{ t('integrations.show.propertySelectValues.help.remoteValue') }}</p>
+                    </FlexCell>
                   </Flex>
                 </div>
                 <div class="col-span-full">
@@ -215,6 +224,9 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                     </FlexCell>
                     <FlexCell>
                       <TextInput v-model="form.remoteName" class="w-full" />
+                    </FlexCell>
+                    <FlexCell>
+                      <p class="mt-1 text-sm leading-6 text-gray-400">{{ t('integrations.show.propertySelectValues.help.remoteName') }}</p>
                     </FlexCell>
                   </Flex>
                 </div>
@@ -233,6 +245,9 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                     </FlexCell>
                     <FlexCell>
                       <FieldQuery :field="localInstanceField as QueryFormField" v-model="form.localInstance.id" @update:modelValue="form.localInstance.id = $event" />
+                    </FlexCell>
+                    <FlexCell>
+                      <p class="mt-1 text-sm leading-6 text-gray-400">{{ t('integrations.show.propertySelectValues.help.selectValue') }}</p>
                     </FlexCell>
                   </Flex>
                 </div>


### PR DESCRIPTION
## Summary
- show tooltip texts in Amazon select value edit page

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: vue-tsc not found)*


------
https://chatgpt.com/codex/tasks/task_e_68542f2f3f68832eb592e9968d84b765