### PR TITLE
Add breadcrumb label for mapping pages

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -113,7 +113,8 @@ const handleFormUpdate = (form) => {
       <Breadcrumbs
         :links="[
           { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
-          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'properties'} }, name: t('integrations.show.amazon.title') }
+          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'properties'} }, name: t('integrations.show.amazon.title') },
+          { name: t('integrations.show.mapProperty') }
         ]" />
     </template>
     <template v-slot:content>

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -169,7 +169,8 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
       <Breadcrumbs
         :links="[
           { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
-          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'propertySelectValues'} }, name: t('integrations.show.amazon.title') }
+          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'propertySelectValues'} }, name: t('integrations.show.amazon.title') },
+          { name: t('integrations.show.mapSelectValue') }
         ]" />
     </template>
     <template v-slot:content>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -148,7 +148,8 @@ const handleFormUpdate = (form) => {
       <Breadcrumbs
         :links="[
           { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
-          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'productRules'} }, name: t('integrations.show.amazon.title') }
+          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'productRules'} }, name: t('integrations.show.amazon.title') },
+          { name: t('integrations.show.mapProductType') }
         ]" />
     </template>
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2220,7 +2220,10 @@
         "allMappedSuccess": "You mapped all the values"
       },
       "generateProperty": "Generate Property",
-      "generateProductType": "Generate Product Type"
+      "generateProductType": "Generate Product Type",
+      "mapProperty": "Map Property",
+      "mapProductType": "Map Product Type",
+      "mapSelectValue": "Map Select Value"
     },
     "create": {
       "title": "Create Integration",


### PR DESCRIPTION
## Summary
- add translation keys for mapping breadcrumbs
- update property, product type and select value edit views to show current page name in breadcrumbs

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625e96b6c8832ea8b12a2d3375258e