### PR TITLE
Add issues info modal

### DIFF
--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -330,6 +330,7 @@ export interface SalesChannelViewAssign {
   id: string;
   remoteUrl: string;
   remoteProductPercentage: number;
+  formattedIssues?: { message?: string | null; severity?: string | null }[];
   product: SalesChannelViewAssignProduct;
   salesChannelView: SalesChannelView;
   remoteProduct: RemoteProduct;

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
@@ -8,16 +8,20 @@ import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { ApolloAlertMutation } from "../../../../../../../../../shared/components/molecules/apollo-alert-mutation";
 import { deleteSalesChannelViewAssignMutation } from "../../../../../../../../../shared/api/mutations/salesChannels.js";
 import { Product } from "../../../../../../configs";
+import type { SalesChannelViewAssign } from "../../../../../../configs";
 import { AssignProgressBar } from "../../../../../../../../../shared/components/molecules/assign-progress-bar";
 import { resyncSalesChannelViewAssignMutation } from "../../../../../../../../../shared/api/mutations/salesChannels.js";
 import { displayApolloError } from "../../../../../../../../../shared/utils";
 import { Toast} from "../../../../../../../../../shared/modules/toast";
 import { LogsInfoModal } from "../logs-info-modal";
+import { IssuesInfoModal } from "../issues-info-modal";
 
 const { t } = useI18n();
 const props = defineProps<{ product: Product }>();
 const infoId = ref(null);
 const showInfoModal = ref(false);
+const issuesList = ref<SalesChannelViewAssign['formattedIssues'] | null>(null);
+const showIssuesModal = ref(false);
 
 const onResyncError = (error) => {
   displayApolloError(error);
@@ -32,9 +36,19 @@ const setInfoId = (id) => {
   showInfoModal.value = true;
 }
 
+const setIssues = (issues) => {
+  issuesList.value = issues || [];
+  showIssuesModal.value = true;
+}
+
 const modalColsed = () => {
   infoId.value = null;
   showInfoModal.value = false;
+}
+
+const issuesModalClosed = () => {
+  issuesList.value = null;
+  showIssuesModal.value = false;
 }
 
 </script>
@@ -63,6 +77,10 @@ const modalColsed = () => {
             </td>
             <td>
               <div class="flex gap-4 items-center justify-end">
+
+                <Button v-if="item.formattedIssues?.length" @click="setIssues(item.formattedIssues)">
+                  <Icon name="exclamation-triangle" size="lg" class="text-red-500" />
+                </Button>
 
                 <Button :disabled="!item.remoteProduct?.id" @click="setInfoId(item.remoteProduct?.id)">
                   <Icon name="clipboard-list" size="lg" class="text-gray-500" />
@@ -104,5 +122,6 @@ const modalColsed = () => {
         </table>
       </div>
       <LogsInfoModal v-model="showInfoModal" :id="infoId" @modal-closed="modalColsed()" />
+      <IssuesInfoModal v-model="showIssuesModal" :issues="issuesList" @modal-closed="issuesModalClosed()" />
     </div>
 </template>

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/issues-info-modal/IssuesInfoModal.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/issues-info-modal/IssuesInfoModal.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { Ref, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Card } from "../../../../../../../../../shared/components/atoms/card";
+import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Modal } from "../../../../../../../../../shared/components/atoms/modal";
+import { Loader } from "../../../../../../../../../shared/components/atoms/loader";
+
+export interface FormattedIssue {
+  message?: string | null;
+  severity?: string | null;
+}
+
+const props = defineProps<{ modelValue: boolean; issues?: FormattedIssue[] | null }>();
+const emit = defineEmits(['modal-closed']);
+const localShowModal = ref(props.modelValue);
+const issues: Ref<FormattedIssue[]> = ref(props.issues ?? []);
+const { t } = useI18n();
+
+watch(() => props.modelValue, (newVal) => {
+  localShowModal.value = newVal;
+  if (newVal && props.issues) {
+    issues.value = props.issues;
+  }
+});
+
+const loading = ref(false);
+
+const closeModal = () => {
+  localShowModal.value = false;
+  emit('modal-closed');
+};
+</script>
+
+<template>
+  <div>
+    <Modal v-model="localShowModal" @closed="closeModal">
+      <Loader :loading="loading" />
+      <Card class="modal-content w-[90%]">
+        <div class="mb-6">
+          <h3 class="text-xl font-semibold leading-7 text-gray-900">
+            {{ t('integrations.salesChannel.modal.issues.title') }}
+          </h3>
+        </div>
+        <ul class="space-y-2 max-h-96 overflow-y-auto">
+          <li v-for="(issue, index) in issues" :key="index" class="flex justify-between">
+            <span class="break-words">{{ issue.message }}</span>
+            <span class="font-semibold capitalize ml-4">{{ issue.severity }}</span>
+          </li>
+        </ul>
+        <hr />
+        <div class="flex justify-end gap-4 mt-4">
+          <Button class="btn btn-outline-dark" @click="closeModal">{{ t('shared.button.cancel') }}</Button>
+        </div>
+      </Card>
+    </Modal>
+  </div>
+</template>

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/issues-info-modal/index.ts
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/issues-info-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as IssuesInfoModal } from "./IssuesInfoModal.vue";

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2396,6 +2396,9 @@
       "modal": {
         "logs": {
           "title": "Logs"
+        },
+        "issues": {
+          "title": "Issues"
         }
       }
     },

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -329,7 +329,6 @@ export const remoteLogsQuery = gql`
   }
 `;
 
-
 export const getSalesChannelViewAssignQuery = gql`
   query getSalesChannelViewAssign($id: GlobalID!) {
     salesChannelViewAssign(id: $id) {

--- a/src/shared/api/subscriptions/products.js
+++ b/src/shared/api/subscriptions/products.js
@@ -65,6 +65,10 @@ export const productSubscription = gql`
           id
           remoteUrl
           remoteProductPercentage
+          formattedIssues {
+            message
+            severity
+          }
           product {
             id
             name


### PR DESCRIPTION
## Summary
- show list of remote product issues
- fetch formatted issues via subscription
- add IssuesInfoModal component
- add button and modal in Website assigns list
- add translation for Issues modal
- attach formatted issues to assigns

## Testing
- `npm run build` *(fails: vue-tsc not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ccc051c832ea3ee3af9d911a341

## Summary by Sourcery

Enable viewing of remote product issues by fetching formatted issues via GraphQL subscription and presenting them in a new modal.

New Features:
- Introduce IssuesInfoModal component to display a list of formatted remote issues
- Extend productSubscription to include formattedIssues and attach them to SalesChannelViewAssign
- Add an issues button in WebsitesList to open the IssuesInfoModal for each assign

Enhancements:
- Add formattedIssues typing to SalesChannelViewAssign config
- Export IssuesInfoModal via index file