### PR TITLE
Enable per-channel product content editing

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { Label } from '../../../../../../../shared/components/atoms/label';
+import { TextInput } from '../../../../../../../shared/components/atoms/input-text';
+import { TextHtmlEditor } from '../../../../../../../shared/components/atoms/input-text-html-editor';
+import { AiContentTranslator } from '../../../../../../../shared/components/organisms/ai-content-translator';
+import { AiContentGenerator } from '../../../../../../../shared/components/organisms/ai-content-generator';
+import { PropType } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
+const props = defineProps({
+  form: {
+    type: Object as PropType<{ name: string; shortDescription: string; description: string; urlKey: string }>,
+    required: true,
+  },
+  fieldErrors: {
+    type: Object as PropType<Record<string, string>>,
+    required: true,
+  },
+  productId: {
+    type: String,
+    required: true,
+  },
+  currentLanguage: {
+    type: String as PropType<string | null>,
+    required: true,
+  },
+  shortDescriptionToolbarOptions: {
+    type: Array as PropType<any[]>,
+    required: true,
+  },
+});
+
+const emit = defineEmits<{
+  (e: 'description', val: string): void;
+  (e: 'shortDescription', val: string): void;
+}>();
+</script>
+
+<template>
+  <Flex vertical>
+    <FlexCell>
+      <Flex  class="gap-4">
+        <FlexCell center>
+          <Label semi-bold>{{ t('shared.labels.name') }}</Label>
+        </FlexCell>
+        <FlexCell v-if="currentLanguage !== null && currentLanguage !== 'en'" center>
+          <AiContentTranslator
+            :product="{ id: productId }"
+            productContentType="NAME"
+            toTranslate=""
+            fromLanguageCode="en"
+            :toLanguageCode="currentLanguage"
+            @translated="val => form.name = val"
+          />
+        </FlexCell>
+      </Flex>
+      <TextInput v-model="form.name" :placeholder="t('products.translation.placeholders.name')"
+                 class="mt-2 mb-4 w-full"/>
+      <div class="mb-1 text-sm leading-6">
+        <p class="text-red-500" v-if="fieldErrors['name']">{{ fieldErrors['name'] }}</p>
+      </div>
+    </FlexCell>
+
+    <FlexCell>
+      <Flex class="gap-4">
+        <FlexCell center>
+          <Label semi-bold>{{ t('shared.labels.shortDescription') }}</Label>
+        </FlexCell>
+        <FlexCell center>
+            <AiContentGenerator
+              :productId="productId"
+              :languageCode="currentLanguage"
+              contentAiGenerateType="SHORT_DESCRIPTION"
+              @generated="val => emit('shortDescription', val)"
+            />
+        </FlexCell>
+        <FlexCell v-if="currentLanguage !== null && currentLanguage !== 'en'" center>
+          <AiContentTranslator
+            :product="{ id: productId }"
+            productContentType="SHORT_DESCRIPTION"
+            toTranslate=""
+            fromLanguageCode="en"
+            :toLanguageCode="currentLanguage"
+            @translated="val => emit('shortDescription', val)"
+          />
+        </FlexCell>
+      </Flex>
+      <div class="mt-4 mb-4">
+        <TextHtmlEditor v-model="form.shortDescription" :toolbar-options="shortDescriptionToolbarOptions"
+                        :placeholder="t('products.translation.placeholders.shortDescription')"
+                        class="w-full" />
+      </div>
+      <div class="mb-1 text-sm leading-6">
+        <p class="text-red-500" v-if="fieldErrors['shortDescription']">{{ fieldErrors['shortDescription'] }}</p>
+      </div>
+    </FlexCell>
+
+    <FlexCell>
+      <Flex class="gap-4">
+        <FlexCell center>
+          <Label semi-bold>{{ t('products.translation.labels.description') }}</Label>
+        </FlexCell>
+        <FlexCell center>
+            <AiContentGenerator
+              :productId="productId"
+              :languageCode="currentLanguage"
+              contentAiGenerateType="DESCRIPTION"
+              @generated="val => emit('description', val)"
+            />
+        </FlexCell>
+        <FlexCell v-if="currentLanguage !== null && currentLanguage !== 'en'" center>
+          <AiContentTranslator
+            :product="{ id: productId }"
+            productContentType="DESCRIPTION"
+            toTranslate=""
+            fromLanguageCode="en"
+            :toLanguageCode="currentLanguage"
+            @translated="val => emit('description', val)"
+          />
+        </FlexCell>
+      </Flex>
+      <div class="mt-4 mb-4">
+        <TextHtmlEditor v-model="form.description"
+                        :placeholder="t('products.translation.placeholders.description')"
+                        class="w-full" />
+      </div>
+      <div class="mb-1 text-sm leading-6">
+        <p class="text-red-500" v-if="fieldErrors['description']">{{ fieldErrors['description'] }}</p>
+      </div>
+    </FlexCell>
+    <FlexCell>
+      <Label semi-bold>{{ t('products.translation.labels.urlKey') }}</Label>
+      <TextInput v-model="form.urlKey" :placeholder="t('products.translation.placeholders.urlKey')" class="mt-2 w-full"/>
+      <div class="mb-1 text-sm leading-6">
+        <p class="text-red-500" v-if="fieldErrors['urlKey']">{{ fieldErrors['urlKey'] }}</p>
+      </div>
+    </FlexCell>
+  </Flex>
+</template>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentPreview.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentPreview.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { IntegrationTypes } from '../../../../../../integrations/integrations/integrations';
+
+const props = defineProps<{
+  content: any | null;
+  defaultContent: any | null;
+  currentChannel: string;
+  channels: any[];
+}>();
+
+const cleanHostname = (hostname: string, type: string) => {
+  if (!hostname) return '';
+  if (type === IntegrationTypes.Amazon) {
+    return hostname;
+  }
+  try {
+    const url = new URL(hostname.startsWith('http') ? hostname : `https://${hostname}`);
+    const clean = url.hostname.replace(/^www\./i, '');
+    return clean.split('.')[0];
+  } catch {
+    return hostname;
+  }
+};
+
+const finalPreview = computed(() => {
+  const base = props.currentChannel !== 'default' && props.defaultContent ? props.defaultContent : {};
+  return {
+    name: props.content?.name || base.name || '',
+    shortDescription: props.content?.shortDescription || base.shortDescription || '',
+    description: props.content?.description || base.description || '',
+    urlKey: props.content?.urlKey || base.urlKey || '',
+  };
+});
+
+const previewUrl = computed(() => {
+  let host = '';
+  if (props.currentChannel === 'default') {
+    host = window.location.hostname;
+  } else {
+    const ch = props.channels.find((c: any) => c.id === props.currentChannel);
+    host = ch ? cleanHostname(ch.hostname, ch.type) : '';
+  }
+  return host ? `${host}/${finalPreview.value.urlKey}` : finalPreview.value.urlKey;
+});
+</script>
+
+<template>
+  <div class="sticky top-20 bg-gray-50 border p-4 rounded">
+    <div class="h-32 w-full bg-gray-200 mb-2"></div>
+    <div class="mb-2" :class="{ 'opacity-50 italic': !content?.shortDescription && defaultContent }" v-html="finalPreview.shortDescription" />
+    <div class="mb-2" :class="{ 'opacity-50 italic': !content?.description && defaultContent }" v-html="finalPreview.description" />
+    <div class="text-sm text-blue-600 underline break-all">{{ previewUrl }}</div>
+  </div>
+</template>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -4,24 +4,24 @@ import {useI18n} from 'vue-i18n';
 import {Product} from "../../../../configs";
 import {Button} from "../../../../../../../shared/components/atoms/button";
 import apolloClient from "../../../../../../../../apollo-client";
