### PR TITLE
Add bullet point editing support

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentPreview.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentPreview.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   defaultContent: any | null;
   currentChannel: string;
   channels: any[];
+  bulletPoints?: any[];
 }>();
 
 const cleanHostname = (hostname: string, type: string) => {
@@ -57,6 +58,7 @@ const finalPreview = computed(() => {
         ? props.content?.description
         : (base.description || ''),
     urlKey: props.content?.urlKey || base.urlKey || '',
+    bulletPoints: props.bulletPoints || [],
   };
 });
 
@@ -103,6 +105,9 @@ const previewUrl = computed(() => {
         :class="{ 'opacity-50 italic': !props.content?.description && props.defaultContent }"
         v-html="finalPreview.description"
       />
+      <ul v-if="finalPreview.bulletPoints.length" class="list-disc pl-6 mt-2 text-gray-700">
+        <li v-for="bp in finalPreview.bulletPoints" :key="bp.id || bp.text">{{ bp.text }}</li>
+      </ul>
     </div>
   </div>
 </template>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { ref, watch, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { TextInput } from '../../../../../../../shared/components/atoms/input-text';
+import { Button } from '../../../../../../../shared/components/atoms/button';
+import { Label } from '../../../../../../../shared/components/atoms/label';
+import { Icon } from '../../../../../../../shared/components/atoms/icon';
+import { VueDraggableNext } from 'vue-draggable-next';
+import apolloClient from '../../../../../../../../apollo-client';
+import { productTranslationBulletPointsQuery } from '../../../../../../../shared/api/queries/products.js';
+import {
+  createProductTranslationBulletPointsMutation,
+  updateProductTranslationBulletPointMutation,
+  deleteProductTranslationBulletPointsMutation,
+} from '../../../../../../../shared/api/mutations/products.js';
+import { processGraphQLErrors } from '../../../../../../../shared/utils';
+import { Toast } from '../../../../../../../shared/modules/toast';
+
+const { t } = useI18n();
+
+const props = defineProps<{ translationId: string | null }>();
+const emit = defineEmits<{ (e: 'update:bulletPoints', value: any[]): void }>();
+
+const bulletPoints = ref<any[]>([]);
+const initialBulletPoints = ref<any[]>([]);
+const fieldErrors = ref<Record<string, string>>({});
+
+const fetchPoints = async () => {
+  if (!props.translationId) {
+    bulletPoints.value = [];
+    initialBulletPoints.value = [];
+    emit('update:bulletPoints', bulletPoints.value);
+    return;
+  }
+  try {
+    const { data } = await apolloClient.query({
+      query: productTranslationBulletPointsQuery,
+      variables: { filter: { translation: { id: { exact: props.translationId } } } },
+      fetchPolicy: 'network-only',
+    });
+    bulletPoints.value = data?.productTranslationBulletPoints.edges.map((e: any) => e.node) || [];
+    initialBulletPoints.value = JSON.parse(JSON.stringify(bulletPoints.value));
+    emit('update:bulletPoints', bulletPoints.value);
+  } catch (e) {
+    console.error('Failed to load bullet points', e);
+  }
+};
+
+onMounted(fetchPoints);
+watch(() => props.translationId, fetchPoints);
+watch(bulletPoints, (val) => emit('update:bulletPoints', val), { deep: true });
+
+const addBulletPoint = () => {
+  if (bulletPoints.value.length >= 10) return;
+  bulletPoints.value.push({ id: null, text: '', sortOrder: bulletPoints.value.length });
+};
+
+const removeBulletPoint = (index: number) => {
+  bulletPoints.value.splice(index, 1);
+  bulletPoints.value.forEach((bp, idx) => { bp.sortOrder = idx; });
+};
+
+const onReorder = () => {
+  bulletPoints.value.forEach((bp, idx) => { bp.sortOrder = idx; });
+};
+
+const save = async (newTranslationId?: string) => {
+  const tId = props.translationId || newTranslationId;
+  if (!tId) return;
+
+  const toCreate = bulletPoints.value
+    .filter((bp) => !bp.id && bp.text.trim())
+    .map((bp) => ({ text: bp.text, sortOrder: bp.sortOrder, translation: { id: tId } }));
+  const toUpdate = bulletPoints.value
+    .filter((bp) => {
+      const orig = initialBulletPoints.value.find((o) => o.id === bp.id);
+      return bp.id && orig && (bp.text !== orig.text || bp.sortOrder !== orig.sortOrder);
+    })
+    .map((bp) => ({ id: bp.id, text: bp.text, sortOrder: bp.sortOrder }));
+  const toDelete = initialBulletPoints.value
+    .filter((bp) => !bulletPoints.value.find((b) => b.id === bp.id))
+    .map((bp) => bp.id);
+
+  try {
+    if (toCreate.length) {
+      await apolloClient.mutate({
+        mutation: createProductTranslationBulletPointsMutation,
+        variables: { data: toCreate },
+      });
+    }
+    for (const data of toUpdate) {
+      await apolloClient.mutate({
+        mutation: updateProductTranslationBulletPointMutation,
+        variables: { data },
+      });
+    }
+    if (toDelete.length) {
+      await apolloClient.mutate({
+        mutation: deleteProductTranslationBulletPointsMutation,
+        variables: { ids: toDelete },
+      });
+    }
+    await fetchPoints();
+  } catch (errors) {
+    const validationErrors = processGraphQLErrors(errors, t);
+    fieldErrors.value = validationErrors;
+    if (validationErrors['__all__']) {
+      Toast.error(validationErrors['__all__']);
+    }
+    throw errors;
+  }
+};
+
+defineExpose({ save });
+</script>
+
+<template>
+  <div class="mt-4">
+    <Label semi-bold>{{ t('products.translation.labels.bulletPoints') }}</Label>
+    <VueDraggableNext v-model="bulletPoints" class="mt-2 space-y-2" @end="onReorder">
+      <div v-for="(point, index) in bulletPoints" :key="point.id || index" class="flex items-start gap-2">
+        <TextInput v-model="point.text" class="w-full" />
+        <Button class="btn btn-outline-danger" @click="removeBulletPoint(index)">
+          <Icon name="trash" />
+        </Button>
+      </div>
+    </VueDraggableNext>
+    <div v-if="bulletPoints.length < 10" class="mt-2">
+      <Button class="btn btn-outline-primary" @click="addBulletPoint">
+        <Icon name="plus" />
+      </Button>
+    </div>
+  </div>
+</template>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -840,7 +840,8 @@
       },
       "labels": {
         "description": "Description",
-        "urlKey": "URL Key"
+        "urlKey": "URL Key",
+        "bulletPoints": "Bullet Points"
       },
       "warning": {
         "inheritFromDefault": "Fields left empty will be inherited from the Default version for this language in the final product content."

--- a/src/shared/api/mutations/products.js
+++ b/src/shared/api/mutations/products.js
@@ -552,3 +552,48 @@ export const refreshInspectorMutation = gql`
     }
   } 
 `;
+export const createProductTranslationBulletPointMutation = gql`
+  mutation createProductTranslationBulletPoint($data: ProductTranslationBulletPointInput!) {
+    createProductTranslationBulletPoint(data: $data) {
+      id
+      text
+      sortOrder
+    }
+  }
+`;
+
+export const createProductTranslationBulletPointsMutation = gql`
+  mutation createProductTranslationBulletPoints($data: [ProductTranslationBulletPointInput!]!) {
+    createProductTranslationBulletPoints(data: $data) {
+      id
+      text
+      sortOrder
+    }
+  }
+`;
+
+export const updateProductTranslationBulletPointMutation = gql`
+  mutation updateProductTranslationBulletPoint($data: ProductTranslationBulletPointPartialInput!) {
+    updateProductTranslationBulletPoint(data: $data) {
+      id
+      text
+      sortOrder
+    }
+  }
+`;
+
+export const deleteProductTranslationBulletPointMutation = gql`
+  mutation deleteProductTranslationBulletPoint($id: GlobalID!) {
+    deleteProductTranslationBulletPoint(data: {id: $id}) {
+      id
+    }
+  }
+`;
+
+export const deleteProductTranslationBulletPointsMutation = gql`
+  mutation deleteProductTranslationBulletPoints($ids: [GlobalID!]!) {
+    deleteProductTranslationBulletPoints(data: {ids: $ids}) {
+      id
+    }
+  }
+`;

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -499,3 +499,17 @@ export const getBillOfMaterialQuery = gql`
   }
 `;
 
+
+export const productTranslationBulletPointsQuery = gql`
+  query ProductTranslationBulletPoints($filter: ProductTranslationBulletPointFilter) {
+    productTranslationBulletPoints(filters: $filter, order: { sortOrder: ASC }) {
+      edges {
+        node {
+          id
+          text
+          sortOrder
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- add bullet point queries and mutations
- provide ProductTranslationBulletPoints component for editing
- show bullet point list in preview panel
- integrate new component in product content view
- update English locale with a label

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859b9585274832e97b63eb1b24718ea

## Summary by Sourcery

Add support for editing and previewing product translation bullet points by extending GraphQL schema, introducing a dedicated Vue component, and integrating it into the product content form and preview.

New Features:
- Implement GraphQL queries and mutations for product translation bullet points (create, update, delete, batch operations)
- Add a ProductTranslationBulletPoints Vue component to create, edit, reorder, and delete translation bullet points
- Integrate the bullet points component into the product content form and extend the save workflow to persist bullet points
- Render bullet points in the product content preview panel

Documentation:
- Add English locale label for bullet points