### PR TITLE
Add dynamic property field for Amazon edit

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/configs.ts
@@ -36,22 +36,7 @@ export const amazonPropertyEditFormConfigConstructor = (
       help: t('integrations.show.properties.help.type')
     },
     { type: FieldType.Boolean, name: 'allowsUnmappedValues', label: t('integrations.show.properties.labels.allowsUnmappedValues'), disabled: true, strict: true, help: t('integrations.show.properties.help.allowsUnmappedValues') },
-    { type: FieldType.Text, name: 'name', label: t('shared.labels.name'), help: t('integrations.show.properties.help.name') },
-    {
-      type: FieldType.Query,
-      name: 'localInstance',
-      label: t('integrations.show.properties.labels.property'),
-      help: t('integrations.show.properties.help.property'),
-      labelBy: 'name',
-      valueBy: 'id',
-      query: propertiesQuery,
-      dataKey: 'properties',
-      isEdge: true,
-      multiple: false,
-      filterable: true,
-      formMapIdentifier: 'id',
-      ...(defaultPropertyId ? { default: defaultPropertyId } : {})
-    }
+    { type: FieldType.Text, name: 'name', label: t('shared.labels.name'), help: t('integrations.show.properties.help.name') }
   ]
 });
 

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -6,6 +6,8 @@ import GeneralTemplate from "../../../../../../../../../shared/templates/General
 import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
 import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
 import { amazonPropertyEditFormConfigConstructor } from "../configs";
+import { FieldType } from "../../../../../../../../../shared/utils/constants";
+import { propertiesQuery } from "../../../../../../../../../shared/api/queries/properties.js";
 import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
 import apolloClient from "../../../../../../../../../../apollo-client";
@@ -100,6 +102,35 @@ onMounted(async () => {
   }
 });
 
+const handleSetData = (data: any) => {
+  const propertyType = data?.amazonProperty?.type;
+  if (!formConfig.value || !propertyType) return;
+
+  const field = {
+    type: FieldType.Query,
+    name: 'localInstance',
+    label: t('integrations.show.properties.labels.property'),
+    help: t('integrations.show.properties.help.property'),
+    labelBy: 'name',
+    valueBy: 'id',
+    query: propertiesQuery,
+    queryVariables: { filter: { type: { exact: propertyType } } },
+    dataKey: 'properties',
+    isEdge: true,
+    multiple: false,
+    filterable: true,
+    formMapIdentifier: 'id',
+    ...(propertyId ? { default: propertyId } : {})
+  };
+
+  const index = formConfig.value.fields.findIndex(f => f.name === 'localInstance');
+  if (index === -1) {
+    formConfig.value.fields.push(field as any);
+  } else {
+    formConfig.value.fields[index] = field as any;
+  }
+};
+
 const handleFormUpdate = (form) => {
   formData.value = form;
 };
@@ -118,7 +149,7 @@ const handleFormUpdate = (form) => {
         ]" />
     </template>
     <template v-slot:content>
-      <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" >
+      <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" @set-data="handleSetData" >
         <template #additional-button>
           <Link :path="{ name: 'properties.properties.create', query: {
             amazonRuleId: `${amazonPropertyId}__${integrationId}__${salesChannelId}`,


### PR DESCRIPTION
## Summary
- don't include localInstance query in the form config
- dynamically inject localInstance query field after data load
- support filtering properties by type when adding the field

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863ce9a330c832e97dc1da2cb0d1284

## Summary by Sourcery

Replace the static property selection field in the Amazon property edit form with a dynamically injected query-driven field that filters available properties by the selected Amazon property’s type.

Enhancements:
- Remove the hardcoded 'localInstance' field from the form config and inject it dynamically via a new handleSetData callback.
- Filter the dynamically injected 'localInstance' query field by the Amazon property’s type when loading form data.
- Add a @set-data listener to GeneralForm to trigger the dynamic field addition after the form data loads.