-import {getProductTranslationByLanguageQuery} from "../../../../../../../shared/api/queries/products.js";
+import {getProductTranslationByLanguageQuery,
+        getProductContentByLanguageAndChannelQuery} from "../../../../../../../shared/api/queries/products.js";
 import {
   updateProductTranslationMutation,
   createProductTranslationMutation,
+  updateProductContentMutation,
+  createProductContentMutation,
 } from "../../../../../../../shared/api/mutations/products.js";
+import { integrationsQuery } from "../../../../../../../shared/api/queries/integrations.js";
 import {Selector} from "../../../../../../../shared/components/atoms/selector";
-import {TextInput} from "../../../../../../../shared/components/atoms/input-text";
-import {TextEditor} from "../../../../../../../shared/components/atoms/input-text-editor";
-import {TextHtmlEditor} from "../../../../../../../shared/components/atoms/input-text-html-editor";
-import {reactive, watch, ref} from "vue";
+import {reactive, watch, ref, onMounted, computed} from "vue";
 import {translationLanguagesQuery} from '../../../../../../../shared/api/queries/languages.js';
-import {Label} from "../../../../../../../shared/components/atoms/label";
 import {Toast} from "../../../../../../../shared/modules/toast";
-import {Icon} from "../../../../../../../shared/components/atoms/icon";
-import {createMediaProductThroughMutation, createVideosMutation} from "../../../../../../../shared/api/mutations/media";
 import {processGraphQLErrors} from "../../../../../../../shared/utils";
