### PR TITLE
Add Amazon import feature

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/Imports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/Imports.vue
@@ -1,144 +1,16 @@
 <script setup lang="ts">
-import { ref } from "vue";
-import { useI18n } from 'vue-i18n';
-import { Link } from "../../../../../../shared/components/atoms/link";
-import { Button } from "../../../../../../shared/components/atoms/button";
-import { ApolloSubscription } from "../../../../../../shared/components/molecules/apollo-subscription";
-import { salesChannelSubscription } from "../../../../../../shared/api/subscriptions/salesChannels.js"
-import { DiscreteLoader } from "../../../../../../shared/components/atoms/discrete-loader";
-import { AssignProgressBar } from "../../../../../../shared/components/molecules/assign-progress-bar";
-import { getStatusBadgeMap, SalesChannelSubscriptionResult } from "./configs";
-import { Badge } from "../../../../../../shared/components/atoms/badge";
-import {
-  createSalesChannelImportMutation,
-  updateSalesChannelImportMutation
-} from "../../../../../../shared/api/mutations/salesChannels";
-import { Toast } from "../../../../../../shared/modules/toast";
-import apolloClient from "../../../../../../../apollo-client";
-import {Icon} from "../../../../../../shared/components/atoms/icon";
-import { useRoute } from "vue-router";
-import { processGraphQLErrors } from "../../../../../../shared/utils";
+import { ref, computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { IntegrationTypes } from "../../../integrations";
+import { AmazonImportsListing, GeneralImportsListing } from './components';
 
 const route = useRoute();
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const type = ref(String(route.params.type));
-
-const { t } = useI18n();
-
-const statusBadgeMap = ref(getStatusBadgeMap(t));
-
-const formatDate = (dateString) => {
-    const date = new Date(dateString);
-
-    return new Intl.DateTimeFormat('en-GB', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false
-    }).format(date);
-};
-
-const isRetryEnabled = (importItem): boolean => {
-  const createdDate = new Date(importItem.createdAt);
-  const oneWeekAgo = new Date();
-  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-
-  console.log(['success', 'failed'].includes(importItem.status))
-  return ['success', 'failed'].includes(importItem.status) && createdDate >= oneWeekAgo;
-};
-
-
-const retryImport = async (importId: string) => {
-  try {
-    await apolloClient.mutate({
-      mutation: updateSalesChannelImportMutation,
-      variables: {
-        data: {
-          id: importId,
-          status: "pending",
-        },
-      },
-    });
-    Toast.success(t("integrations.imports.retry.success"));
-  } catch (e) {
-    Toast.error(t("integrations.imports.retry.error"));
-    console.error("Retry failed:", e);
-  }
-};
-
+const isAmazon = computed(() => type.value === IntegrationTypes.Amazon);
 </script>
 
 <template>
