### PR TITLE
Add hover text for badge colors

### DIFF
--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -74,12 +74,13 @@ export const getInspectorStatusOptions = (t) => [
   { name: '🔴', code: InspectorStatus.RED },
 ];
 
-export const getInspectorStatusBadgeMap = (): Record<string, Badge> => {
-  const defaultBadge: Badge = { text: '🔴', color: 'none' };
+export const getInspectorStatusBadgeMap = (t?: Function): Record<string, Badge> => {
+  const translate = (key: string) => (t ? t(key) : key);
+  const defaultBadge: Badge = { text: '🔴', color: 'none', hoverText: translate('shared.colors.red') };
 
   const badgeMap: Record<InspectorStatusType, Badge> = {
-    [InspectorStatus.GREEN]: { text: '🟢', color: 'none' },
-    [InspectorStatus.ORANGE]: { text: '🟠', color: 'none' },
+    [InspectorStatus.GREEN]: { text: '🟢', color: 'none', hoverText: translate('shared.colors.green') },
+    [InspectorStatus.ORANGE]: { text: '🟠', color: 'none', hoverText: translate('shared.colors.orange') },
     [InspectorStatus.RED]: defaultBadge,
   };
 
@@ -318,7 +319,7 @@ export const listingConfigConstructor = (t: Function, isMainPage: boolean = fals
     {
       name: 'inspectorStatus',
       type: FieldType.Badge,
-      badgeMap: getInspectorStatusBadgeMap(),
+      badgeMap: getInspectorStatusBadgeMap(t),
     },
     {
       type: FieldType.Badge,

--- a/src/core/products/products/product-show/containers/tabs/alias-parents/containers/alias-parents-list/AliasParentsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/alias-parents/containers/alias-parents-list/AliasParentsList.vue
@@ -60,7 +60,7 @@ const aliasProducts = computed(() => props.products ?? []);
             <Icon v-else name="times-circle" class="text-red-500" />
           </td>
           <td>
-            {{ getInspectorStatusBadgeMap()[alias.inspectorStatus]?.text || '-' }}
+            {{ getInspectorStatusBadgeMap(t)[alias.inspectorStatus]?.text || '-' }}
           </td>
         </tr>
       </tbody>

--- a/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
@@ -110,7 +110,7 @@ onMounted(async () => {
               <Icon v-else name="times-circle" class="text-red-500" />
             </td>
             <td>
-              {{ getInspectorStatusBadgeMap()[parent.inspectorStatus]?.text || '-' }}
+              {{ getInspectorStatusBadgeMap(t)[parent.inspectorStatus]?.text || '-' }}
             </td>
           </tr>
         </tbody>

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
@@ -168,7 +168,7 @@ const handleQuantityChanged = debounce(async (event, id) => {
                     <Icon v-else name="times-circle" class="ml-2 text-red-500" />
                   </td>
                   <td>
-                    {{ getInspectorStatusBadgeMap()[item.node.variation.inspectorStatus].text }}
+                    {{ getInspectorStatusBadgeMap(t)[item.node.variation.inspectorStatus].text }}
                   </td>
                   <td v-if="product.type != ProductType.Configurable">
                     <TextInput v-model="localQuantities[item.node.id]" @update:model-value="handleQuantityChanged($event, item.node.id)" float />

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -3,7 +3,12 @@
     "button": {
       "login": "Anmelden",
       "register": "Registrieren",
-      "recover": "Wiederherstellen"
+    "recover": "Wiederherstellen"
+    },
+    "colors": {
+      "red": "Rot",
+      "green": "Grün",
+      "orange": "Orange"
     }
   },
   "auth": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -311,6 +311,11 @@
       "editAll": "Edit all",
       "change": "Change"
     },
+    "colors": {
+      "red": "Red",
+      "green": "Green",
+      "orange": "Orange"
+    },
     "labels": {
       "createdAt": "Created At",
       "updatedAt": "Updated At",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -3,7 +3,12 @@
     "button": {
       "login": "Se connecter",
       "register": "S'inscrire",
-      "recover": "Récupérer"
+    "recover": "Récupérer"
+    },
+    "colors": {
+      "red": "Rouge",
+      "green": "Vert",
+      "orange": "Orange"
     }
   },
   "auth": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -179,6 +179,11 @@
       "fix": "Fixen",
       "downloadConfirmation": ""
     },
+    "colors": {
+      "red": "Rood",
+      "green": "Groen",
+      "orange": "Oranje"
+    },
     "labels": {
       "createdAt": "Gecreëerd op",
       "updatedAt": "Gewijzigd op",

--- a/src/shared/components/atoms/badge/Badge.vue
+++ b/src/shared/components/atoms/badge/Badge.vue
@@ -5,6 +5,7 @@ import { computed } from 'vue';
 const props = defineProps<{
   text: string;
   color: string;
+  hoverText?: string;
 }>();
 
 
@@ -38,5 +39,5 @@ const badgeClass = computed(() => {
 </script>
 
 <template>
-  <span class="whitespace-nowrap" :class="badgeClass">{{ text }}</span>
+  <span class="whitespace-nowrap" :class="badgeClass" :title="hoverText">{{ text }}</span>
 </template>

--- a/src/shared/components/organisms/general-show/containers/field-badge/FieldBadge.vue
+++ b/src/shared/components/organisms/general-show/containers/field-badge/FieldBadge.vue
@@ -18,7 +18,8 @@ function getBadgeData(key: string | number) {
     <Badge
       v-if="modelValue && getBadgeData(modelValue)"
       :text="getBadgeData(modelValue).text"
-      :color="getBadgeData(modelValue).color" />
+      :color="getBadgeData(modelValue).color"
+      :hover-text="getBadgeData(modelValue).hoverText" />
     <span v-else>{{ modelValue }}</span>
   </div>
 </template>

--- a/src/shared/components/organisms/general-show/showConfig.ts
+++ b/src/shared/components/organisms/general-show/showConfig.ts
@@ -76,6 +76,7 @@ export interface ArrayField extends ShowBaseField {
 export interface Badge {
   text: string;
   color: string;
+  hoverText?: string;
 }
 
 export interface BadgeField extends ShowBaseField {

--- a/src/shared/components/organisms/variations-adder/VariationsAdder.vue
+++ b/src/shared/components/organisms/variations-adder/VariationsAdder.vue
@@ -300,7 +300,7 @@ onMounted(fetchData);
               <Icon v-else name="times-circle" class="ml-2 text-red-500" />
             </td>
             <td>
-              {{ getInspectorStatusBadgeMap()[variation.inspectorStatus].text }}
+              {{ getInspectorStatusBadgeMap(t)[variation.inspectorStatus].text }}
             </td>
           </tr>
         </tbody>
@@ -352,7 +352,7 @@ onMounted(fetchData);
               <Icon v-else name="times-circle" class="ml-2 text-red-500" />
             </td>
             <td>
-              {{ getInspectorStatusBadgeMap()[item.inspectorStatus].text }}
+              {{ getInspectorStatusBadgeMap(t)[item.inspectorStatus].text }}
             </td>
             <td v-if="hasQty()">{{ item.quantity }}</td>
           </tr>


### PR DESCRIPTION
## Summary
- add translation keys for color names
- translate inspector status badge hover text
- pass translator to inspector status badge map
- use translated badge hover text in various lists

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862dbd2c71c832ea110ac79bb7c17ef

## Summary by Sourcery

Enable localized hover text on status badges by adding hoverText support, defining translation keys for color names, and passing the translator through badge map and consuming components.

New Features:
- Introduce hoverText property to Badge component for displaying localized color names on hover.

Enhancements:
- Add translation keys for badge color names and wire them into locale files.
- Inject translator into getInspectorStatusBadgeMap to supply localized hoverText for each status.
- Update all consumers of getInspectorStatusBadgeMap to pass the translation function.
- Extend Badge.vue, FieldBadge.vue, and related interfaces to accept and render hoverText.