### PR TITLE
Add Amazon default unit dashboard card

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
@@ -13,7 +13,7 @@ import { SecondaryButton } from "../../../../../../../shared/components/atoms/bu
 import { CancelButton } from "../../../../../../../shared/components/atoms/button-cancel";
 import { Toast } from "../../../../../../../shared/modules/toast";
 import { useEnterKeyboardListener, useShiftBackspaceKeyboardListener, useShiftEnterKeyboardListener } from "../../../../../../../shared/modules/keyboard";
-import { useRouter } from 'vue-router';
+import { useRouter, useRoute } from 'vue-router';
 import { updateAmazonSalesChannelMutation } from "../../../../../../../shared/api/mutations/salesChannels.js";
 import { processGraphQLErrors } from "../../../../../../../shared/utils";
 import { AmazonRegions, AmazonCountries } from "../../../../integrations";
@@ -42,6 +42,7 @@ interface EditAmazonForm {
 const props = defineProps<{ data: EditAmazonForm }>();
 const { t } = useI18n();
 const router = useRouter();
+const route = useRoute();
 
 const formData = ref<EditAmazonForm>({ ...props.data });
 const fieldErrors = ref<Record<string, string>>({});
@@ -63,6 +64,8 @@ watch(unitConfigurators, (val) => {
     }));
   }
 }, { deep: true });
+
+const openAccordionItem = computed(() => String(route.query.accordion || ''));
 
 const accordionItems = [
   { name: 'throttling', label: t('integrations.show.sections.throttling'), icon: 'gauge' },
@@ -289,7 +292,7 @@ useShiftBackspaceKeyboardListener(goBack);
       </div>
     </div>
 
-    <Accordion class="mt-8" :items="accordionItems">
+    <Accordion class="mt-8" :items="accordionItems" :default-active="openAccordionItem" :key="openAccordionItem">
       <template #throttling>
         <div class="grid grid-cols-12 gap-4">
           <div class="md:col-span-6 col-span-12">

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -58,7 +58,7 @@ const configTypeChoices = [
 const propertyTypeBadgeMap = getPropertyTypeBadgeMap(t);
 
 const accordionItems = [
-  {name: 'items', label: t('shared.tabs.items'), icon: 'sitemap'},
+  {name: 'items', label: t('integrations.imports.types.schema'), icon: 'sitemap'},
 ];
 
 const setupFormConfig = () => {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -161,6 +161,10 @@
         "unmappedSelectValues": {
           "title": "Unmapped Select Values",
           "description": "Amazon property values that need mapping."
+        },
+        "unmappedDefaultUnitConfigurators": {
+          "title": "Default Unit Configurator",
+          "description": "Amazon unit configurators missing a default unit."
         }
       }
     },

--- a/src/shared/components/atoms/accordion/Accordion.vue
+++ b/src/shared/components/atoms/accordion/Accordion.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import { Icon } from "../../atoms/icon";
 
 interface AccordionItem {
@@ -10,9 +10,24 @@ interface AccordionItem {
 
 const props = defineProps<{
   items: AccordionItem[];
+  defaultActive?: string | null;
 }>();
 
 const activeIndex = ref<number | null>(null);
+
+onMounted(() => {
+  if (props.defaultActive) {
+    const idx = props.items.findIndex(i => i.name === props.defaultActive);
+    if (idx !== -1) activeIndex.value = idx;
+  }
+});
+
+watch(() => props.defaultActive, (val) => {
+  if (val) {
+    const idx = props.items.findIndex(i => i.name === val);
+    if (idx !== -1) activeIndex.value = idx;
+  }
+});
 
 const toggleAccordion = (index: number) => {
   activeIndex.value = activeIndex.value === index ? null : index;


### PR DESCRIPTION
## Summary
- show unmapped Amazon default unit configurators on dashboard
- link card to general tab with units accordion opened
- allow Accordion to open a default item via new prop
- tweak Amazon general tab to read query for accordion
- rename Amazon product type accordion tab to "Schema"
- update English locale

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679e211478832eb22a7316aa20603f

## Summary by Sourcery

Add a new Amazon default unit configurators card to the dashboard with link to the units section of the general tab, extend the Accordion component to open a default item via prop, and sync the Amazon general tab and product type editing UI with the new accordion behavior and labels

New Features:
- Add a dashboard card showing unmapped Amazon default unit configurators
- Allow Accordion to accept a defaultActive prop and open the specified item
- Enable the Amazon general tab to read an "accordion" query parameter and open the corresponding section

Enhancements:
- Rename the Amazon product type accordion tab from "Items" to "Schema"
- Update English locale strings for the new dashboard card and renamed tab