### PR TITLE
Add shortenText in product lists

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/alias-parents/containers/alias-parents-list/AliasParentsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/alias-parents/containers/alias-parents-list/AliasParentsList.vue
@@ -6,6 +6,7 @@ import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { Badge } from "../../../../../../../../../shared/components/atoms/badge";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { getProductTypeBadgeMap, getInspectorStatusBadgeMap } from "../../../../../../configs";
+import { shortenText } from "../../../../../../../../../shared/utils";
 
 const props = defineProps<{ products: ProductWithAliasFields[] }>();
 const { t } = useI18n();
@@ -41,7 +42,7 @@ const aliasProducts = computed(() => props.products ?? []);
                   v-else
                   class="w-8 h-8 rounded-md bg-gray-200 flex justify-center items-center"
                 ></div>
-                <span>{{ alias.name }}</span>
+                <span :title="alias.name">{{ shortenText(alias.name, 64) }}</span>
               </div>
             </Link>
           </td>

--- a/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
@@ -8,6 +8,7 @@ import { configurableVariationsQuery, bundleVariationsQuery } from "../../../../
 import apolloClient from "../../../../../../../../../../apollo-client";
 import { Loader } from "../../../../../../../../../shared/components/atoms/loader";
 import { Badge } from "../../../../../../../../../shared/components/atoms/badge";
+import { shortenText } from "../../../../../../../../../shared/utils";
 
 const { t } = useI18n();
 const props = defineProps<{ product: Product }>();
@@ -94,7 +95,7 @@ onMounted(async () => {
                     v-else
                     class="w-8 h-8 rounded-md bg-gray-200 flex justify-center items-center"
                   ></div>
-                  <span>{{ parent.name }}</span>
+                  <span :title="parent.name">{{ shortenText(parent.name, 64) }}</span>
                 </div>
               </Link>
             </td>

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
@@ -18,6 +18,7 @@ import {
 } from "../../../../../../../../../shared/api/mutations/products.js";
 import {Image} from "../../../../../../../../../shared/components/atoms/image";
 import {TextInput} from "../../../../../../../../../shared/components/atoms/input-text";
+import { shortenText } from "../../../../../../../../../shared/utils";
 import {ref} from "vue";
 import debounce from 'lodash.debounce'
 import apolloClient from "../../../../../../../../../../apollo-client";
@@ -156,7 +157,9 @@ const handleQuantityChanged = debounce(async (event, id) => {
                             <div v-else class="w-8 h-8 overflow-hidden rounded-md bg-gray-200 flex justify-center items-center">
                           </div>
                         </FlexCell>
-                        <FlexCell center>{{ item.node.variation.name }}</FlexCell>
+                        <FlexCell center :title="item.node.variation.name">
+                          {{ shortenText(item.node.variation.name, 64) }}
+                        </FlexCell>
                       </Flex>
                     </Link>
                   </td>

--- a/src/shared/components/organisms/variations-adder/VariationsAdder.vue
+++ b/src/shared/components/organisms/variations-adder/VariationsAdder.vue
@@ -16,6 +16,7 @@ import {Link} from "../../atoms/link";
 import {Image} from "../../atoms/image";
 import {getInspectorStatusBadgeMap} from "../../../../core/products/products/configs";
 import {Label} from "../../atoms/label";
+import { shortenText } from "../../../utils";
 
 const { t } = useI18n();
 
@@ -290,7 +291,9 @@ onMounted(fetchData);
                         <div v-else class="w-8 h-8 overflow-hidden rounded-md bg-gray-200 flex justify-center items-center">
                       </div>
                     </FlexCell>
-                    <FlexCell center>{{ variation.name }}</FlexCell>
+                    <FlexCell center :title="variation.name">
+                      {{ shortenText(variation.name, 64) }}
+                    </FlexCell>
                   </Flex>
                 </FlexCell>
               </Flex>
@@ -342,7 +345,9 @@ onMounted(fetchData);
                         <div v-else class="w-8 h-8 overflow-hidden rounded-md bg-gray-200 flex justify-center items-center">
                       </div>
                     </FlexCell>
-                    <FlexCell center>{{ item.name }}</FlexCell>
+                    <FlexCell center :title="item.name">
+                      {{ shortenText(item.name, 64) }}
+                    </FlexCell>
                   </Flex>
                 </FlexCell>
               </Flex>


### PR DESCRIPTION
## Summary
- trim long product names in variation, parent, and alias parent lists
- shorten text in variations adder component

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d5fdf698832eabaf198af28a5c18

## Summary by Sourcery

Enhancements:
- Trim long product and variation names to 64 characters using shortenText and show the full name via tooltip in various list components