### PR TITLE
Feature/amazon

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/configs.ts
@@ -36,22 +36,7 @@ export const amazonPropertyEditFormConfigConstructor = (
       help: t('integrations.show.properties.help.type')
     },
     { type: FieldType.Boolean, name: 'allowsUnmappedValues', label: t('integrations.show.properties.labels.allowsUnmappedValues'), disabled: true, strict: true, help: t('integrations.show.properties.help.allowsUnmappedValues') },
-    { type: FieldType.Text, name: 'name', label: t('shared.labels.name'), help: t('integrations.show.properties.help.name') },
-    {
-      type: FieldType.Query,
-      name: 'localInstance',
-      label: t('integrations.show.properties.labels.property'),
-      help: t('integrations.show.properties.help.property'),
-      labelBy: 'name',
-      valueBy: 'id',
-      query: propertiesQuery,
-      dataKey: 'properties',
-      isEdge: true,
-      multiple: false,
-      filterable: true,
-      formMapIdentifier: 'id',
-      ...(defaultPropertyId ? { default: defaultPropertyId } : {})
-    }
+    { type: FieldType.Text, name: 'name', label: t('shared.labels.name'), help: t('integrations.show.properties.help.name') }
   ]
 });
 

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -6,6 +6,8 @@ import GeneralTemplate from "../../../../../../../../../shared/templates/General
 import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
 import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
 import { amazonPropertyEditFormConfigConstructor } from "../configs";
+import { FieldType } from "../../../../../../../../../shared/utils/constants";
+import { propertiesQuery } from "../../../../../../../../../shared/api/queries/properties.js";
 import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
 import apolloClient from "../../../../../../../../../../apollo-client";
@@ -100,6 +102,35 @@ onMounted(async () => {
   }
 });
 
+const handleSetData = (data: any) => {
+  const propertyType = data?.amazonProperty?.type;
+  if (!formConfig.value || !propertyType) return;
+
+  const field = {
+    type: FieldType.Query,
+    name: 'localInstance',
+    label: t('integrations.show.properties.labels.property'),
+    help: t('integrations.show.properties.help.property'),
+    labelBy: 'name',
+    valueBy: 'id',
+    query: propertiesQuery,
+    queryVariables: { filter: { type: { exact: propertyType } } },
+    dataKey: 'properties',
+    isEdge: true,
+    multiple: false,
+    filterable: true,
+    formMapIdentifier: 'id',
+    ...(propertyId ? { default: propertyId } : {})
+  };
+
+  const index = formConfig.value.fields.findIndex(f => f.name === 'localInstance');
+  if (index === -1) {
+    formConfig.value.fields.push(field as any);
+  } else {
+    formConfig.value.fields[index] = field as any;
+  }
+};
+
 const handleFormUpdate = (form) => {
   formData.value = form;
 };
@@ -118,7 +149,7 @@ const handleFormUpdate = (form) => {
         ]" />
     </template>
     <template v-slot:content>
-      <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" >
+      <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" @set-data="handleSetData" >
         <template #additional-button>
           <Link :path="{ name: 'properties.properties.create', query: {
             amazonRuleId: `${amazonPropertyId}__${integrationId}__${salesChannelId}`,

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -16,8 +16,11 @@ import { Badge } from "../../../../../../../../../shared/components/atoms/badge"
 import { getPropertyTypeBadgeMap } from "../../../../../../../../properties/properties/configs";
 import { ConfigTypes } from "../../../../../../../../../shared/utils/constants";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
