### PR TITLE
Add Amazon default unit configurator UI

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
@@ -5,6 +5,10 @@ import { TextInput } from "../../../../../../../shared/components/atoms/input-te
 import { Label } from "../../../../../../../shared/components/atoms/label";
 import { Toggle } from "../../../../../../../shared/components/atoms/toggle";
 import { Accordion } from "../../../../../../../shared/components/atoms/accordion";
+import { FieldInlineItems } from "../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-inline-items";
+import { FormType } from "../../../../../../../shared/components/organisms/general-form/formConfig";
+import { amazonDefaultUnitConfiguratorsQuery } from "../../../../../../../shared/api/queries/salesChannels.js";
+import { updateAmazonDefaultUnitConfiguratorMutation } from "../../../../../../../shared/api/mutations/salesChannels.js";
 import { PrimaryButton } from "../../../../../../../shared/components/atoms/button-primary";
 import { SecondaryButton } from "../../../../../../../shared/components/atoms/button-secondary";
 import { CancelButton } from "../../../../../../../shared/components/atoms/button-cancel";
@@ -43,6 +47,31 @@ const formData = ref<EditAmazonForm>({ ...props.data });
 const fieldErrors = ref<Record<string, string>>({});
 const submitButtonRef = ref();
 const submitContinueButtonRef = ref();
+const unitConfigurators = ref<any[]>([]);
+
+const unitConfiguratorField = {
+  type: FieldType.InlineItems,
+  name: 'unitConfigurators',
+  label: t('integrations.labels.defaultUnits'),
+  valueKey: 'salesChannel',
+  allowAdd: false,
+  allowDelete: false,
+  query: amazonDefaultUnitConfiguratorsQuery,
+  dataKey: 'amazonDefaultUnitConfigurators',
+  isEdge: true,
+  createMutation: null,
+  createMutationKey: '',
+  editMutation: updateAmazonDefaultUnitConfiguratorMutation,
+  editMutationKey: 'updateAmazonDefaultUnitConfigurator',
+  deleteMutation: null,
+  deleteMutationKey: '',
+  mode: FormType.EDIT,
+  fields: [
+    { type: FieldType.Text, name: 'name', label: t('shared.labels.name'), disabled: true },
+    { type: FieldType.Text, name: 'code', label: t('shared.labels.code'), disabled: true },
+    { type: FieldType.Choice, name: 'selectedUnit', label: t('shared.labels.unit'), labelBy: 'name', valueBy: 'value', optionsField: 'choices' },
+  ],
+};
 
 watch(() => props.data, (newData) => {
   formData.value = { ...newData };
@@ -51,6 +80,7 @@ watch(() => props.data, (newData) => {
 const accordionItems = [
   { name: 'throttling', label: t('integrations.show.sections.throttling'), icon: 'gauge' },
   { name: 'sync', label: t('integrations.show.sections.syncPreferences'), icon: 'sync' },
+  { name: 'units', label: t('integrations.show.sections.defaultUnits'), icon: 'weight-hanging' },
 ];
 
 const regionLabel = computed(() => {
@@ -256,6 +286,10 @@ useShiftBackspaceKeyboardListener(goBack);
             </div>
           </div>
         </div>
+      </template>
+
+      <template #units>
+        <FieldInlineItems v-model="unitConfigurators" :field="unitConfiguratorField" />
       </template>
     </Accordion>
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2150,7 +2150,8 @@
       "sections": {
         "throttling": "Throttling",
         "syncPreferences": "Sync Preferences",
-        "authentication": "Authentication"
+        "authentication": "Authentication",
+        "defaultUnits": "Default Units"
       },
       "noImportBanner": {
         "title": "First Import Not Completed",
@@ -2344,7 +2345,8 @@
       "region": "Region",
       "country": "Country",
       "expirationDate": "Access Token Expiration",
-      "pullData": "Pull Data"
+      "pullData": "Pull Data",
+      "defaultUnits": "Default Units"
     },
     "placeholders": {
       "hostApiUsername": "Enter API Username",

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -534,3 +534,16 @@ export const updateAmazonImportProcessMutation = gql`
     }
   }
 `;
+
+// Amazon Default Unit Configurator Mutation
+export const updateAmazonDefaultUnitConfiguratorMutation = gql`
+  mutation updateAmazonDefaultUnitConfigurator($data: AmazonDefaultUnitConfiguratorPartialInput!) {
+    updateAmazonDefaultUnitConfigurator(data: $data) {
+      id
+      name
+      code
+      selectedUnit
+      choices
+    }
+  }
+`;

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -780,3 +780,54 @@ export const getAmazonProductTypeQuery = gql`
     }
   }
 `;
+
+// Amazon Default Unit Configurator Queries
+export const amazonDefaultUnitConfiguratorsQuery = gql`
+  query AmazonDefaultUnitConfigurators(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: AmazonDefaultUnitConfiguratorOrder
+    $filter: AmazonDefaultUnitConfiguratorFilter
+  ) {
+    amazonDefaultUnitConfigurators(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filter
+    ) {
+      edges {
+        node {
+          id
+          name
+          code
+          selectedUnit
+          choices
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getAmazonDefaultUnitConfiguratorQuery = gql`
+  query getAmazonDefaultUnitConfigurator($id: GlobalID!) {
+    amazonDefaultUnitConfigurator(id: $id) {
+      id
+      name
+      code
+      selectedUnit
+      choices
+    }
+  }
+`;

--- a/src/shared/components/organisms/general-form/containers/form-fields/field-inline-items/FieldInlineItems.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-inline-items/FieldInlineItems.vue
@@ -141,6 +141,14 @@ const deselectAll = () => {
   selectedRows.value = selectedRows.value.map(() => false);
 };
 
+// Return field config merged with row specific options if provided
+const getFieldWithRow = (fieldItem: any, row: any) => {
+  if (fieldItem.optionsField && row[fieldItem.optionsField]) {
+    return { ...fieldItem, options: row[fieldItem.optionsField] };
+  }
+  return fieldItem;
+};
+
 // Show a confirmation alert before deletion
 const triggerDeleteAlert = async () => {
   const defaultSwalOptions = {
@@ -345,7 +353,7 @@ onMounted(() => {
             <component
               v-model="row[fieldItem.name]"
               :is="getFieldComponent(fieldItem.type)"
-              :field="fieldItem"
+              :field="getFieldWithRow(fieldItem, row)"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- support dynamic options in `FieldInlineItems`
- expose queries and mutation for Amazon default unit configurators
- display and edit default units in Amazon general tab
- update i18n strings for new section

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864380595f4832ea26e6542749f0434

## Summary by Sourcery

Enable management of Amazon default unit configurators by exposing GraphQL endpoints and integrating an inline items editor in the Amazon general settings tab.

New Features:
- Expose GraphQL queries and mutation for Amazon default unit configurators
- Add UI in Amazon general tab to display and edit default unit configurators

Enhancements:
- Extend FieldInlineItems component to merge row-specific option lists dynamically

Documentation:
- Add i18n strings for default units section