### PR TITLE
Add Amazon product type items table

### DIFF
--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -733,6 +733,17 @@ export const getAmazonProductTypeQuery = gql`
           value
         }
       }
+      amazonproducttypeitemSet {
+        id
+        remoteProperty {
+          id
+          name
+          code
+          allowsUnmappedValues
+          type
+        }
+        remoteType
+      }
     }
   }
 `;export const amazonImportProcessesQuery = gql`

--- a/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
+++ b/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
@@ -29,6 +29,8 @@ const initialFormUpdate = (data: any) => {
     return true;
   }
 
+  emit('setData', data);
+
   const dataToEdit = props.config.queryDataKey ? data[props.config.queryDataKey] : data;
 
   props.config.fields.forEach(field => {


### PR DESCRIPTION
## Summary
- query Amazon product type items
- display Amazon product type items next to edit form
- handle product type items via `setData` event

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b2c47ec0832ea53d251273f3f177