-import {AiContentGenerator} from "../../../../../../../shared/components/organisms/ai-content-generator";
-import {AiContentTranslator} from "../../../../../../../shared/components/organisms/ai-content-translator";
+import { IntegrationTypes } from "../../../../../../integrations/integrations/integrations";
+import SalesChannelTabs from "./SalesChannelTabs.vue";
+import ProductContentPreview from "./ProductContentPreview.vue";
+import ProductContentForm from "./ProductContentForm.vue";
 
 const {t} = useI18n();
 const props = defineProps<{ product: Product }>();
@@ -35,10 +35,16 @@ const initialForm = ref({
 
 const form = reactive({...initialForm.value});
 const currentLanguage = ref(null);
+const currentSalesChannel = ref<'default' | string>('default');
 const mutation = ref(null);
 const translationId = ref(null);
 const oldLang = ref(currentLanguage.value);
+const oldChannel = ref(currentSalesChannel.value);
+const salesChannels = ref<any[]>([]);
+const previewContent = ref<any | null>(null);
+const defaultPreviewContent = ref<any | null>(null);
 const fieldErrors = ref<Record<string, string>>({});
+
 
 const cleanedData = (rawData) => {
   if (rawData && rawData.languages.length > 0) {
@@ -51,31 +57,72 @@ const cleanedData = (rawData) => {
   return [];
 };
 
-const setFormAndMutation = async (language) => {
+const cleanHostname = (hostname: string, type: string) => {
+  if (!hostname) return '';
+  if (type === IntegrationTypes.Amazon) {
+    return hostname;
+  }
+  try {
+    const url = new URL(hostname.startsWith('http') ? hostname : `https://${hostname}`);
+    const clean = url.hostname.replace(/^www\./i, '');
+    return clean.split('.')[0];
+  } catch { return hostname; }
+};
+
+const loadSalesChannels = async () => {
+  try {
+    const { data } = await apolloClient.query({ query: integrationsQuery, fetchPolicy: 'network-only' });
+    salesChannels.value = data?.integrations.edges.map((e: any) => e.node) || [];
+  } catch (e) {
+    console.error('Failed to load sales channels', e);
+  }
+};
+
+onMounted(async () => {
+  await loadSalesChannels();
+  if (currentLanguage.value !== null) {
+    await setFormAndMutation(currentLanguage.value, currentSalesChannel.value);
+  }
+});
+
+const setFormAndMutation = async (language, channel) => {
   try {
     const {data} = await apolloClient.query({
-      query: getProductTranslationByLanguageQuery,
-      variables: {languageCode: language, productId: props.product.id},
+      query: getProductContentByLanguageAndChannelQuery,
+      variables: {languageCode: language, productId: props.product.id, salesChannelId: channel === 'default' ? null : channel},
       fetchPolicy: 'network-only'
     });
 
-    if (data && data.productTranslations.edges.length === 1) {
-      const translation = data.productTranslations.edges[0].node;
+    if (data && data.productContents.edges.length === 1) {
+      const translation = data.productContents.edges[0].node;
       form.name = translation.name;
       form.shortDescription = translation.shortDescription;
       form.description = translation.description;
       form.urlKey = translation.urlKey;
       translationId.value = translation.id;
-      mutation.value = updateProductTranslationMutation;
+      mutation.value = updateProductContentMutation;
+      previewContent.value = translation;
     } else {
       form.name = '';
       form.shortDescription = '<p><br></p>';
       form.description = '<p><br></p>';
       form.urlKey = '';
       translationId.value = null;
-      mutation.value = createProductTranslationMutation;
+      mutation.value = createProductContentMutation;
+      previewContent.value = null;
     }
     initialForm.value = {...form};
+
+    if (channel !== 'default') {
+      const { data: def } = await apolloClient.query({
+        query: getProductContentByLanguageAndChannelQuery,
+        variables: { languageCode: language, productId: props.product.id, salesChannelId: null },
+        fetchPolicy: 'network-only'
+      });
+      defaultPreviewContent.value = def?.productContents.edges[0]?.node || null;
+    } else {
+      defaultPreviewContent.value = null;
+    }
   } catch (error) {
     console.error("Error fetching translation:", error);
   }
@@ -83,8 +130,15 @@ const setFormAndMutation = async (language) => {
 
 watch(currentLanguage, async (newLanguage, oldLanguage) => {
   if (oldLanguage === null) {
-    await setFormAndMutation(newLanguage);
+    await setFormAndMutation(newLanguage, currentSalesChannel.value);
     oldLang.value = newLanguage;
+  }
+});
+
+watch(currentSalesChannel, async (newChannel, oldChannelVal) => {
+  if (oldChannelVal === null) {
+    await setFormAndMutation(currentLanguage.value, newChannel);
+    oldChannel.value = newChannel;
   }
 });
 
@@ -99,7 +153,21 @@ const handleLanguageSelection = async (newLanguage) => {
   }
 
   oldLang.value = newLanguage;
-  await setFormAndMutation(newLanguage);
+  await setFormAndMutation(newLanguage, currentSalesChannel.value);
+};
+
+const handleSalesChannelSelection = async (newChannel) => {
+
+  if (JSON.stringify(form) !== JSON.stringify(initialForm.value)) {
+    const confirmChange = confirm(t('products.translation.confirmLanguageChange'));
+    if (!confirmChange) {
+      currentSalesChannel.value = oldChannel.value;
+      return;
+    }
+  }
+
+  oldChannel.value = newChannel;
+  await setFormAndMutation(currentLanguage.value, newChannel);
 };
 
 
@@ -107,7 +175,8 @@ const getVariables = () => {
   const variables = {
     ...form,
     product: {id: props.product.id},
-    language: currentLanguage.value
+    language: currentLanguage.value,
+    salesChannel: currentSalesChannel.value === 'default' ? null : { id: currentSalesChannel.value }
   };
 
   if (translationId.value) {
@@ -121,6 +190,7 @@ const onMutationCompleted = () => {
   Toast.success(t('products.translation.successfullyUpdated'));
   initialForm.value = {...form};
   fieldErrors.value = {};
+  previewContent.value = {...form};
 };
 
 const handleGeneratedDescriptionContent =  (newVal) => {
@@ -178,108 +248,34 @@ const shortDescriptionToolbarOptions = [
     </FlexCell>
   </Flex>
 
-  <Flex between>
-    <FlexCell class="w-full xl:w-2/3">
-      <Flex vertical>
-        <FlexCell>
-          <Flex  class="gap-4">
-            <FlexCell center>
-              <Label semi-bold>{{ t('shared.labels.name') }}</Label>
-            </FlexCell>
-            <FlexCell v-if="currentLanguage !== null && currentLanguage !== 'en'" center>
-              <AiContentTranslator
-                :product="{ id: product.id }"
-                productContentType="NAME"
-                toTranslate=""
-                fromLanguageCode="en"
-                :toLanguageCode="currentLanguage"
-                @translated="translatedText => form.name = translatedText"
-              />
-            </FlexCell>
-          </Flex>
+  <Flex between class="mt-4">
+    <FlexCell class="w-40">
+      <SalesChannelTabs
+        v-model="currentSalesChannel"
+        :channels="salesChannels"
+        @update:modelValue="handleSalesChannelSelection"
+      />
+    </FlexCell>
 
-          <TextInput v-model="form.name" :placeholder="t('products.translation.placeholders.name')"
-                     class="mt-2 mb-4 w-full"/>
-          <div class="mb-1 text-sm leading-6">
-            <p class="text-red-500" v-if="fieldErrors['name']">{{ fieldErrors['name'] }}</p>
-          </div>
-        </FlexCell>
+    <FlexCell class="w-full xl:w-1/2">
+      <ProductContentForm
+        :form="form"
+        :field-errors="fieldErrors"
+        :product-id="product.id"
+        :current-language="currentLanguage"
+        :short-description-toolbar-options="shortDescriptionToolbarOptions"
+        @description="handleGeneratedDescriptionContent"
+        @shortDescription="handleGeneratedShortDescriptionContent"
+      />
+    </FlexCell>
 
-        <FlexCell>
-          <Flex class="gap-4">
-            <FlexCell center>
-              <Label semi-bold>{{ t('shared.labels.shortDescription') }}</Label>
-            </FlexCell>
-            <FlexCell center>
-                <AiContentGenerator
-                  :productId="product.id"
-                  :languageCode="currentLanguage"
-                  contentAiGenerateType="SHORT_DESCRIPTION"
-                  @generated="handleGeneratedShortDescriptionContent"
-                />
-            </FlexCell>
-            <FlexCell v-if="currentLanguage !== null && currentLanguage !== 'en'" center>
-              <AiContentTranslator
-                :product="{ id: product.id }"
-                productContentType="SHORT_DESCRIPTION"
-                toTranslate=""
-                fromLanguageCode="en"
-                :toLanguageCode="currentLanguage"
-                @translated="handleGeneratedShortDescriptionContent"
-              />
-            </FlexCell>
-          </Flex>
-          <div class="mt-4 mb-4">
-            <TextHtmlEditor v-model="form.shortDescription" :toolbar-options="shortDescriptionToolbarOptions"
-                            :placeholder="t('products.translation.placeholders.shortDescription')"
-                            class="w-full" />
-          </div>
-          <div class="mb-1 text-sm leading-6">
-            <p class="text-red-500" v-if="fieldErrors['shortDescription']">{{ fieldErrors['shortDescription'] }}</p>
-          </div>
-        </FlexCell>
-
-        <FlexCell>
-          <Flex class="gap-4">
-            <FlexCell center>
-              <Label semi-bold>{{ t('products.translation.labels.description') }}</Label>
-            </FlexCell>
-            <FlexCell center>
-                <AiContentGenerator
-                  :productId="product.id"
-                  :languageCode="currentLanguage"
-                  contentAiGenerateType="DESCRIPTION"
-                  @generated="handleGeneratedDescriptionContent"
-                />
-            </FlexCell>
-            <FlexCell v-if="currentLanguage !== null && currentLanguage !== 'en'" center>
-              <AiContentTranslator
-                :product="{ id: product.id }"
-                productContentType="DESCRIPTION"
-                toTranslate=""
-                fromLanguageCode="en"
-                :toLanguageCode="currentLanguage"
-                @translated="handleGeneratedDescriptionContent"
-              />
-            </FlexCell>
-          </Flex>
-          <div class="mt-4 mb-4">
-            <TextHtmlEditor v-model="form.description"
-                            :placeholder="t('products.translation.placeholders.description')"
-                            class="w-full" />
-          </div>
-          <div class="mb-1 text-sm leading-6">
-            <p class="text-red-500" v-if="fieldErrors['description']">{{ fieldErrors['description'] }}</p>
-          </div>
-        </FlexCell>
-        <FlexCell>
-          <Label semi-bold>{{ t('products.translation.labels.urlKey') }}</Label>
-          <TextInput v-model="form.urlKey" :placeholder="t('products.translation.placeholders.urlKey')" class="mt-2 w-full"/>
-          <div class="mb-1 text-sm leading-6">
-            <p class="text-red-500" v-if="fieldErrors['urlKey']">{{ fieldErrors['urlKey'] }}</p>
-          </div>
-        </FlexCell>
-      </Flex>
+    <FlexCell class="hidden xl:block xl:w-1/3">
+      <ProductContentPreview
+        :content="previewContent"
+        :default-content="defaultPreviewContent"
+        :current-channel="currentSalesChannel"
+        :channels="salesChannels"
+      />
     </FlexCell>
 
   </Flex>

--- a/src/core/products/products/product-show/containers/tabs/content/SalesChannelTabs.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/SalesChannelTabs.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { IntegrationTypes } from '../../../../../../integrations/integrations/integrations';
+import { Icon } from '../../../../../../../shared/components/atoms/icon';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{ channels: any[]; modelValue: string }>();
+const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>();
+const { t } = useI18n();
+
+const cleanHostname = (hostname: string, type: string) => {
+  if (!hostname) return '';
+  if (type === IntegrationTypes.Amazon) {
+    return hostname;
+  }
+  try {
+    const url = new URL(hostname.startsWith('http') ? hostname : `https://${hostname}`);
+    const clean = url.hostname.replace(/^www\./i, '');
+    return clean.split('.')[0];
+  } catch {
+    return hostname;
+  }
+};
+
+const select = (val: string) => emit('update:modelValue', val);
+</script>
+
+<template>
+  <div>
+    <div class="overflow-y-auto max-h-[500px]">
+      <div
+        class="cursor-pointer flex items-center gap-2 p-2"
+        :class="{ 'bg-primary text-white': modelValue === 'default' }"
+        @click="select('default')"
+      >
+        <Icon name="store" class="w-4 h-4" />
+        Default
+      </div>
+      <div
+        v-for="channel in channels"
+        :key="channel.id"
+        class="cursor-pointer flex items-center gap-2 p-2"
+        :class="{ 'bg-primary text-white': modelValue === channel.id }"
+        @click="select(channel.id)"
+      >
+        <Icon :name="channel.type" class="w-4 h-4" />
+        {{ cleanHostname(channel.hostname, channel.type) }}
+      </div>
+    </div>
+    <div v-if="modelValue !== 'default'" class="text-xs text-gray-500 mt-2">
+      {{ t('products.translation.warning.inheritFromDefault') }}
+    </div>
+  </div>
+</template>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -840,6 +840,9 @@
       "labels": {
         "description": "Description",
         "urlKey": "URL Key"
+      },
+      "warning": {
+        "inheritFromDefault": "Fields left empty will be inherited from the Default version for this language in the final product content."
       }
     },
     "products": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -599,6 +599,9 @@
       "labels": {
         "description": "Beschrijving",
         "urlKey": "URL Sleutel"
+      },
+      "warning": {
+        "inheritFromDefault": "Lege velden worden overgenomen van de standaardversie voor deze taal in de uiteindelijke productinhoud."
       }
     },
     "products": {

--- a/src/shared/api/mutations/products.js
+++ b/src/shared/api/mutations/products.js
@@ -233,6 +233,30 @@ export const updateProductTranslationMutation = gql`
   }
 `;
 
+export const createProductContentMutation = gql`
+  mutation createProductContent($data: ProductContentInput!) {
+    createProductContent(data: $data) {
+      id
+      name
+      shortDescription
+      description
+      urlKey
+    }
+  }
+`;
+
+export const updateProductContentMutation = gql`
+  mutation updateProductContent($data: ProductContentPartialInput!) {
+    updateProductContent(data: $data) {
+      id
+      name
+      shortDescription
+      description
+      urlKey
+    }
+  }
+`;
+
 export const deleteProductTranslationMutation = gql`
   mutation deleteProductTranslation($id: GlobalID!) {
     deleteProductTranslation(data: {id: $id}) {

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -147,6 +147,26 @@ export const getProductTranslationByLanguageQuery = gql`
   }
 `;
 
+export const getProductContentByLanguageAndChannelQuery = gql`
+  query getProductContentByLanguageAndChannel($languageCode: String!, $productId: GlobalID!, $salesChannelId: GlobalID) {
+    productContents(filters: {
+      language: {exact: $languageCode},
+      product: {id: {exact: $productId}},
+      salesChannel: {id: {exact: $salesChannelId}}
+    }) {
+      edges {
+        node {
+          id
+          name
+          shortDescription
+          description
+          urlKey
+        }
+      }
+    }
+  }
+`;
+
 export const configurableVariationsQuery = gql`
   query ConfigurableVariations($first: Int, $last: Int, $after: String, $before: String, $order: ConfigurableVariationOrder, $filter: ConfigurableVariationFilter) {
     configurableVariations(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {


### PR DESCRIPTION
## Summary
- extend product content editing to support per-sales-channel content
- add preview with inherited default values
- allow switching between sales channels via vertical tabs
- support new GraphQL queries/mutations for product content
- update locales for new warning message
- refactor product content view into smaller components

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68598273c5e0832e8a4147f25a1c46fc

## Summary by Sourcery

Enable per-sales-channel product content editing with channel selection, content preview inheriting default values, and new GraphQL support, modularized into reusable components.

New Features:
- Support product content editing scoped to individual sales channels.
- Provide live preview of channel-specific or inherited default content.
- Allow switching between sales channels via vertical tabs during editing.

Enhancements:
- Introduce new GraphQL queries and mutations for product content per channel.
- Refactor monolithic content view into separate form, preview, and tab components.
- Implement hostname cleanup logic for accurate preview URLs.

Documentation:
- Add locale entries for inheritance warning when editing non-default channels.