### PR TITLE
Add AI bullet point generation

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -358,6 +358,8 @@ const shortDescriptionToolbarOptions = [
           v-if="fieldRules.bulletPoints"
           ref="bulletPointsRef"
           :translation-id="translationId"
+          :product-id="product.id"
+          :language-code="currentLanguage"
           @initial-bullet-points="previewBulletPoints = [...$event]"
         />
       </div>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -15,10 +15,11 @@ import {
 } from '../../../../../../../shared/api/mutations/products.js';
 import { processGraphQLErrors } from '../../../../../../../shared/utils';
 import { Toast } from '../../../../../../../shared/modules/toast';
+import { AiBulletPointsGenerator } from '../../../../../../../shared/components/organisms/ai-bullet-points-generator';
 
 const { t } = useI18n();
 
-const props = defineProps<{ translationId: string | null }>();
+const props = defineProps<{ translationId: string | null; productId: string | number; languageCode: string | null }>();
 const emit = defineEmits<{
   (e: 'update:bulletPoints', value: any[]): void;
   (e: 'initial-bullet-points', value: any[]): void;
@@ -27,6 +28,14 @@ const emit = defineEmits<{
 const bulletPoints = ref<any[]>([]);
 const initialBulletPoints = ref<any[]>([]);
 const fieldErrors = ref<Record<string, string>>({});
+
+const handleGeneratedBulletPoints = (list: any[]) => {
+  bulletPoints.value = list.map((bp, idx) => ({
+    id: null,
+    text: bp.text,
+    sortOrder: idx,
+  }));
+};
 
 const fetchPoints = async () => {
   if (!props.translationId) {
@@ -144,6 +153,13 @@ defineExpose({ save, fetchPoints });
             <Icon name="plus" />
           </Button>
         </div>
+      </FlexCell>
+      <FlexCell>
+        <AiBulletPointsGenerator
+          :product-id="props.productId"
+          :language-code="props.languageCode"
+          @generated="handleGeneratedBulletPoints"
+        />
       </FlexCell>
     </Flex>
     <VueDraggableNext v-model="bulletPoints" class="mt-2 space-y-2" @end="onReorder">

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -468,6 +468,13 @@
             "step2": "Performing translation",
             "step3": "Finalizing translation"
         },
+        "aiBulletPointsGenerator": {
+            "title": "Generating bullet points...",
+            "success": "Bullet points successfully generated. It cost {points} SilAI Credit(s).",
+            "step1": "Gathering product information",
+            "step2": "Generating bullet points",
+            "step3": "Finalizing"
+        },
         "remotePropertiesDetector": {
           "step1": "Analyzing remote attributes",
           "step2": "Filtering irrelevant properties",

--- a/src/shared/api/mutations/llm.js
+++ b/src/shared/api/mutations/llm.js
@@ -74,3 +74,24 @@ export const detectRemoteValidPropertiesMutation = gql`
     }
   }
 `;
+
+export const generateProductAiBulletPointsMutation = gql`
+  mutation generateProductAiBulletPointsMutation($data: ProductAiBulletPointsInput!) {
+    generateProductBulletPointsAi(instance: $data) {
+      ... on AiBulletPoints {
+        bulletPoints {
+          text
+        }
+        points
+      }
+      ... on OperationInfo {
+        messages {
+          kind
+          message
+          field
+          code
+        }
+      }
+    }
+  }
+`;

--- a/src/shared/components/organisms/ai-bullet-points-generator/AiBulletPointsGenerator.vue
+++ b/src/shared/components/organisms/ai-bullet-points-generator/AiBulletPointsGenerator.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { generateProductAiBulletPointsMutation } from '../../../api/mutations/llm.js';
+import { AiProcess } from "../ai-process";
+
+interface Props {
+  productId: string | number;
+  languageCode: string | null;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  (e: 'generated', bulletPoints: any[]): void;
+}>();
+
+const { t } = useI18n();
+
+const mutationVariables = computed(() => ({
+  data: {
+    id: props.productId,
+    languageCode: props.languageCode,
+  },
+}));
+
+const steps = computed(() => [
+  t('shared.components.organisms.aiBulletPointsGenerator.step1'),
+  t('shared.components.organisms.aiBulletPointsGenerator.step2'),
+  t('shared.components.organisms.aiBulletPointsGenerator.step3'),
+]);
+</script>
+
+<template>
+  <AiProcess
+    :variables="mutationVariables"
+    :mutation="generateProductAiBulletPointsMutation"
+    :steps="steps"
+    mutationKey="generateProductBulletPointsAi"
+    modal-title="shared.components.organisms.aiBulletPointsGenerator.title"
+    successToastKey="shared.components.organisms.aiBulletPointsGenerator.success"
+    @bullet-points-processed="points => emit('generated', points)"
+  />
+</template>

--- a/src/shared/components/organisms/ai-bullet-points-generator/index.ts
+++ b/src/shared/components/organisms/ai-bullet-points-generator/index.ts
@@ -1,0 +1,1 @@
+export { default as AiBulletPointsGenerator } from './AiBulletPointsGenerator.vue';

--- a/src/shared/components/organisms/ai-process/AiProcess.vue
+++ b/src/shared/components/organisms/ai-process/AiProcess.vue
@@ -27,6 +27,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'processed', result: string): void;
+  (e: 'bullet-points-processed', points: any[]): void;
 }>();
 
 const { t } = useI18n();
@@ -61,10 +62,15 @@ const onCompleted = (data: any) => {
   loading.value = false;
 
   const result = data?.data?.[props.mutationKey]?.content;
+  const bulletPointsResult = data?.data?.[props.mutationKey]?.bulletPoints;
   const points = data?.data?.[props.mutationKey]?.points;
 
   if (result) {
     emit("processed", result);
+  }
+
+  if (bulletPointsResult) {
+    emit('bullet-points-processed', bulletPointsResult);
   }
 
   if (points && props.successToastKey) {


### PR DESCRIPTION
## Summary
- add mutation for generating AI bullet points
- extend AiProcess to emit bullet-points data
- create AiBulletPointsGenerator component
- hook generator into ProductTranslationBulletPoints
- pass required props from ProductContentView
- add related i18n strings

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863079be008832e81591782b2bea2dc

## Summary by Sourcery

Enable AI-driven generation of product bullet points by adding a dedicated mutation, creating a reusable generator component, extending the processing workflow, and embedding the feature into existing translation and content views.

New Features:
- Add GraphQL mutation to generate AI-powered product bullet points
- Introduce AiBulletPointsGenerator component for AI-driven bullet point creation

Enhancements:
- Extend AiProcess component to emit and handle bullet-points-processed events
- Integrate AI bullet point generator into ProductTranslationBulletPoints and ProductContentView with productId and languageCode props
- Add i18n entries for AiBulletPointsGenerator steps, modal title, and success toast