### PR TITLE
Add generate button for Amazon select values

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -19,6 +19,7 @@ import { selectValueOnTheFlyConfig } from "../../../../../../../../properties/pr
 import apolloClient from "../../../../../../../../../../apollo-client";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import { Link } from "../../../../../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../../../../../shared/components/atoms/button";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -91,6 +92,15 @@ const localPropertyEditPath = computed(() =>
     : null
 );
 
+const generateValuePath = computed(() =>
+  localPropertyId.value
+    ? {
+        name: 'properties.values.create',
+        query: { propertyId: localPropertyId.value, value: form.remoteName },
+      }
+    : null
+);
+
 onMounted(async () => {
   const { data } = await apolloClient.query({
     query: getAmazonPropertySelectValueQuery,
@@ -132,8 +142,7 @@ onMounted(async () => {
         isEdge: true,
         multiple: false,
         filterable: true,
-        formMapIdentifier: 'id',
-        createOnFlyConfig: selectValueOnTheFlyConfig(t, localPropertyId.value, form.remoteName)
+        formMapIdentifier: 'id'
       }
     }
   }
@@ -290,6 +299,13 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                     </FlexCell>
                     <FlexCell>
                       <p class="mt-1 text-sm leading-6 text-gray-400">{{ t('integrations.show.propertySelectValues.help.selectValue') }}</p>
+                    </FlexCell>
+                    <FlexCell>
+                      <Link v-if="generateValuePath" :path="generateValuePath">
+                        <Button type="button" class="btn btn-info">
+                          {{ t('integrations.show.generatePropertySelectValue') }}
+                        </Button>
+                      </Link>
                     </FlexCell>
                   </Flex>
                 </div>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2225,6 +2225,7 @@
       },
       "generateProperty": "Generate Property",
       "generateProductType": "Generate Product Type",
+      "generatePropertySelectValue": "Generate Select Value",
       "mapProperty": "Map Property",
       "mapProductType": "Map Product Type",
       "mapSelectValue": "Map Select Value",


### PR DESCRIPTION
## Summary
- let user create property select values via a Generate button
- wire up route to the property value creation page
- translate new label for Generate button

## Testing
- `npm install --ignore-scripts`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862dafadc60832ea90850da6659927f