### PR TITLE
Add additional button slot for Amazon product type

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -126,7 +126,7 @@ const handleFormUpdate = (form) => {
             amazonWizard: isWizard ? '1' : '0',
             ...(amazonCreateValue ? { amazonCreateValue } : {}) } }">
             <Button type="button" class="btn btn-info">
-                {{  t('properties.properties.create.title') }}
+              {{ t('integrations.show.generateProperty') }}
             </Button>
           </Link>
         </template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -152,18 +152,16 @@ const handleFormUpdate = (form) => {
         ]" />
     </template>
 
-    <template v-slot:buttons>
-        <div>
+    <template v-slot:content>
+      <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" >
+        <template #additional-button>
           <Link :path="{ name: 'properties.values.create', query: { propertyId: propertyProductTypeId, isRule: '1', amazonRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`, value: formData.name } }">
-            <Button type="button" class="btn btn-primary">
-                {{  t('properties.rule.create.title') }}
+            <Button type="button" class="btn btn-info">
+              {{ t('integrations.show.generateProductType') }}
             </Button>
           </Link>
-      </div>
-    </template>
-
-    <template v-slot:content>
-      <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" />
+        </template>
+      </GeneralForm>
     </template>
   </GeneralTemplate>
 </template>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2213,7 +2213,9 @@
         "startMapping": "Start Mapping",
         "saveAndMapNext": "Save & Map Next",
         "allMappedSuccess": "You mapped all the values"
-      }
+      },
+      "generateProperty": "Generate Property",
+      "generateProductType": "Generate Product Type"
     },
     "create": {
       "title": "Create Integration",


### PR DESCRIPTION
## Summary
- expose extra button slot in Amazon product type edit
- adjust label wording for Amazon property
- translate new generate buttons

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685552907f74832e955af6d78a1460e0