### PR TITLE
Add resend invitation action

### DIFF
--- a/src/core/profile/company/containers/company-members-list/CompanyMembersList.vue
+++ b/src/core/profile/company/containers/company-members-list/CompanyMembersList.vue
@@ -7,7 +7,7 @@ import { Icon } from "../../../../../shared/components/atoms/icon";
 import { Button } from "../../../../../shared/components/atoms/button";
 import { Modal } from "../../../../../shared/components/atoms/modal";
 import Vue3Datatable from "@bhplugin/vue3-datatable";
-import { disableMemberMutation, enableMemberMutation } from "../../../../../shared/api/mutations/members.js";
+import { disableMemberMutation, enableMemberMutation, resendInviteMutation } from "../../../../../shared/api/mutations/members.js";
 import "@bhplugin/vue3-datatable/dist/style.css";
 import { injectAuth, isCompanyOwner } from '../../../../../shared/modules/auth';
 import {Toast} from "../../../../../shared/modules/toast";
@@ -69,6 +69,10 @@ const onMemberEnabledCompleted = (response) => {
   Toast.success(t('auth.register.company.members.alert.enableMemberSuccess'));
 };
 
+const onInviteResendCompleted = () => {
+  Toast.success(t('auth.register.company.members.alert.resendInviteSuccess'));
+};
+
 const onMemberActionError = (error) => {
   Toast.error(error);
 };
@@ -118,7 +122,7 @@ const inviteMember = () => {
           <Icon v-else name="times-circle" class="text-red-500" />
         </template>
         <template #actions="row" v-if="isCompanyOwner(auth)">
-          <div v-if="isCompanyOwner(auth) && row.value.invitationAccepted && !row.value.isOwner">
+          <div v-if="row.value.invitationAccepted && !row.value.isOwner">
             <ApolloMutation
               v-if="row.value.isActive"
               :mutation="disableMemberMutation"
@@ -140,6 +144,19 @@ const inviteMember = () => {
               <template #default="{ mutate, loading }">
                 <button type="button" :disabled="loading" @click="mutate">
                   <Icon name="undo-alt" class="text-green-500" />
+                </button>
+              </template>
+            </ApolloMutation>
+          </div>
+          <div v-else-if="!row.value.invitationAccepted && !row.value.isOwner">
+            <ApolloMutation
+              :mutation="resendInviteMutation"
+              :variables="{ id: row.value.id }"
+              @done="onInviteResendCompleted"
+              @error="onMemberActionError">
+              <template #default="{ mutate, loading }">
+                <button type="button" :disabled="loading" @click="mutate">
+                  <Icon name="paper-plane" class="text-blue-500" />
                 </button>
               </template>
             </ApolloMutation>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -536,7 +536,8 @@
         "members": {
           "alert": {
             "deleteMemberSuccess": "Member was successfully deleted!",
-            "enableMemberSuccess": "Member was successfully added back!"
+            "enableMemberSuccess": "Member was successfully added back!",
+            "resendInviteSuccess": "Invitation resent successfully!"
           },
           "labels": {
             "invitationAccepted": "Invitation Accepted"

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -348,7 +348,8 @@
         "members": {
           "alert": {
             "deleteMemberSuccess": "Gebruiker was succesvol verwijderd!",
-            "enableMemberSuccess": "Gebruiker succesvol opnieuw toegevoegd!"
+            "enableMemberSuccess": "Gebruiker succesvol opnieuw toegevoegd!",
+            "resendInviteSuccess": "Uitnodiging opnieuw verzonden!"
           },
           "labels": {
             "invitationAccepted": "Uitnodiging geaccepteerd"

--- a/src/shared/api/mutations/members.js
+++ b/src/shared/api/mutations/members.js
@@ -16,3 +16,10 @@ mutation enableUser($id: GlobalID!) {
     isActive
   }
 }`;
+
+export const resendInviteMutation = gql`
+mutation resendInvite($id: GlobalID!) {
+  resendInvite(data: {id: $id}) {
+    id
+  }
+}`;

--- a/src/shared/plugins/font-awesome.ts
+++ b/src/shared/plugins/font-awesome.ts
@@ -149,7 +149,8 @@ import {
   faGem,
   faCircle,
   faGauge,
-  faClone
+  faClone,
+  faPaperPlane
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(faBell as IconDefinition);
@@ -299,6 +300,7 @@ library.add(faGem as IconDefinition);
 library.add(faCircle as IconDefinition);
 library.add(faGauge as IconDefinition);
 library.add(faClone as IconDefinition);
+library.add(faPaperPlane as IconDefinition);
 
 
 export default {


### PR DESCRIPTION
## Summary
- add `resendInviteMutation`
- show resend button for members who haven't accepted invites
- show toast when invite resend succeeds
- translate resend invite success message for NL and EN locales

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68557f5e2350832ebd19da12ecd578f3

## Summary by Sourcery

Add functionality to resend invitations to company members who haven’t accepted invites, including backend mutation, UI actions, notifications, and translations.

New Features:
- Introduce resendInviteMutation in the API
- Add a resend invite button for members with pending invitations
- Show a localized success toast upon successful invite resend
- Add English and Dutch translations for the resend success message