### PR TITLE
Add accordion for Amazon product type items

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -16,6 +16,7 @@ import { Badge } from "../../../../../../../../../shared/components/atoms/badge"
 import { getPropertyTypeBadgeMap } from "../../../../../../../../properties/properties/configs";
 import { ConfigTypes } from "../../../../../../../../../shared/utils/constants";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
+import { Accordion } from "../../../../../../../../../shared/components/atoms/accordion";
 import {FormConfig, FormType} from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import {HelpSection} from "../../../../../../../../../shared/components/organisms/general-form/containers/help-section";
@@ -52,6 +53,10 @@ const configTypeChoices = [
 ];
 
 const propertyTypeBadgeMap = getPropertyTypeBadgeMap(t);
+
+const accordionItems = [
+  { name: 'items', label: t('shared.tabs.items'), icon: 'sitemap' },
+];
 
 const setupFormConfig = () => {
   formConfig.value = amazonProductTypeEditFormConfigConstructor(
@@ -186,35 +191,37 @@ const handleFormUpdate = (form) => {
             </Link>
           </template>
         </GeneralForm>
-        <div>
-          <div v-if="items.length" class="mt-4 grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3">
-            <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
-              <div class="overflow-x-auto">
-                <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
-                  <thead>
-                    <tr>
-                      <th class="p-2 text-left">{{ t('shared.labels.name') }}</th>
-                      <th class="p-2 text-left">{{ t('integrations.show.properties.labels.code') }}</th>
-                      <th class="p-2 text-left">{{ t('integrations.show.properties.labels.allowsUnmappedValues') }}</th>
-                      <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-gray-200 bg-white">
-                    <tr v-for="item in items" :key="item.id">
-                      <td class="p-2">{{ item.remoteProperty.name }}</td>
-                      <td class="p-2">{{ item.remoteProperty.code }}</td>
-                      <td class="p-2">
-                        <Icon v-if="item.remoteProperty.allowsUnmappedValues" name="check-circle" class="text-green-500" />
-                        <Icon v-else name="times-circle" class="text-red-500" />
-                      </td>
-                      <td class="p-2">{{ configTypeChoices.find(c => c.id === item.remoteType)?.text }}</td>
-                    </tr>
-                  </tbody>
-                </table>
+        <Accordion v-if="items.length" class="mt-4" :items="accordionItems">
+          <template #items>
+            <div class="grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3">
+              <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
+                <div class="overflow-x-auto">
+                  <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+                    <thead>
+                      <tr>
+                        <th class="p-2 text-left">{{ t('shared.labels.name') }}</th>
+                        <th class="p-2 text-left">{{ t('integrations.show.properties.labels.code') }}</th>
+                        <th class="p-2 text-left">{{ t('integrations.show.mapping.mappedLocally') }}</th>
+                        <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 bg-white">
+                      <tr v-for="item in items" :key="item.id">
+                        <td class="p-2">{{ item.remoteProperty.name }}</td>
+                        <td class="p-2">{{ item.remoteProperty.code }}</td>
+                        <td class="p-2">
+                          <Icon v-if="item.remoteProperty.mappedLocally" name="check-circle" class="text-green-500" />
+                          <Icon v-else name="times-circle" class="text-red-500" />
+                        </td>
+                        <td class="p-2">{{ configTypeChoices.find(c => c.id === item.remoteType)?.text }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-              </div>
-          </div>
-        </div>
+            </div>
+          </template>
+        </Accordion>
 
     </template>
   </GeneralTemplate>

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -739,6 +739,7 @@ export const getAmazonProductTypeQuery = gql`
           id
           name
           code
+          mappedLocally
           allowsUnmappedValues
           type
         }


### PR DESCRIPTION
## Summary
- add `mappedLocally` field to the product type query
- wrap product type items table in an accordion
- show `mappedLocally` column instead of `allowsUnmappedValues`

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c9328e8c832ea822b14b111a69d6

## Summary by Sourcery

Wrap the Amazon product types items table in an accordion and switch the mapping status display to use the new mappedLocally field by exposing it in the GraphQL query.

New Features:
- Wrap Amazon product type items table in an accordion for collapsible display

Enhancements:
- Replace allowsUnmappedValues column with mappedLocally status in the items table
- Expose mappedLocally field in the Amazon product type GraphQL query