### PR TITLE
Restrict product content fields by sales channel

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
@@ -30,6 +30,14 @@ const props = defineProps({
     type: Array as PropType<any[]>,
     required: true,
   },
+  showShortDescription: {
+    type: Boolean,
+    default: true,
+  },
+  showUrlKey: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const emit = defineEmits<{
@@ -40,7 +48,7 @@ const emit = defineEmits<{
 
 <template>
   <Flex vertical>
-    <FlexCell>
+    <FlexCell v-if="showShortDescription">
       <Flex  class="gap-4">
         <FlexCell center>
           <Label semi-bold>{{ t('shared.labels.name') }}</Label>
@@ -63,7 +71,7 @@ const emit = defineEmits<{
       </div>
     </FlexCell>
 
-    <FlexCell>
+    <FlexCell v-if="showShortDescription">
       <Flex class="gap-4">
         <FlexCell center>
           <Label semi-bold>{{ t('shared.labels.shortDescription') }}</Label>
@@ -130,7 +138,7 @@ const emit = defineEmits<{
         <p class="text-red-500" v-if="fieldErrors['description']">{{ fieldErrors['description'] }}</p>
       </div>
     </FlexCell>
-    <FlexCell>
+    <FlexCell v-if="showUrlKey">
       <Label semi-bold>{{ t('products.translation.labels.urlKey') }}</Label>
       <TextInput v-model="form.urlKey" :placeholder="t('products.translation.placeholders.urlKey')" class="mt-2 w-full"/>
       <div class="mb-1 text-sm leading-6">

--- a/src/core/products/products/product-show/containers/tabs/content/contentFieldRules.ts
+++ b/src/core/products/products/product-show/containers/tabs/content/contentFieldRules.ts
@@ -1,0 +1,30 @@
+import { IntegrationTypes } from '../../../../../../integrations/integrations/integrations';
+
+export interface ContentFieldRules {
+  name: boolean;
+  shortDescription: boolean;
+  description: boolean;
+  urlKey: boolean;
+  bulletPoints: boolean;
+}
+
+const baseRules: ContentFieldRules = {
+  name: true,
+  shortDescription: true,
+  description: true,
+  urlKey: true,
+  bulletPoints: false,
+};
+
+export const FIELD_RULES: Record<string, ContentFieldRules> = {
+  [IntegrationTypes.Magento]: { ...baseRules },
+  [IntegrationTypes.Woocommerce]: { ...baseRules },
+  [IntegrationTypes.Shopify]: { ...baseRules, shortDescription: false },
+  [IntegrationTypes.Amazon]: { ...baseRules, shortDescription: false, urlKey: false, bulletPoints: true },
+  default: { ...baseRules },
+};
+
+export function getContentFieldRules(type?: string): ContentFieldRules {
+  if (!type) return FIELD_RULES.default;
+  return FIELD_RULES[type] || FIELD_RULES.default;
+}


### PR DESCRIPTION
## Summary
- control which product content fields are editable per integration
- hide/show fields in the form based on selected channel
- adjust preview to swap bullet points with short description for Amazon

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d4b97ffc832e952c4f291f9da0af