### PR TITLE
Add redirect for Amazon select value creation

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -96,7 +96,11 @@ const generateValuePath = computed(() =>
   localPropertyId.value
     ? {
         name: 'properties.values.create',
-        query: { propertyId: localPropertyId.value, value: form.remoteName },
+        query: {
+          propertyId: localPropertyId.value,
+          amazonSelectValueId: `${valueId.value}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`,
+          value: form.remoteName,
+        },
       }
     : null
 );

--- a/src/core/properties/property-select-values/configs.ts
+++ b/src/core/properties/property-select-values/configs.ts
@@ -29,13 +29,14 @@ export const baseFormConfigConstructor = (
     addImage: boolean = true,
     redirectToRules: boolean = false,
     amazonRuleId: string | null = null,
+    amazonSelectValueId: string | null = null,
 ): FormConfig => ({
     cols: 1,
     type: type,
     mutation: mutation,
     mutationKey: mutationKey,
-    submitUrl: getSubmitUrl(redirectToRules, propertyId, amazonRuleId),
-    addSubmitAndContinue: !amazonRuleId,
+    submitUrl: getSubmitUrl(redirectToRules, propertyId, amazonRuleId, amazonSelectValueId),
+    addSubmitAndContinue: !amazonRuleId && !amazonSelectValueId,
     submitAndContinueUrl: {name: 'properties.values.edit'},
     deleteMutation: deletePropertySelectValueMutation,
     ...(redirectToRules && amazonRuleId ? { addIdAsQueryParamInSubmitUrl: true } : {}),
@@ -60,7 +61,22 @@ const getSubmitUrl = (
     redirectToRules: boolean,
     propertyId: string | null,
     amazonRuleId: string | null,
+    amazonSelectValueId: string | null,
 ) => {
+    if (amazonSelectValueId) {
+        const [selectValueId, integrationId, salesChannelId, wizard] = amazonSelectValueId.split('__');
+        const url: any = { name: 'integrations.amazonPropertySelectValues.edit', params: { type: 'amazon', id: selectValueId } };
+        if (integrationId) {
+            url.query = { integrationId } as any;
+            if (salesChannelId) {
+                url.query.salesChannelId = salesChannelId;
+            }
+            if (wizard) {
+                url.query.wizard = wizard;
+            }
+        }
+        return url;
+    }
     if (redirectToRules && amazonRuleId) {
         const [ruleId, integrationId, salesChannelId, wizard] = amazonRuleId.split('__');
         const url: any = { name: 'integrations.amazonProductTypes.edit', params: { type: 'amazon', id: ruleId } };

--- a/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
+++ b/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
@@ -21,6 +21,7 @@ onMounted(async () => {
   const propertyId = route.query.propertyId ? route.query.propertyId.toString() : null;
   const isRule = route.query.isRule ? route.query.isRule.toString() : null;
   const amazonRuleId = route.query.amazonRuleId ? route.query.amazonRuleId.toString() : null;
+  const amazonSelectValueId = route.query.amazonSelectValueId ? route.query.amazonSelectValueId.toString() : null;
 
   if (propertyId) {
     const { data } = await apolloClient.query({
@@ -40,7 +41,8 @@ onMounted(async () => {
     propertyId,
     addImage,
     isRule !== null,
-    amazonRuleId
+    amazonRuleId,
+    amazonSelectValueId
   );
 
   if (defaultValue && formConfig.value) {


### PR DESCRIPTION
## Summary
- generate correct link to create a select value from Amazon mapping
- pass redirect data via `amazonSelectValueId`
- support redirect in select value create form config

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f4c391cc832ebcbdaa5a645fafc9

## Summary by Sourcery

Enable redirect flow for creating Amazon-derived select values by capturing amazonSelectValueId in the form config and routing logic

New Features:
- Add redirect support for Amazon select value creation by introducing amazonSelectValueId parameter
- Generate correct edit link for newly created Amazon-managed select values

Enhancements:
- Extend base form configuration to accept amazonSelectValueId and adjust submit URLs and continuation logic
- Enhance getSubmitUrl to route to the Amazon select value edit page when amazonSelectValueId is provided
- Propagate amazonSelectValueId through route queries in the select value selector and creation controllers