### PR TITLE
Add back button component

### DIFF
--- a/src/shared/components/molecules/back-button/BackButton.vue
+++ b/src/shared/components/molecules/back-button/BackButton.vue
@@ -1,0 +1,69 @@
+<script lang="ts" setup>
+import { useRouter } from 'vue-router';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Icon } from '../../atoms/icon';
+
+const { t } = useI18n();
+const router = useRouter();
+const navigating = ref(false);
+
+const goBack = async () => {
+  const getBasePath = (url?: string | null) => {
+    if (!url) return null;
+    return url.split('?')[0];
+  };
+
+  const initialRoute = getBasePath(router.options.history.state.current as string | undefined);
+  let backRoute = getBasePath(router.options.history.state.back as string | undefined);
+
+  if (backRoute === null) {
+    router.back();
+  } else {
+    // keep going back until the route base path changes
+    while (true) {
+      navigating.value = true;
+      const trimmedBack = getBasePath(backRoute);
+
+      if (trimmedBack !== initialRoute) {
+        router.back();
+        navigating.value = false;
+        break;
+      }
+
+      router.back();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      backRoute = getBasePath(router.options.history.state.back as string | undefined);
+      navigating.value = false;
+      if (backRoute === null) break;
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="relative">
+    <button type="button" class="group block" @click="goBack">
+      <Icon name="chevron-left" class="w-8 h-8 rounded-full object-cover saturate-50 group-hover:saturate-100 text-gray-600 hover:text-indigo-600" />
+      <span class="sr-only">{{ t('shared.button.back') }}</span>
+    </button>
+    <div
+      v-show="navigating"
+      class="overlay w-full bg-black bg-opacity-30 p-2 text-white"
+    ></div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/src/shared/components/molecules/back-button/index.ts
+++ b/src/shared/components/molecules/back-button/index.ts
@@ -1,0 +1,1 @@
+export { default as BackButton } from './BackButton.vue';

--- a/src/shared/components/organisms/nav-bar/HeaderBar.vue
+++ b/src/shared/components/organisms/nav-bar/HeaderBar.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import { Icon } from "../../atoms/icon";
 import { Dropdown } from "../../molecules/dropdown";
+import { BackButton } from "../../molecules/back-button";
 import LanguageDropdown from "../../molecules/languages-dropdown/LanguageDropdown.vue";
 import UserProfileDropdown from "../user-profile-dropdown/UserProfileDropdown.vue";
 import GeneralSearch from "../general-search/GeneralSearch.vue";
@@ -93,6 +94,7 @@ const allowCreateDropdown = () => {
                           </button>
                         </template>
                       </Dropdown>
+                  <BackButton />
                   <UserProfileDropdown />
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- create BackButton component to navigate to the previous unique route
- export BackButton from a new module
- place BackButton in the header bar next to the profile dropdown

## Testing
- `npm run build` *(fails: Property errors in GeneralListing.vue)*

------
https://chatgpt.com/codex/tasks/task_e_6862d7562728832ea8fc31f3a76420b8

## Summary by Sourcery

Add a reusable BackButton component to navigate to the previous unique route and integrate it into the header bar.

New Features:
- Introduce BackButton component that navigates back to the first different base path in history
- Export BackButton from a new molecules/back-button module
- Embed BackButton alongside the user profile dropdown in the HeaderBar