### PR TITLE
Add bullet points editor for product translations

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/TranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/TranslationBulletPoints.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { TextInput } from '../../../../../../../shared/components/atoms/input-text';
+import { Button } from '../../../../../../../shared/components/atoms/button';
+import { Icon } from '../../../../../../../shared/components/atoms/icon';
+import { Label } from '../../../../../../../shared/components/atoms/label';
+
+export interface BulletPoint {
+  id?: string;
+  text: string;
+  sortOrder: number;
+}
+
+const props = defineProps<{ modelValue: BulletPoint[]; max?: number }>();
+const emit = defineEmits<{ (e: 'update:modelValue', value: BulletPoint[]): void }>();
+const { t } = useI18n();
+
+const bulletPoints = ref(props.modelValue);
+
+const update = () => emit('update:modelValue', bulletPoints.value);
+
+const addBulletPoint = () => {
+  if (bulletPoints.value.length >= (props.max || 10)) return;
+  bulletPoints.value.push({ text: '', sortOrder: bulletPoints.value.length });
+  update();
+};
+
+const removePoint = (index: number) => {
+  bulletPoints.value.splice(index, 1);
+  bulletPoints.value.forEach((p, i) => (p.sortOrder = i));
+  update();
+};
+
+const moveUp = (index: number) => {
+  if (index === 0) return;
+  const item = bulletPoints.value.splice(index, 1)[0];
+  bulletPoints.value.splice(index - 1, 0, item);
+  bulletPoints.value.forEach((p, i) => (p.sortOrder = i));
+  update();
+};
+
+const moveDown = (index: number) => {
+  if (index === bulletPoints.value.length - 1) return;
+  const item = bulletPoints.value.splice(index, 1)[0];
+  bulletPoints.value.splice(index + 1, 0, item);
+  bulletPoints.value.forEach((p, i) => (p.sortOrder = i));
+  update();
+};
+
+</script>
+
+<template>
+  <div class="mt-4">
+    <Label semi-bold>{{ t('products.translation.labels.bulletPoints') }}</Label>
+    <div v-for="(point, index) in bulletPoints" :key="point.id || index" class="flex items-start gap-2 mt-2">
+      <TextInput v-model="point.text" class="flex-1" :placeholder="t('products.translation.placeholders.bulletPoint')" />
+      <Button :disabled="index === 0" @click="moveUp(index)"><Icon name="arrow-up" /></Button>
+      <Button :disabled="index === bulletPoints.length - 1" @click="moveDown(index)"><Icon name="arrow-down" /></Button>
+      <Button @click="removePoint(index)"><Icon name="trash" /></Button>
+    </div>
+    <Button v-if="bulletPoints.length < (props.max || 10)" class="btn btn-secondary mt-2" @click="addBulletPoint">
+      <Icon name="plus" />
+    </Button>
+  </div>
+</template>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -833,13 +833,15 @@
       "placeholders": {
         "language": "Select a language",
         "name": "Enter name",
-        "shortDescription": "Enter a short description",
-        "description": "Enter a detailed description",
-        "urlKey": "Enter URL key"
+      "shortDescription": "Enter a short description",
+      "description": "Enter a detailed description",
+        "urlKey": "Enter URL key",
+        "bulletPoint": "Enter bullet point"
       },
       "labels": {
         "description": "Description",
-        "urlKey": "URL Key"
+        "urlKey": "URL Key",
+        "bulletPoints": "Bullet Points"
       }
     },
     "products": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -594,11 +594,13 @@
         "name": "Product Naam",
         "shortDescription": "Korte beschrijving van het product voor de snelle lezer.",
         "description": "Schrijf hier de lange product beschrijving die tot in detail gaat. Voor de geïnformeerde klant.",
-        "urlKey": "Voer URL sleutel in"
+        "urlKey": "Voer URL sleutel in",
+        "bulletPoint": "Voer bullet point in"
       },
       "labels": {
         "description": "Beschrijving",
-        "urlKey": "URL Sleutel"
+        "urlKey": "URL Sleutel",
+        "bulletPoints": "Opsommingpunten"
       }
     },
     "products": {

--- a/src/shared/api/mutations/products.js
+++ b/src/shared/api/mutations/products.js
@@ -249,6 +249,52 @@ export const deleteProductTranslationsMutation = gql`
   }
 `;
 
+export const createProductTranslationBulletPointMutation = gql`
+  mutation createProductTranslationBulletPoint($data: ProductTranslationBulletPointInput!) {
+    createProductTranslationBulletPoint(data: $data) {
+      id
+      text
+      sortOrder
+    }
+  }
+`;
+
+export const createProductTranslationBulletPointsMutation = gql`
+  mutation createProductTranslationBulletPoints($data: [ProductTranslationBulletPointInput!]!) {
+    createProductTranslationBulletPoints(data: $data) {
+      id
+      text
+      sortOrder
+    }
+  }
+`;
+
+export const updateProductTranslationBulletPointMutation = gql`
+  mutation updateProductTranslationBulletPoint($data: ProductTranslationBulletPointPartialInput!) {
+    updateProductTranslationBulletPoint(data: $data) {
+      id
+      text
+      sortOrder
+    }
+  }
+`;
+
+export const deleteProductTranslationBulletPointMutation = gql`
+  mutation deleteProductTranslationBulletPoint($id: GlobalID!) {
+    deleteProductTranslationBulletPoint(data: {id: $id}) {
+      id
+    }
+  }
+`;
+
+export const deleteProductTranslationBulletPointsMutation = gql`
+  mutation deleteProductTranslationBulletPoints($ids: [GlobalID!]!) {
+    deleteProductTranslationBulletPoints(data: {ids: $ids}) {
+      id
+    }
+  }
+`;
+
 export const createConfigurableVariationMutation = gql`
   mutation createConfigurableVariation($data: ConfigurableVariationInput!) {
     createConfigurableVariation(data: $data) {

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -147,6 +147,20 @@ export const getProductTranslationByLanguageQuery = gql`
   }
 `;
 
+export const productTranslationBulletPointsQuery = gql`
+  query ProductTranslationBulletPoints($filter: ProductTranslationBulletPointFilter) {
+    productTranslationBulletPoints(filters: $filter, order: { sortOrder: ASC }) {
+      edges {
+        node {
+          id
+          text
+          sortOrder
+        }
+      }
+    }
+  }
+`;
+
 export const configurableVariationsQuery = gql`
   query ConfigurableVariations($first: Int, $last: Int, $after: String, $before: String, $order: ConfigurableVariationOrder, $filter: ConfigurableVariationFilter) {
     configurableVariations(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {


### PR DESCRIPTION
## Summary
- support product translation bullet points via new GraphQL queries/mutations
- add `TranslationBulletPoints` component for editing bullet points
- integrate bullet points in product content form with preview
- update English and Dutch locales

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859b46fa15c832e81409efdbcbe9d27

## Summary by Sourcery

Add bullet point support for product translations by implementing GraphQL operations and integrating a Vue editor component into the translation form.

New Features:
- Support create, update, and delete GraphQL operations for product translation bullet points
- Introduce TranslationBulletPoints component for editing and ordering translation bullet points
- Integrate bullet point editing and preview into the product translation content form

Documentation:
- Add English and Dutch locale entries for bullet point labels and placeholders