### PR TITLE
Feature/amazon

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
@@ -339,7 +339,7 @@ useShiftBackspaceKeyboardListener(goBack);
       </template>
 
       <template #units>
-        <div class="max-h-[700px] overflow-y-auto border rounded-md custom-scrollbar">
+        <div class="max-h-[700px] overflow-y-auto  rounded-md custom-scrollbar">
           <table class="table-auto w-full">
             <thead>
               <tr>

--- a/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
@@ -339,29 +339,31 @@ useShiftBackspaceKeyboardListener(goBack);
       </template>
 
       <template #units>
-        <table class="table-auto w-full">
-          <thead>
-            <tr>
-              <th>{{ t('shared.labels.name') }}</th>
-              <th>{{ t('integrations.show.properties.labels.code') }}</th>
-              <th>{{ t('shared.labels.unit') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(config, index) in unitConfigurators" :key="config.id">
-              <td>{{ config.name }}</td>
-              <td>{{ config.code }}</td>
-              <td>
-                <Selector
-                  v-model="config.selectedUnit"
-                  :options="config.choices"
-                  label-by="name"
-                  value-by="value"
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="max-h-[700px] overflow-y-auto border rounded-md custom-scrollbar">
+          <table class="table-auto w-full">
+            <thead>
+              <tr>
+                <th>{{ t('shared.labels.name') }}</th>
+                <th>{{ t('integrations.show.properties.labels.code') }}</th>
+                <th>{{ t('shared.labels.unit') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(config, index) in unitConfigurators" :key="config.id">
+                <td>{{ config.name }}</td>
+                <td>{{ config.code }}</td>
+                <td>
+                  <Selector
+                    v-model="config.selectedUnit"
+                    :options="config.choices"
+                    label-by="name"
+                    value-by="value"
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </template>
     </Accordion>
 
@@ -397,3 +399,30 @@ useShiftBackspaceKeyboardListener(goBack);
     {{ t('integrations.show.amazonNotConnectedBanner.content') }}
   </div>
 </template>
+
+<style scoped>
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 10px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #4361EE;
+  border-radius: 10px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: #c0c0c0;
+}
+
+.custom-scrollbar {
+  padding-right: 15px;
+}
+
+</style>

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
@@ -15,6 +15,7 @@ const { t } = useI18n();
 const router = useRouter();
 
 const canStartMapping = ref(false);
+const generalListingRef = ref<any>(null);
 
 const fetchFirstUnmapped = async () => {
   const { data } = await apolloClient.query({
@@ -46,6 +47,10 @@ const startMapping = async () => {
   }
 };
 
+const clearSelection = () => {
+  generalListingRef.value?.clearSelected?.()
+}
+
 const searchConfig = amazonPropertySelectValuesSearchConfigConstructor(t, props.salesChannelId);
 const listingConfig = amazonPropertySelectValuesListingConfigConstructor(t, props.id);
 </script>
@@ -60,6 +65,7 @@ const listingConfig = amazonPropertySelectValuesListingConfigConstructor(t, prop
 
     <template v-slot:content>
       <GeneralListing
+        ref="generalListingRef"
         :search-config="searchConfig"
         :config="listingConfig"
         :query="listingQuery"
@@ -69,7 +75,7 @@ const listingConfig = amazonPropertySelectValuesListingConfigConstructor(t, prop
         <template #bulkActions="{ selectedEntities }">
           <BulkAmazonPropertySelectValueAssigner
             :selected-entities="selectedEntities"
-            @started="emit('pull-data')"
+            @started="clearSelection"
           />
         </template>
       </GeneralListing>

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
@@ -1,5 +1,11 @@
 import {FieldType, PropertyTypes} from "../../../../../../../../shared/utils/constants";
-import { amazonPropertySelectValuesQuery, getAmazonPropertySelectValueQuery, amazonPropertiesQuery, amazonChannelsQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
+import {
+  amazonPropertySelectValuesQuery,
+  getAmazonPropertySelectValueQuery,
+  amazonPropertiesQuery,
+  amazonChannelsQuery,
+  salesChannelViewsQuery
+} from "../../../../../../../../shared/api/queries/salesChannels.js";
 import { propertySelectValuesQuery } from "../../../../../../../../shared/api/queries/properties.js";
 import { selectValueOnTheFlyConfig } from "../../../../../../../properties/property-select-values/configs";
 import { updateAmazonPropertySelectValueMutation } from "../../../../../../../../shared/api/mutations/salesChannels.js";
@@ -54,15 +60,15 @@ export const amazonPropertySelectValuesSearchConfigConstructor = (t: Function, s
       type: FieldType.Query,
       name: 'marketplace',
       label: t('integrations.show.propertySelectValues.labels.marketplace'),
-      labelBy: 'hostname',
+      labelBy: 'name',
       valueBy: 'id',
-      query: amazonChannelsQuery,
-      dataKey: 'amazonChannels',
+      query: salesChannelViewsQuery,
+      dataKey: 'salesChannelViews',
       filterable: true,
       isEdge: true,
       addLookup: true,
       lookupKeys: ['id'],
-      queryVariables: { filters: { id: { exact: salesChannelId } } }
+      queryVariables: { filters: { salesChannel: { id: { exact: salesChannelId } } } }
     }
   ],
   orders: []

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
@@ -96,6 +96,7 @@ export const amazonPropertySelectValuesListingConfigConstructor = (t: Function, 
   showUrlName: 'integrations.amazonPropertySelectValues.edit',
   addDelete: false,
   addPagination: true,
+  addBulkActions: true,
 });
 
 export const listingQueryKey = 'amazonPropertySelectValues';

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -496,8 +496,8 @@ export const updateAmazonPropertySelectValueMutation = gql`
 
 export const bulkUpdateAmazonPropertySelectValueLocalInstanceMutation = gql`
   mutation bulkUpdateAmazonPropertySelectValueLocalInstance($data: BulkAmazonPropertySelectValueLocalInstanceInput!) {
-    bulkUpdateAmazonPropertySelectValueLocalInstance(data: $data) {
-      ids
+    bulkUpdateAmazonPropertySelectValueLocalInstance(instance: $data) {
+      id
     }
   }
 `;

--- a/src/shared/components/organisms/general-listing/GeneralListing.vue
+++ b/src/shared/components/organisms/general-listing/GeneralListing.vue
@@ -77,7 +77,7 @@ const getUpdatedField = (field, item, index) => {
 const selectedEntities = ref<string[]>([]);
 
 // "haveBulk" is true when either bulk edit or bulk delete is enabled.
-const haveBulk = computed(() => props.config.addBulkEdit || (props.config.addBulkDelete && props.config.bulkDeleteMutation));
+const haveBulk = computed(() => props.config.addBulkEdit || (props.config.addBulkDelete && props.config.bulkDeleteMutation) || props.config.addBulkActions);
 
 // For an individual row, add or remove its ID from the selection.
 const selectCheckbox = (id: string, value: boolean) => {
@@ -275,12 +275,7 @@ defineExpose({
             </div>
 
             <div v-if="viewType === 'table'">
-              <div v-if="selectedEntities.length > 0" class="absolute flex h-12 items-center space-x-3 bg-white"
-                   :class="config.addGridView ? 'left-4 top-4' : 'left-12 top-1 '">
-
-                <span class="text-sm font-semibold text-gray-900">
-                  {{ selectedEntities.length }} {{ t('shared.labels.selected') }}
-                </span>
+              <div v-if="selectedEntities.length > 0" class="flex ml-4 items-center space-x-3 bg-white">
 
                 <button v-if="config.addBulkEdit" type="button"
                         class="inline-flex items-center rounded bg-white px-2 py-1 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-white">

--- a/src/shared/components/organisms/general-listing/listingConfig.ts
+++ b/src/shared/components/organisms/general-listing/listingConfig.ts
@@ -28,6 +28,7 @@ export interface ListingConfig {
   addActions?: boolean;
   addBulkEdit?: boolean;
   addBulkDelete?: boolean;
+  addBulkActions?: boolean;
   bulkDeleteMutation?: any;
   bulkDeleteSuccessAlert?: string;
   bulkDeleteErrorAlert?: string;


### PR DESCRIPTION
## Summary by Sourcery

Add bulk assignment capability for Amazon property select values by integrating a new BulkAmazonPropertySelectValueAssigner component into the listing and wiring a GraphQL mutation, enhance the general listing to support custom bulk actions, and adjust related configs and UI styles.

New Features:
- Introduce a BulkAmazonPropertySelectValueAssigner component to enable bulk assigning of property select values.
- Add a GraphQL mutation (bulkUpdateAmazonPropertySelectValueLocalInstance) for updating multiple Amazon property select value instances at once.

Enhancements:
- Extend GeneralListing to expose the query object to bulkActions slots and add an addBulkActions configuration flag.
- Update Amazon property select values search and listing configs to use salesChannelViews, change labelBy from hostname to name, and adjust filter variables.
- Remove extra border styling from the Amazon general info tab scroll container.

Chores:
- Extend ListingConfig interface to include addBulkActions.
- Add ref clearing logic in AmazonPropertySelectValues to reset selections after bulk actions.