-import { FormConfig } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
+import {FormConfig, FormType} from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
+import {HelpSection} from "../../../../../../../../../shared/components/organisms/general-form/containers/help-section";
+import {FormCreate} from "../../../../../../../../../shared/components/organisms/general-form/containers/form-create";
+import {FormEdit} from "../../../../../../../../../shared/components/organisms/general-form/containers/form-edit";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -174,50 +177,45 @@ const handleFormUpdate = (form) => {
     </template>
 
     <template v-slot:content>
-      <div class="grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" @set-data="handleSetData" >
+          <template #additional-button>
+            <Link :path="{ name: 'properties.values.create', query: { propertyId: propertyProductTypeId, isRule: '1', amazonRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`, value: formData.name } }">
+              <Button type="button" class="btn btn-info">
+                {{ t('integrations.show.generateProductType') }}
+              </Button>
+            </Link>
+          </template>
+        </GeneralForm>
         <div>
-          <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" @set-data="handleSetData" >
-            <template #additional-button>
-              <Link :path="{ name: 'properties.values.create', query: { propertyId: propertyProductTypeId, isRule: '1', amazonRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`, value: formData.name } }">
-                <Button type="button" class="btn btn-info">
-                  {{ t('integrations.show.generateProductType') }}
-                </Button>
-              </Link>
-            </template>
-          </GeneralForm>
+          <div v-if="items.length" class="mt-4 grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3">
+            <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
+              <div class="overflow-x-auto">
+                <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+                  <thead>
+                    <tr>
+                      <th class="p-2 text-left">{{ t('shared.labels.name') }}</th>
+                      <th class="p-2 text-left">{{ t('integrations.show.properties.labels.code') }}</th>
+                      <th class="p-2 text-left">{{ t('integrations.show.properties.labels.allowsUnmappedValues') }}</th>
+                      <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-gray-200 bg-white">
+                    <tr v-for="item in items" :key="item.id">
+                      <td class="p-2">{{ item.remoteProperty.name }}</td>
+                      <td class="p-2">{{ item.remoteProperty.code }}</td>
+                      <td class="p-2">
+                        <Icon v-if="item.remoteProperty.allowsUnmappedValues" name="check-circle" class="text-green-500" />
+                        <Icon v-else name="times-circle" class="text-red-500" />
+                      </td>
+                      <td class="p-2">{{ configTypeChoices.find(c => c.id === item.remoteType)?.text }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              </div>
+          </div>
         </div>
-        <div>
-          <Card v-if="items.length">
-            <div class="overflow-x-auto">
-              <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
-                <thead>
-                  <tr>
-                    <th class="p-2 text-left">{{ t('shared.labels.name') }}</th>
-                    <th class="p-2 text-left">{{ t('integrations.show.properties.labels.code') }}</th>
-                    <th class="p-2 text-left">{{ t('integrations.show.properties.labels.allowsUnmappedValues') }}</th>
-                    <th class="p-2 text-left">{{ t('integrations.show.properties.labels.type') }}</th>
-                    <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-200 bg-white">
-                  <tr v-for="item in items" :key="item.id">
-                    <td class="p-2">{{ item.remoteProperty.name }}</td>
-                    <td class="p-2">{{ item.remoteProperty.code }}</td>
-                    <td class="p-2">
-                      <Icon v-if="item.remoteProperty.allowsUnmappedValues" name="check-circle" class="text-green-500" />
-                      <Icon v-else name="times-circle" class="text-red-500" />
-                    </td>
-                    <td class="p-2">
-                      <Badge :color="propertyTypeBadgeMap[item.remoteProperty.type]?.color" :text="propertyTypeBadgeMap[item.remoteProperty.type]?.text" />
-                    </td>
-                    <td class="p-2">{{ configTypeChoices.find(c => c.id === item.remoteType)?.text }}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </Card>
-        </div>
-      </div>
+
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -1,29 +1,32 @@
 <script setup lang="ts">
 import {onMounted, ref} from 'vue';
-import { useRouter } from 'vue-router';
-import { useI18n } from 'vue-i18n';
+import {useRouter} from 'vue-router';
+import {useI18n} from 'vue-i18n';
 import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
-import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
-import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
-import { useRoute } from "vue-router";
-import { amazonProductTypeEditFormConfigConstructor, listingQuery } from "../configs";
+import {Breadcrumbs} from "../../../../../../../../../shared/components/molecules/breadcrumbs";
+import {GeneralForm} from "../../../../../../../../../shared/components/organisms/general-form";
+import {useRoute} from "vue-router";
+import {amazonProductTypeEditFormConfigConstructor, listingQuery} from "../configs";
 import apolloClient from "../../../../../../../../../../apollo-client";
-import { productPropertiesRulesQuery, propertiesQuery } from "../../../../../../../../../shared/api/queries/properties.js";
-import { Link } from "../../../../../../../../../shared/components/atoms/link";
-import { Button } from "../../../../../../../../../shared/components/atoms/button";
-import { Card } from "../../../../../../../../../shared/components/atoms/card";
-import { Badge } from "../../../../../../../../../shared/components/atoms/badge";
-import { getPropertyTypeBadgeMap } from "../../../../../../../../properties/properties/configs";
-import { ConfigTypes } from "../../../../../../../../../shared/utils/constants";
-import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
-import { Accordion } from "../../../../../../../../../shared/components/atoms/accordion";
+import {
+  productPropertiesRulesQuery,
+  propertiesQuery
+} from "../../../../../../../../../shared/api/queries/properties.js";
+import {Link} from "../../../../../../../../../shared/components/atoms/link";
+import {Button} from "../../../../../../../../../shared/components/atoms/button";
+import {Card} from "../../../../../../../../../shared/components/atoms/card";
+import {Badge} from "../../../../../../../../../shared/components/atoms/badge";
+import {getPropertyTypeBadgeMap} from "../../../../../../../../properties/properties/configs";
+import {ConfigTypes} from "../../../../../../../../../shared/utils/constants";
+import {Icon} from "../../../../../../../../../shared/components/atoms/icon";
+import {Accordion} from "../../../../../../../../../shared/components/atoms/accordion";
 import {FormConfig, FormType} from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
-import { Toast } from "../../../../../../../../../shared/modules/toast";
+import {Toast} from "../../../../../../../../../shared/modules/toast";
 import {HelpSection} from "../../../../../../../../../shared/components/organisms/general-form/containers/help-section";
 import {FormCreate} from "../../../../../../../../../shared/components/organisms/general-form/containers/form-create";
 import {FormEdit} from "../../../../../../../../../shared/components/organisms/general-form/containers/form-edit";
 
-const { t } = useI18n();
+const {t} = useI18n();
 const route = useRoute();
 const router = useRouter();
 
@@ -46,35 +49,35 @@ const handleSetData = (data: any) => {
 };
 
 const configTypeChoices = [
-  { id: ConfigTypes.REQUIRED_IN_CONFIGURATOR, text: t('properties.rule.configTypes.requiredInConfigurator.title') },
-  { id: ConfigTypes.OPTIONAL_IN_CONFIGURATOR, text: t('properties.rule.configTypes.optionalInConfigurator.title') },
-  { id: ConfigTypes.REQUIRED, text: t('properties.rule.configTypes.required.title') },
-  { id: ConfigTypes.OPTIONAL, text: t('properties.rule.configTypes.optional.title') }
+  {id: ConfigTypes.REQUIRED_IN_CONFIGURATOR, text: t('properties.rule.configTypes.requiredInConfigurator.title')},
+  {id: ConfigTypes.OPTIONAL_IN_CONFIGURATOR, text: t('properties.rule.configTypes.optionalInConfigurator.title')},
+  {id: ConfigTypes.REQUIRED, text: t('properties.rule.configTypes.required.title')},
+  {id: ConfigTypes.OPTIONAL, text: t('properties.rule.configTypes.optional.title')}
 ];
 
 const propertyTypeBadgeMap = getPropertyTypeBadgeMap(t);
 
 const accordionItems = [
-  { name: 'items', label: t('shared.tabs.items'), icon: 'sitemap' },
+  {name: 'items', label: t('shared.tabs.items'), icon: 'sitemap'},
 ];
 
 const setupFormConfig = () => {
   formConfig.value = amazonProductTypeEditFormConfigConstructor(
-    t,
-    type.value,
-    productTypeId.value,
-    integrationId,
-    resolvedDefaultRuleId.value
+      t,
+      type.value,
+      productTypeId.value,
+      integrationId,
+      resolvedDefaultRuleId.value
   );
 };
 
 const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boolean }> => {
-  const { data } = await apolloClient.query({
+  const {data} = await apolloClient.query({
     query: listingQuery,
     variables: {
       first: 2,
       filter: {
-        salesChannel: { id: { exact: salesChannelId } },
+        salesChannel: {id: {exact: salesChannelId}},
         mappedLocally: false,
       },
     },
@@ -89,24 +92,24 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
     }
   }
   const last = edges.length === 1 && edges[0].node.id === productTypeId.value;
-  return { nextId, last };
+  return {nextId, last};
 };
 
 const fetchProductType = async () => {
-    const {data} = await apolloClient.query({
-      query: propertiesQuery,
-      variables: {filter: {isProductType: { exact: true } }}
-    })
+  const {data} = await apolloClient.query({
+    query: propertiesQuery,
+    variables: {filter: {isProductType: {exact: true}}}
+  })
 
-    if (data && data.properties && data.properties.edges && data.properties.edges.length == 1) {
-      propertyProductTypeId.value = data.properties.edges[0].node.id;
-    }
+  if (data && data.properties && data.properties.edges && data.properties.edges.length == 1) {
+    propertyProductTypeId.value = data.properties.edges[0].node.id;
+  }
 }
 
 const fetchDefaultRuleId = async () => {
   if (!defaultRuleId) return;
 
-  const { data } = await apolloClient.query({
+  const {data} = await apolloClient.query({
     query: productPropertiesRulesQuery,
     variables: {
       filter: {
@@ -126,7 +129,6 @@ const fetchDefaultRuleId = async () => {
 };
 
 
-
 onMounted(async () => {
   await fetchProductType();
   await fetchDefaultRuleId();
@@ -134,32 +136,36 @@ onMounted(async () => {
 
   if (!isWizard || formConfig.value == null) return;
 
-  const { nextId, last } = await fetchNextUnmapped();
+  const {nextId, last} = await fetchNextUnmapped();
   nextWizardId.value = nextId;
 
   formConfig.value.addSubmitAndContinue = false;
   formConfig.value.cancelUrl = {
     name: 'integrations.integrations.show',
-    params: { type: type.value, id: integrationId },
-    query: { tab: 'productRules' }
+    params: {type: type.value, id: integrationId},
+    query: {tab: 'productRules'}
   };
 
   if (nextId) {
     formConfig.value.submitUrl = {
       name: 'integrations.amazonProductTypes.edit',
-      params: { type: type.value, id: nextId },
-      query: { integrationId, salesChannelId, wizard: '1' },
+      params: {type: type.value, id: nextId},
+      query: {integrationId, salesChannelId, wizard: '1'},
     };
     formConfig.value.submitLabel = t('integrations.show.mapping.saveAndMapNext');
   } else if (last) {
     formConfig.value.submitUrl = {
       name: 'integrations.integrations.show',
-      params: { type: type.value, id: integrationId },
-      query: { tab: 'productRules' }
+      params: {type: type.value, id: integrationId},
+      query: {tab: 'productRules'}
     };
   } else {
     Toast.success(t('integrations.show.mapping.allMappedSuccess'));
-    router.push({ name: 'integrations.integrations.show', params: { type: type.value, id: integrationId }, query: { tab: 'productRules' } });
+    router.push({
+      name: 'integrations.integrations.show',
+      params: {type: type.value, id: integrationId},
+      query: {tab: 'productRules'}
+    });
   }
 });
 
@@ -174,54 +180,62 @@ const handleFormUpdate = (form) => {
   <GeneralTemplate>
     <template v-slot:breadcrumbs>
       <Breadcrumbs
-        :links="[
+          :links="[
           { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
           { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'productRules'} }, name: t('integrations.show.amazon.title') },
           { name: t('integrations.show.mapProductType') }
-        ]" />
+        ]"/>
     </template>
 
     <template v-slot:content>
-        <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" @set-data="handleSetData" >
-          <template #additional-button>
-            <Link :path="{ name: 'properties.values.create', query: { propertyId: propertyProductTypeId, isRule: '1', amazonRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`, value: formData.name } }">
-              <Button type="button" class="btn btn-info">
-                {{ t('integrations.show.generateProductType') }}
-              </Button>
-            </Link>
-          </template>
-        </GeneralForm>
-        <Accordion v-if="items.length" class="mt-4" :items="accordionItems">
-          <template #items>
-            <div class="grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3">
-              <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
-                <div class="overflow-x-auto">
-                  <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
-                    <thead>
-                      <tr>
-                        <th class="p-2 text-left">{{ t('shared.labels.name') }}</th>
-                        <th class="p-2 text-left">{{ t('integrations.show.properties.labels.code') }}</th>
-                        <th class="p-2 text-left">{{ t('integrations.show.mapping.mappedLocally') }}</th>
-                        <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
-                      </tr>
-                    </thead>
-                    <tbody class="divide-y divide-gray-200 bg-white">
-                      <tr v-for="item in items" :key="item.id">
-                        <td class="p-2">{{ item.remoteProperty.name }}</td>
-                        <td class="p-2">{{ item.remoteProperty.code }}</td>
-                        <td class="p-2">
-                          <Icon v-if="item.remoteProperty.mappedLocally" name="check-circle" class="text-green-500" />
-                          <Icon v-else name="times-circle" class="text-red-500" />
-                        </td>
-                        <td class="p-2">{{ configTypeChoices.find(c => c.id === item.remoteType)?.text }}</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
+      <GeneralForm v-if="formConfig" :config="formConfig" @form-updated="handleFormUpdate" @set-data="handleSetData">
+        <template #additional-button>
+          <Link
+              :path="{ name: 'properties.values.create', query: { propertyId: propertyProductTypeId, isRule: '1', amazonRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`, value: formData.name } }">
+            <Button type="button" class="btn btn-info">
+              {{ t('integrations.show.generateProductType') }}
+            </Button>
+          </Link>
+        </template>
+      </GeneralForm>
+
+      <div class="grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3 mt-4">
+        <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
+          <Accordion v-if="items.length" :items="accordionItems">
+            <template #items>
+
+
+              <div class="overflow-x-auto">
+                <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+                  <thead>
+                  <tr>
+                    <th class="p-2 text-left">{{ t('shared.labels.name') }}</th>
+                    <th class="p-2 text-left">{{ t('integrations.show.properties.labels.code') }}</th>
+                    <th class="p-2 text-left">{{ t('integrations.show.mapping.mappedLocally') }}</th>
+                    <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
+                  </tr>
+                  </thead>
+                  <tbody class="divide-y divide-gray-200 bg-white">
+                  <tr v-for="item in items" :key="item.id">
+                    <td class="p-2">
+                      <Link :path="{ name: 'integrations.amazonProperties.edit', params: { type: type, id: item.remoteProperty.id }, query: { integrationId, salesChannelId } }">
+                        {{ item.remoteProperty.name }}
+                      </Link>
+                    </td>
+                    <td class="p-2">{{ item.remoteProperty.code }}</td>
+                    <td class="p-2">
+                      <Icon v-if="item.remoteProperty.mappedLocally" name="check-circle" class="text-green-500"/>
+                      <Icon v-else name="times-circle" class="text-red-500"/>
+                    </td>
+                    <td class="p-2">{{ configTypeChoices.find(c => c.id === item.remoteType)?.text }}</td>
+                  </tr>
+                  </tbody>
+                </table>
               </div>
-            </div>
-          </template>
-        </Accordion>
+            </template>
+          </Accordion>
+        </div>
+      </div>
 
     </template>
   </GeneralTemplate>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -16,6 +16,7 @@ import { Badge } from "../../../../../../../../../shared/components/atoms/badge"
 import { getPropertyTypeBadgeMap } from "../../../../../../../../properties/properties/configs";
 import { ConfigTypes } from "../../../../../../../../../shared/utils/constants";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
+import { Accordion } from "../../../../../../../../../shared/components/atoms/accordion";
 import {FormConfig, FormType} from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import {HelpSection} from "../../../../../../../../../shared/components/organisms/general-form/containers/help-section";
@@ -52,6 +53,10 @@ const configTypeChoices = [
 ];
 
 const propertyTypeBadgeMap = getPropertyTypeBadgeMap(t);
+
+const accordionItems = [
+  { name: 'items', label: t('shared.tabs.items'), icon: 'sitemap' },
+];
 
 const setupFormConfig = () => {
   formConfig.value = amazonProductTypeEditFormConfigConstructor(
@@ -186,35 +191,37 @@ const handleFormUpdate = (form) => {
             </Link>
           </template>
         </GeneralForm>
-        <div>
-          <div v-if="items.length" class="mt-4 grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3">
-            <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
-              <div class="overflow-x-auto">
-                <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
-                  <thead>
-                    <tr>
-                      <th class="p-2 text-left">{{ t('shared.labels.name') }}</th>
-                      <th class="p-2 text-left">{{ t('integrations.show.properties.labels.code') }}</th>
-                      <th class="p-2 text-left">{{ t('integrations.show.properties.labels.allowsUnmappedValues') }}</th>
-                      <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-gray-200 bg-white">
-                    <tr v-for="item in items" :key="item.id">
-                      <td class="p-2">{{ item.remoteProperty.name }}</td>
-                      <td class="p-2">{{ item.remoteProperty.code }}</td>
-                      <td class="p-2">
-                        <Icon v-if="item.remoteProperty.allowsUnmappedValues" name="check-circle" class="text-green-500" />
-                        <Icon v-else name="times-circle" class="text-red-500" />
-                      </td>
-                      <td class="p-2">{{ configTypeChoices.find(c => c.id === item.remoteType)?.text }}</td>
-                    </tr>
-                  </tbody>
-                </table>
+        <Accordion v-if="items.length" class="mt-4" :items="accordionItems">
+          <template #items>
+            <div class="grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3">
+              <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
+                <div class="overflow-x-auto">
+                  <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+                    <thead>
+                      <tr>
+                        <th class="p-2 text-left">{{ t('shared.labels.name') }}</th>
+                        <th class="p-2 text-left">{{ t('integrations.show.properties.labels.code') }}</th>
+                        <th class="p-2 text-left">{{ t('integrations.show.mapping.mappedLocally') }}</th>
+                        <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
+                      </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 bg-white">
+                      <tr v-for="item in items" :key="item.id">
+                        <td class="p-2">{{ item.remoteProperty.name }}</td>
+                        <td class="p-2">{{ item.remoteProperty.code }}</td>
+                        <td class="p-2">
+                          <Icon v-if="item.remoteProperty.mappedLocally" name="check-circle" class="text-green-500" />
+                          <Icon v-else name="times-circle" class="text-red-500" />
+                        </td>
+                        <td class="p-2">{{ configTypeChoices.find(c => c.id === item.remoteType)?.text }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-              </div>
-          </div>
-        </div>
+            </div>
+          </template>
+        </Accordion>
 
     </template>
   </GeneralTemplate>

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -733,6 +733,17 @@ export const getAmazonProductTypeQuery = gql`
           value
         }
       }
+      amazonproducttypeitemSet {
+        id
+        remoteProperty {
+          id
+          name
+          code
+          allowsUnmappedValues
+          type
+        }
+        remoteType
+      }
     }
   }
 `;export const amazonImportProcessesQuery = gql`

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -739,6 +739,7 @@ export const getAmazonProductTypeQuery = gql`
           id
           name
           code
+          mappedLocally
           allowsUnmappedValues
           type
         }

--- a/src/shared/components/organisms/general-form/GeneralForm.vue
+++ b/src/shared/components/organisms/general-form/GeneralForm.vue
@@ -24,8 +24,8 @@ const handleFormUpdate = (updatedForm) => {
   emit('formUpdated', updatedForm);
 };
 
-const handleSetData = (form) => {
-  emit('setData', form);
+const handleSetData = (data) => {
+  emit('setData', data);
 };
 
 watch(() => props.config, (newConfig) => {

--- a/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
+++ b/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
@@ -24,7 +24,6 @@ const errors: Ref<Record<string, string> | null> = ref(null);
 
 const initialFormUpdate = (data: any) => {
 
-  emit('setData', data)
   // we want to updated only the first time then we can freely update it from outside without coming back to the initial values (example using clear fields)
   if (Object.keys(form).length !== 0) {
     return true;
@@ -66,6 +65,7 @@ const initialFormUpdate = (data: any) => {
   });
 
   emit('formUpdated', form);
+
   return true;
 };
 

--- a/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
+++ b/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
@@ -24,6 +24,7 @@ const errors: Ref<Record<string, string> | null> = ref(null);
 
 const initialFormUpdate = (data: any) => {
 
+  emit('setData', data)
   // we want to updated only the first time then we can freely update it from outside without coming back to the initial values (example using clear fields)
   if (Object.keys(form).length !== 0) {
     return true;

--- a/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
+++ b/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
@@ -30,6 +30,8 @@ const initialFormUpdate = (data: any) => {
     return true;
   }
 
+  emit('setData', data);
+
   const dataToEdit = props.config.queryDataKey ? data[props.config.queryDataKey] : data;
 
   props.config.fields.forEach(field => {


### PR DESCRIPTION
## Summary by Sourcery

Display and manage Amazon product type items and dynamic property mappings by extending GraphQL queries, refactoring form data handling, and enhancing the edit interfaces with accordion-based listings and injected fields.

New Features:
- Render associated Amazon product type items in an accordion table on the product type edit page
- Inject a dynamic localInstance query field into the Amazon property edit form based on the remote property type

Enhancements:
- Extend getAmazonProductTypeQuery to include amazonproducttypeitemSet for item mappings
- Refactor GeneralForm and FormEdit components to emit a set-data event for initial data population
- Introduce Accordion, Icon, Badge, and Card UI components to present mapping listings in a structured layout