### PR TITLE
Expose query refetch for bulk actions

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
@@ -47,8 +47,9 @@ const startMapping = async () => {
   }
 };
 
-const clearSelection = () => {
+const clearSelection = (query?: any) => {
   generalListingRef.value?.clearSelected?.()
+  query?.refetch?.()
 }
 
 const searchConfig = amazonPropertySelectValuesSearchConfigConstructor(t, props.salesChannelId);
@@ -72,10 +73,10 @@ const listingConfig = amazonPropertySelectValuesListingConfigConstructor(t, prop
         :query-key="listingQueryKey"
         :fixed-filter-variables="{'salesChannel': {'id': {exact: salesChannelId}}}"
       >
-        <template #bulkActions="{ selectedEntities }">
+        <template #bulkActions="{ selectedEntities, query }">
           <BulkAmazonPropertySelectValueAssigner
             :selected-entities="selectedEntities"
-            @started="clearSelection"
+            @started="clearSelection(query)"
           />
         </template>
       </GeneralListing>

--- a/src/shared/components/organisms/general-listing/GeneralListing.vue
+++ b/src/shared/components/organisms/general-listing/GeneralListing.vue
@@ -35,7 +35,7 @@ const props = withDefaults(
     }
 );
 const slots = defineSlots<{
-  bulkActions?: (scope: { selectedEntities: string[]; viewType: string }) => any;
+  bulkActions?: (scope: { selectedEntities: string[]; viewType: string; query: any }) => any;
 }>();
 
 
@@ -252,7 +252,7 @@ defineExpose({
                   {{ t('shared.button.deleteAll') }}
                 </button>
 
-                <slot name="bulkActions" v-bind="{ selectedEntities, viewType }" />
+                <slot name="bulkActions" v-bind="{ selectedEntities, viewType, query }" />
               </div>
               <!-- Select All control -->
               <div v-if="viewType === 'grid' && haveBulk" class="flex items-center mt-1">
@@ -286,7 +286,7 @@ defineExpose({
                   {{ t('shared.button.deleteAll') }}
                 </button>
 
-                <slot name="bulkActions" v-bind="{ selectedEntities, viewType }" />
+                  <slot name="bulkActions" v-bind="{ selectedEntities, viewType, query }" />
               </div>
                 <div :class="data[queryKey].edges.length > 0 ? 'table-responsive custom-table-scroll' : ''">
                   <table class="w-full min-w-max divide-y divide-gray-300 table-hover">


### PR DESCRIPTION
## Summary
- expose the query object for `GeneralListing` bulk action slots
- allow Amazon property value assigner to refetch after bulk action

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667c90fbb8832e9d06c87a488ce3b8

## Summary by Sourcery

Expose and utilize the listing query refetch method within bulk actions to refresh data after Amazon property value assignments

Enhancements:
- Expose the query object in the bulkActions slot of GeneralListing to enable data refetching.
- Invoke query.refetch() in AmazonPropertySelectValues after clearing selections on bulk actions.