### PR TITLE
Add sales channel type to AI content generator

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
@@ -38,6 +38,10 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  salesChannelType: {
+    type: String as PropType<string | undefined>,
+    default: undefined,
+  },
 });
 
 const emit = defineEmits<{
@@ -81,6 +85,7 @@ const emit = defineEmits<{
               :productId="productId"
               :languageCode="currentLanguage"
               contentAiGenerateType="SHORT_DESCRIPTION"
+              :sales-channel-type="salesChannelType"
               @generated="val => emit('shortDescription', val)"
             />
         </FlexCell>
@@ -115,6 +120,7 @@ const emit = defineEmits<{
               :productId="productId"
               :languageCode="currentLanguage"
               contentAiGenerateType="DESCRIPTION"
+              :sales-channel-type="salesChannelType"
               @generated="val => emit('description', val)"
             />
         </FlexCell>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -350,6 +350,7 @@ const shortDescriptionToolbarOptions = [
           :short-description-toolbar-options="shortDescriptionToolbarOptions"
           :show-short-description="fieldRules.shortDescription"
           :show-url-key="fieldRules.urlKey"
+          :sales-channel-type="currentChannelType"
           @description="handleGeneratedDescriptionContent"
           @shortDescription="handleGeneratedShortDescriptionContent"
         />

--- a/src/shared/components/organisms/ai-content-generator/AiContentGenerator.vue
+++ b/src/shared/components/organisms/ai-content-generator/AiContentGenerator.vue
@@ -8,6 +8,7 @@ interface Props {
   productId: string | number;
   languageCode: string | null;
   contentAiGenerateType: string;
+  salesChannelType?: string;
 }
 
 const { t } = useI18n();
@@ -18,13 +19,17 @@ const emit = defineEmits<{
 }>();
 
 
-const mutationVariables = computed(() => ({
-  data: {
+const mutationVariables = computed(() => {
+  const data: Record<string, any> = {
     id: props.productId,
     languageCode: props.languageCode,
     contentAiGenerateType: props.contentAiGenerateType,
-  },
-}));
+  };
+  if (props.salesChannelType && props.salesChannelType !== 'default') {
+    data.salesChannelType = props.salesChannelType;
+  }
+  return { data };
+});
 
 const steps = computed(() => [
   t("shared.components.organisms.aiContentGenerator.step1"),


### PR DESCRIPTION
## Summary
- support passing optional `salesChannelType` to `AiContentGenerator`
- forward `currentChannelType` through `ProductContentView` to `ProductContentForm`
- include `salesChannelType` in AI content generation mutation variables when provided

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862deb3c53c832e9e6a3efe57097bc4

## Summary by Sourcery

Add support for optional salesChannelType to the AI content generator and propagate it through the product content view and form into the generation mutation

New Features:
- Support an optional salesChannelType prop for AiContentGenerator and product content components

Enhancements:
- Forward currentChannelType as salesChannelType from ProductContentView to ProductContentForm
- Conditionally include salesChannelType in the AI content generation mutation payload when not default