### PR TITLE
Truncate product name in integration list

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/products/Products.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/products/Products.vue
@@ -14,7 +14,7 @@ import {
   deleteSalesChannelViewAssignMutation,
   resyncSalesChannelViewAssignMutation
 } from "../../../../../../shared/api/mutations/salesChannels.js";
-import {displayApolloError} from "../../../../../../shared/utils";
+import {displayApolloError, shortenText} from "../../../../../../shared/utils";
 import {Toast} from "../../../../../../shared/modules/toast";
 import { LogsInfoModal } from "../../../../../products/products/product-show/containers/tabs/websites/containers/logs-info-modal";
 import {Badge} from "../../../../../../shared/components/atoms/badge";
@@ -111,8 +111,8 @@ const getStatusText = (item) => {
                     <tbody class="divide-y divide-gray-200 bg-white">
                     <tr v-for="item in data.salesChannelViewAssigns.edges" :key="item.node.id">
                       <td>
-                        <Link :path="{name: 'products.products.show', params: { id: item.node.product.id}, query: {tab: 'websites'}}">
-                          {{ item.node.product.name }}
+                        <Link :path="{name: 'products.products.show', params: { id: item.node.product.id}, query: {tab: 'websites'}}" :title="item.node.product.name">
+                          {{ shortenText(item.node.product.name, 64) }}
                         </Link>
                       </td>
                       <td>


### PR DESCRIPTION
## Summary
- import `shortenText` in integration products list
- display truncated product name with title attribute

## Testing
- `npm install --ignore-scripts --silent` *(fails: method is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68625e057d18832ebf4b9eab0b8bb699

## Summary by Sourcery

Enhancements:
- Shorten product names to 64 characters in the integration list and add the full name as a tooltip