### PR TITLE
Add marketplace info to default unit configurators

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
@@ -345,6 +345,7 @@ useShiftBackspaceKeyboardListener(goBack);
               <tr>
                 <th>{{ t('shared.labels.name') }}</th>
                 <th>{{ t('integrations.show.properties.labels.code') }}</th>
+                <th>{{ t('integrations.show.propertySelectValues.labels.marketplace') }}</th>
                 <th>{{ t('shared.labels.unit') }}</th>
               </tr>
             </thead>
@@ -352,6 +353,7 @@ useShiftBackspaceKeyboardListener(goBack);
               <tr v-for="(config, index) in unitConfigurators" :key="config.id">
                 <td>{{ config.name }}</td>
                 <td>{{ config.code }}</td>
+                <td>{{ config.marketplace?.name }}</td>
                 <td>
                   <Selector
                     v-model="config.selectedUnit"

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -804,6 +804,10 @@ export const amazonDefaultUnitConfiguratorsQuery = gql`
           id
           name
           code
+          marketplace {
+            id
+            name
+          }
           selectedUnit
           choices
         }
@@ -826,6 +830,10 @@ export const getAmazonDefaultUnitConfiguratorQuery = gql`
       id
       name
       code
+      marketplace {
+        id
+        name
+      }
       selectedUnit
       choices
     }


### PR DESCRIPTION
## Summary
- fetch marketplace in amazon default unit configurators
- display marketplace name in Amazon integration table

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68646e719164832eb70c5197178bf72b

## Summary by Sourcery

Add marketplace information to Amazon default unit configurators by extending GraphQL queries to include marketplace id and name, and update the Amazon integration UI to display the marketplace name in the unit configurators table.

New Features:
- Fetch marketplace id and name in Amazon default unit configurators GraphQL queries
- Display marketplace name column in the Amazon integration default unit configurators table