### PR TITLE
Add password toggle guard for disabled inputs

### DIFF
--- a/src/shared/components/atoms/input-text/TextInput.vue
+++ b/src/shared/components/atoms/input-text/TextInput.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
+import { Icon } from '../icon';
 
 const props = defineProps<{
   placeholder?: string;
@@ -25,6 +26,24 @@ const emit = defineEmits({
 });
 
 const input: any = ref(null);
+const showPassword = ref(false);
+
+const togglePasswordVisibility = () => {
+  if (props.disabled) {
+    return;
+  }
+  showPassword.value = !showPassword.value;
+};
+
+const inputType = computed(() => {
+  if (props.secret) {
+    return showPassword.value ? 'text' : 'password';
+  }
+  if (props.number || props.float) {
+    return 'number';
+  }
+  return 'text';
+});
 
 const focus = () => {
   input.value?.focus();
@@ -61,14 +80,14 @@ const handleInput = (event) => {
 </script>
 
 <template>
-  <div v-if="prepend" class="relative mt-2 w-full">
-    <span class="absolute left-4 top-1/2 -translate-y-1/2 text-gray-600">
+  <div v-if="prepend || secret" class="relative mt-2 w-full">
+    <span v-if="prepend" class="absolute left-4 top-1/2 -translate-y-1/2 text-gray-600">
       {{ prepend }}
     </span>
     <input
       ref="input"
-      class="text-input focus:outline-none focus:border-sky-500 focus:ring-sky-500 block rounded-md px-3 py-2 text-sm placeholder:italic focus:ring-1  w-full"
-      :type="secret ? 'password' : (number || float) ? 'number' : 'text'"
+      class="text-input focus:outline-none focus:border-sky-500 focus:ring-sky-500 block rounded-md px-3 py-2 text-sm placeholder:italic focus:ring-1 w-full"
+      :type="inputType"
       :step="float ? 'any' : (number ? '1' : undefined)"
       :min="number && minNumber ? minNumber : undefined"
       :max="number && maxNumber ? maxNumber : undefined"
@@ -86,14 +105,25 @@ const handleInput = (event) => {
       @input="handleInput"
       @focus="$emit('focus')"
       @keyup.enter="blur"
-      :style="{ paddingLeft: prepend ? '2.5rem' : undefined }"
+      :style="{
+        paddingLeft: prepend ? '2.5rem' : undefined,
+        paddingRight: secret ? '2.5rem' : undefined
+      }"
     />
+    <span
+      v-if="secret"
+      class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-600 cursor-pointer"
+      :class="{ 'cursor-not-allowed pointer-events-none': disabled }"
+      @click="togglePasswordVisibility"
+    >
+      <Icon :name="showPassword ? 'eye-slash' : 'eye'" />
+    </span>
   </div>
   <input
     v-else
     ref="input"
     class="text-input focus:outline-none focus:border-sky-500 focus:ring-sky-500 block rounded-md px-3 py-2 text-sm placeholder:italic focus:ring-1"
-    :type="secret ? 'password' : (number || float) ? 'number' : 'text'"
+    :type="inputType"
     :step="float ? 'any' : (number ? '1' : undefined)"
     :min="number && minNumber ? minNumber : undefined"
     :max="number && maxNumber ? maxNumber : undefined"

--- a/src/shared/plugins/font-awesome.ts
+++ b/src/shared/plugins/font-awesome.ts
@@ -58,6 +58,7 @@ import {
   faStar,
   faStarHalf,
   faEye,
+  faEyeSlash,
   faArrowUp,
   faArrowDown,
   faArrowRightArrowLeft,
@@ -211,6 +212,7 @@ library.add(faHourglassStart as IconDefinition);
 library.add(faStar as IconDefinition);
 library.add(faStarHalf as IconDefinition);
 library.add(faEye as IconDefinition);
+library.add(faEyeSlash as IconDefinition);
 library.add(faArrowUp as IconDefinition);
 library.add(faArrowRightArrowLeft as IconDefinition);
 library.add(faBullseye as IconDefinition);


### PR DESCRIPTION
## Summary
- prevent password visibility toggle when TextInput is disabled
- disable pointer events for the eye icon if the input is disabled

## Testing
- `npm run build` *(fails: vue-tsc not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b98557b80832eaf0170ce04e9dac4

## Summary by Sourcery

Add and style a password visibility toggle for secret inputs, guard it when inputs are disabled, streamline type logic via a computed property, and include the hide icon in the FontAwesome setup.

New Features:
- Add a password visibility toggle with an eye icon to secret TextInput components

Enhancements:
- Disable the eye icon’s pointer events and toggle action when the input is disabled
- Compute the input type with a computed property for clearer type handling
- Add right padding to secret inputs to accommodate the eye icon
- Register the faEyeSlash icon in the FontAwesome plugin for toggle functionality