-  <ApolloSubscription :subscription="salesChannelSubscription" :variables="{ pk: props.salesChannelId }">
-  <template #default="{ result }">
-    <div v-if="result">
-      <div class="flex items-center justify-between flex-wrap gap-4 mb-4">
-        <div></div>
-        <div>
-            <Link
-              :disabled="(result as SalesChannelSubscriptionResult).salesChannel.isImporting"
-              :path="{ name: 'integrations.imports.create', params: { integrationId: id } }"
-            >
-              <Button
-                :disabled="(result as SalesChannelSubscriptionResult).salesChannel.isImporting"
-                type="button"
-                class="btn btn-primary"
-              >
-                {{ t('integrations.imports.create.title') }}
-              </Button>
-            </Link>
-        </div>
-      </div>
-
-      <div class="mt-2 h-full">
-        <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
-          <thead>
-            <tr>
-              <th class="p-2 text-left">{{ t('shared.labels.createdAt') }}</th>
-              <th class="p-2 text-left">{{ t('shared.labels.status') }}</th>
-              <th class="p-2 text-left">{{ t('shared.labels.progress') }}</th>
-              <th class="p-2 text-left">{{ t('shared.labels.actions') }}</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-200 bg-white">
-            <tr
-              v-for="importItem in (result as SalesChannelSubscriptionResult).salesChannel.saleschannelimportSet"
-              :key="importItem.id"
-              class="border-b dark:border-[#191e3a]"
-            >
-              <td class="p-2">{{ formatDate(importItem.createdAt) }}</td>
-              <td class="p-2">
-                <Badge
-                  :color="statusBadgeMap[importItem.status]?.color"
-                  :text="statusBadgeMap[importItem.status]?.text"
-                />
-              </td>
-              <td class="p-2">
-                <AssignProgressBar
-                  :progress="importItem.percentage"
-                  :is-error="importItem.status === 'failed'"
-                />
-              </td>
-              <td class="p-2 text-right">
-              <Button
-                :disabled="!isRetryEnabled(importItem)"
-                @click="retryImport(importItem.id)"
-              >
-                <Icon name="clock-rotate-left" size="lg" class="text-gray-500" />
-              </Button>
-            </td>
-
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-    <div v-else>
-      <DiscreteLoader :loading="true" />
-    </div>
-  </template>
-</ApolloSubscription>
-
+  <AmazonImportsListing v-if="isAmazon" :id="id" :sales-channel-id="salesChannelId" />
+  <GeneralImportsListing v-else :id="id" :sales-channel-id="salesChannelId" />
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/components/AmazonImportsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/components/AmazonImportsListing.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Link } from "../../../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../../../shared/components/atoms/button";
+import { ApolloSubscription } from "../../../../../../../shared/components/molecules/apollo-subscription";
+import { DiscreteLoader } from "../../../../../../../shared/components/atoms/discrete-loader";
+import { AssignProgressBar } from "../../../../../../../shared/components/molecules/assign-progress-bar";
+import { Badge } from "../../../../../../../shared/components/atoms/badge";
+import { salesChannelSubscription } from "../../../../../../../shared/api/subscriptions/salesChannels.js";
+import { getStatusBadgeMap, SalesChannelSubscriptionResult } from "../configs";
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const { t } = useI18n();
+
+const statusBadgeMap = getStatusBadgeMap(t);
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+};
+</script>
+
+<template>
+  <ApolloSubscription :subscription="salesChannelSubscription" :variables="{ pk: props.salesChannelId }">
+    <template #default="{ result }">
+      <div v-if="result">
+        <div class="flex items-center justify-between flex-wrap gap-4 mb-4">
+          <div></div>
+          <div>
+            <Link :path="{ name: 'integrations.imports.create', params: { integrationId: id } }">
+              <Button type="button" class="btn btn-primary">
+                {{ t('integrations.imports.create.title') }}
+              </Button>
+            </Link>
+          </div>
+        </div>
+        <div class="mt-2 h-full">
+          <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+            <thead>
+              <tr>
+                <th class="p-2 text-left">{{ t('shared.labels.createdAt') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.status') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.progress') }}</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <tr v-for="importItem in (result as SalesChannelSubscriptionResult).salesChannel.amazonImports" :key="importItem.id" class="border-b dark:border-[#191e3a]">
+                <td class="p-2">{{ formatDate(importItem.createdAt) }}</td>
+                <td class="p-2">{{ t(`integrations.imports.types.${importItem.type}`) }}</td>
+                <td class="p-2">
+                  <Badge :color="statusBadgeMap[importItem.status]?.color" :text="statusBadgeMap[importItem.status]?.text" />
+                </td>
+                <td class="p-2">
+                  <AssignProgressBar :progress="importItem.percentage" :is-error="importItem.status === 'failed'" />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div v-else>
+        <DiscreteLoader :loading="true" />
+      </div>
+    </template>
+  </ApolloSubscription>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/components/GeneralImportsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/components/GeneralImportsListing.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Link } from "../../../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../../../shared/components/atoms/button";
+import { ApolloSubscription } from "../../../../../../../shared/components/molecules/apollo-subscription";
+import { DiscreteLoader } from "../../../../../../../shared/components/atoms/discrete-loader";
+import { AssignProgressBar } from "../../../../../../../shared/components/molecules/assign-progress-bar";
+import { Badge } from "../../../../../../../shared/components/atoms/badge";
+import { Icon } from "../../../../../../../shared/components/atoms/icon";
+import { salesChannelSubscription } from "../../../../../../../shared/api/subscriptions/salesChannels.js";
+import { updateSalesChannelImportMutation } from "../../../../../../../shared/api/mutations/salesChannels";
+import apolloClient from "../../../../../../../../apollo-client";
+import { Toast } from "../../../../../../../shared/modules/toast";
+import { getStatusBadgeMap, SalesChannelSubscriptionResult } from "../configs";
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const { t } = useI18n();
+
+const statusBadgeMap = getStatusBadgeMap(t);
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+};
+
+const isRetryEnabled = (importItem: any): boolean => {
+  const createdDate = new Date(importItem.createdAt);
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+  return ['success', 'failed'].includes(importItem.status) && createdDate >= oneWeekAgo;
+};
+
+const retryImport = async (importId: string) => {
+  try {
+    await apolloClient.mutate({
+      mutation: updateSalesChannelImportMutation,
+      variables: { data: { id: importId, status: 'pending' } },
+    });
+    Toast.success(t('integrations.imports.retry.success'));
+  } catch (e) {
+    Toast.error(t('integrations.imports.retry.error'));
+    console.error('Retry failed:', e);
+  }
+};
+</script>
+
+<template>
+  <ApolloSubscription :subscription="salesChannelSubscription" :variables="{ pk: props.salesChannelId }">
+    <template #default="{ result }">
+      <div v-if="result">
+        <div class="flex items-center justify-between flex-wrap gap-4 mb-4">
+          <div></div>
+          <div>
+            <Link :disabled="(result as SalesChannelSubscriptionResult).salesChannel.isImporting" :path="{ name: 'integrations.imports.create', params: { integrationId: id } }">
+              <Button :disabled="(result as SalesChannelSubscriptionResult).salesChannel.isImporting" type="button" class="btn btn-primary">
+                {{ t('integrations.imports.create.title') }}
+              </Button>
+            </Link>
+          </div>
+        </div>
+        <div class="mt-2 h-full">
+          <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+            <thead>
+              <tr>
+                <th class="p-2 text-left">{{ t('shared.labels.createdAt') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.status') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.progress') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.actions') }}</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <tr v-for="importItem in (result as SalesChannelSubscriptionResult).salesChannel.saleschannelimportSet" :key="importItem.id" class="border-b dark:border-[#191e3a]">
+                <td class="p-2">{{ formatDate(importItem.createdAt) }}</td>
+                <td class="p-2">
+                  <Badge :color="statusBadgeMap[importItem.status]?.color" :text="statusBadgeMap[importItem.status]?.text" />
+                </td>
+                <td class="p-2">
+                  <AssignProgressBar :progress="importItem.percentage" :is-error="importItem.status === 'failed'" />
+                </td>
+                <td class="p-2 text-right">
+                  <Button :disabled="!isRetryEnabled(importItem)" @click="retryImport(importItem.id)">
+                    <Icon name="clock-rotate-left" size="lg" class="text-gray-500" />
+                  </Button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div v-else>
+        <DiscreteLoader :loading="true" />
+      </div>
+    </template>
+  </ApolloSubscription>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/components/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/components/index.ts
@@ -1,0 +1,2 @@
+export { default as AmazonImportsListing } from './AmazonImportsListing.vue';
+export { default as GeneralImportsListing } from './GeneralImportsListing.vue';

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/ImportCreateController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/ImportCreateController.vue
@@ -5,8 +5,9 @@ import { useRoute, useRouter } from 'vue-router';
 import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../../shared/components/molecules/breadcrumbs";
 import { MagentoImporter } from "./containers/magento/magento-importer";
-import {IntegrationTypes} from "../../../../../integrations";
 import { ShopifyImporter } from "./containers/shopify/shopify-importer";
+import { AmazonImporter } from "./containers/amazon/amazon-importer";
+import {IntegrationTypes} from "../../../../../integrations";
 
 
 const { t } = useI18n();
@@ -32,6 +33,7 @@ const type = ref(String(route.params.type));
     <template #content>
       <MagentoImporter v-if="type == IntegrationTypes.Magento" :integration-id="integrationId" :type="type" />
       <ShopifyImporter v-else-if="type == IntegrationTypes.Shopify" :integration-id="integrationId" :type="type" />
+      <AmazonImporter v-else-if="type == IntegrationTypes.Amazon" :integration-id="integrationId" :type="type" />
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/amazon/amazon-importer/AmazonImporter.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/amazon/amazon-importer/AmazonImporter.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import { Wizard } from '../../../../../../../../../../shared/components/molecules/wizard';
+import { OptionSelector } from '../../../../../../../../../../shared/components/molecules/option-selector';
+import apolloClient from '../../../../../../../../../../../apollo-client';
+import { Toast } from '../../../../../../../../../../shared/modules/toast';
+import { createAmazonImportProcessMutation } from '../../../../../../../../../../shared/api/mutations/salesChannels';
+import { amazonImportProcessesQuery } from '../../../../../../../../../../shared/api/queries/salesChannels';
+import { IntegrationTypes } from '../../../../../../integrations';
+
+const props = defineProps<{ integrationId: string; type: string }>();
+const router = useRouter();
+const { t } = useI18n();
+
+const importType = ref('schema');
+const hasFinishedSchema = ref(false);
+const loading = ref(false);
+
+const typeChoices = computed(() => [
+  { name: 'schema' },
+  { name: 'products', disabled: !hasFinishedSchema.value },
+]);
+
+const fetchImports = async () => {
+  loading.value = true;
+  try {
+    const { data } = await apolloClient.query({
+      query: amazonImportProcessesQuery,
+      variables: { filter: { salesChannel: { id: { exact: props.integrationId } } } },
+      fetchPolicy: 'network-only',
+    });
+    const edges = data?.amazonImportProcesses?.edges || [];
+    hasFinishedSchema.value = edges.some((e: any) => e.node.type === 'schema' && e.node.status === 'success');
+  } catch (e) {
+    console.error(e);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchImports);
+
+const createImport = async () => {
+  try {
+    await apolloClient.mutate({
+      mutation: createAmazonImportProcessMutation,
+      variables: {
+        data: {
+          salesChannel: { id: props.integrationId },
+          type: importType.value,
+          status: 'pending',
+        },
+      },
+    });
+    Toast.success(t('integrations.imports.create.success'));
+    router.push({ name: 'integrations.integrations.show', params: { id: props.integrationId, type: props.type }, query: { tab: 'imports' } });
+  } catch (err) {
+    console.error(err);
+    Toast.error(t('shared.form.error'));
+  }
+};
+
+const wizardSteps = [{ title: t('integrations.imports.create.title'), name: 'selectType' }];
+
+</script>
+
+<template>
+  <Wizard :steps="wizardSteps" :show-buttons="true" @on-finish="createImport">
+    <template #selectType>
+      <div class="flex flex-col gap-6">
+        <OptionSelector v-model="importType" :choices="typeChoices">
+          <template #schema>
+            <div>
+              <h3 class="text-lg font-bold">{{ t('integrations.imports.types.schema') }}</h3>
+            </div>
+          </template>
+          <template #products>
+            <div>
+              <h3 class="text-lg font-bold">{{ t('integrations.imports.types.products') }}</h3>
+            </div>
+          </template>
+        </OptionSelector>
+      </div>
+    </template>
+  </Wizard>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/amazon/amazon-importer/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/amazon/amazon-importer/index.ts
@@ -1,0 +1,1 @@
+export { default as AmazonImporter } from './AmazonImporter.vue';

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2397,6 +2397,10 @@
         "success": "Retry import process success",
         "error": "Retry import process had an unexpected error"
       },
+      "types": {
+        "schema": "Schema",
+        "products": "Products"
+      },
       "create": {
         "success": "Create import process success",
         "title": "Create Import",

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -505,3 +505,17 @@ export const updateAmazonProductTypeMutation = gql`
     }
   }
 `;
+export const createAmazonImportProcessMutation = gql`
+  mutation createAmazonImportProcess($data: AmazonSalesChannelImportInput!) {
+    createAmazonImportProcess(data: $data) {
+      id
+      type
+      status
+      percentage
+      createdAt
+      salesChannel {
+        id
+      }
+    }
+  }
+`;

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -735,4 +735,36 @@ export const getAmazonProductTypeQuery = gql`
       }
     }
   }
+`;export const amazonImportProcessesQuery = gql`
+  query AmazonImportProcesses(
+    $first: Int,
+    $last: Int,
+    $after: String,
+    $before: String,
+    $order: AmazonSalesChannelImportOrder,
+    $filter: AmazonSalesChannelImportFilter
+  ) {
+    amazonImportProcesses(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          type
+          status
+          percentage
+          createdAt
+          salesChannel {
+            id
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
 `;

--- a/src/shared/api/subscriptions/salesChannels.js
+++ b/src/shared/api/subscriptions/salesChannels.js
@@ -13,6 +13,13 @@ export const salesChannelSubscription = gql`
         percentage
         createdAt
       }
+      amazonImports {
+        id
+        type
+        status
+        percentage
+        createdAt
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- split imports listing into dedicated Amazon and general listing components
- update imports page to use new components
- extend sales channel subscription with amazonImports field

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685467cd0a80832e840fdc0a6abb297b