### PR TITLE
Fix bullet point editing

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -214,7 +214,7 @@ const onMutationCompleted = async (response) => {
   }
   try {
     await bulletPointsRef.value?.save(translationId.value);
-    previewBulletPoints.value = bulletPointsRef.value?.bulletPoints || [];
+    // bullet points are emitted from the child component after saving
   } catch (e) { /* errors handled in component */ }
   Toast.success(t('products.translation.successfullyUpdated'));
   initialForm.value = {...form};

--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -38,7 +38,8 @@ const fetchPoints = async () => {
       variables: { filter: { productTranslation: { id: { exact: props.translationId } } } },
       fetchPolicy: 'network-only',
     });
-    bulletPoints.value = data?.productTranslationBulletPoints.edges.map((e: any) => e.node) || [];
+    bulletPoints.value =
+      data?.productTranslationBulletPoints.edges.map((e: any) => ({ ...e.node })) || [];
     initialBulletPoints.value = JSON.parse(JSON.stringify(bulletPoints.value));
     emit('update:bulletPoints', bulletPoints.value);
   } catch (e) {
@@ -48,7 +49,6 @@ const fetchPoints = async () => {
 
 onMounted(fetchPoints);
 watch(() => props.translationId, fetchPoints);
-watch(bulletPoints, (val) => emit('update:bulletPoints', val), { deep: true });
 
 const addBulletPoint = () => {
   if (bulletPoints.value.length >= 10) return;


### PR DESCRIPTION
## Summary
- fix read-only props by cloning bullet point nodes
- remove live bullet point preview updates
- rely on emitted update after save for preview

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859cb893bc0832e9a05aec4232a454d

## Summary by Sourcery

Fix bullet point editing by cloning nodes to avoid read-only prop errors and deferring preview updates until after save.

Bug Fixes:
- Clone bullet point objects when fetching to prevent modifying read-only props

Enhancements:
- Remove deep watch for live bullet point preview updates
- Rely on the emitted update event after saving for preview synchronization