### PR TITLE
Add Shopify API credential fields

### DIFF
--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/shopify/ShopifyChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/shopify/ShopifyChannelInfoStep.vue
@@ -2,6 +2,7 @@
 import { computed, defineProps } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Label } from "../../../../../../../shared/components/atoms/label";
+import { TextInput } from "../../../../../../../shared/components/atoms/input-text";
 import { ShopifyChannelInfo } from '../../../../integrations';
 import { Icon } from "../../../../../../../shared/components/atoms/icon";
 import { Button } from "../../../../../../../shared/components/atoms/button";
@@ -77,6 +78,31 @@ const propertyField = computed(() => ({
                 <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
                   <p>{{ t('integrations.salesChannel.helpText.shopifyVendorProperty') }}</p>
                 </div>
+              </FlexCell>
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.apiKey') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                    class="w-96"
+                    v-model="channelInfo.apiKey"
+                    :placeholder="t('integrations.placeholders.apiKey')"
+                />
+              </FlexCell>
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.apiSecret') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                    class="w-96"
+                    v-model="channelInfo.apiSecret"
+                    :placeholder="t('integrations.placeholders.apiSecret')"
+                    :secret="true"
+                />
               </FlexCell>
             </Flex>
           </FlexCell>

--- a/src/core/integrations/integrations/integrations-show/containers/general/shopify-general-tab/ShopifyGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/shopify-general-tab/ShopifyGeneralInfoTab.vue
@@ -37,6 +37,8 @@ interface EditShopifyForm {
   syncEanCodes: boolean;
   syncPrices: boolean;
   importOrders: boolean;
+  apiKey: string;
+  apiSecret: string;
   accessToken?: string;
   state?: string;
   vendorProperty: {
@@ -176,23 +178,38 @@ useShiftBackspaceKeyboardListener(goBack);
       </div>
     </div>
 
-    <div class="grid grid-cols-12 gap-4">
-      <div class="md:col-span-6 col-span-12">
-        <Flex vertical>
-          <FlexCell>
-            <Label class="font-semibold block text-sm leading-6 text-gray-900">
-              {{ t('integrations.labels.vendorProperty') }}
-            </Label>
-          </FlexCell>
-          <FlexCell>
-            <FieldQuery v-model="formData.vendorProperty.id" :field="propertyField as QueryFormField" />
-            <div class="mt-1 text-sm leading-6 text-gray-400">
-              <p>{{ t('integrations.salesChannel.helpText.shopifyVendorProperty') }}</p>
-            </div>
-          </FlexCell>
-        </Flex>
-      </div>
+  <div class="grid grid-cols-12 gap-4">
+    <div class="md:col-span-6 col-span-12">
+      <Flex vertical>
+        <FlexCell>
+          <Label class="font-semibold block text-sm leading-6 text-gray-900">
+            {{ t('integrations.labels.vendorProperty') }}
+          </Label>
+        </FlexCell>
+        <FlexCell>
+          <FieldQuery v-model="formData.vendorProperty.id" :field="propertyField as QueryFormField" />
+          <div class="mt-1 text-sm leading-6 text-gray-400">
+            <p>{{ t('integrations.salesChannel.helpText.shopifyVendorProperty') }}</p>
+          </div>
+        </FlexCell>
+      </Flex>
     </div>
+  </div>
+
+  <div class="grid grid-cols-12 gap-4">
+    <div class="md:col-span-6 col-span-12">
+      <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+        {{ t('integrations.labels.apiKey') }}
+      </Label>
+      <TextInput v-model="formData.apiKey" disabled class="w-full" />
+    </div>
+    <div class="md:col-span-6 col-span-12">
+      <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+        {{ t('integrations.labels.apiSecret') }}
+      </Label>
+      <TextInput v-model="formData.apiSecret" disabled :secret="true" class="w-full" />
+    </div>
+  </div>
 
     <!-- Accordion -->
     <Accordion class="mt-8" :items="accordionItems">

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -84,6 +84,8 @@ export interface MagentoChannelInfo extends SpecificChannelInfo {
 
 export interface ShopifyChannelInfo extends SpecificChannelInfo {
   vendorProperty: { id: string | null };
+  apiKey: string;
+  apiSecret: string;
   hmac?: string;
   host?: string;
   timestamp?: string;
@@ -117,6 +119,8 @@ export function getMagentoDefaultFields(): MagentoChannelInfo {
 export function getShopifyDefaultFields(): ShopifyChannelInfo {
   return {
     vendorProperty: { id: null },
+    apiKey: '',
+    apiSecret: '',
   };
 }
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2349,6 +2349,8 @@
       "attributeSetSkeletonId": "Attribute Set Skeleton ID",
       "eanCodeAttribute": "EAN Code Attribute",
       "vendorProperty": "Vendor Property",
+      "apiKey": "API Key",
+      "apiSecret": "API Secret",
       "region": "Region",
       "country": "Country",
       "expirationDate": "Access Token Expiration",
@@ -2359,7 +2361,9 @@
       "hostApiUsername": "Enter API Username",
       "hostApiKey": "Enter Access Token",
       "attributeSetSkeletonId": "Enter attribute set skeleton ID",
-      "eanCodeAttribute": "Enter EAN code attribute"
+      "eanCodeAttribute": "Enter EAN code attribute",
+      "apiKey": "Enter API Key",
+      "apiSecret": "Enter API Secret"
     },
     "regions": {
       "northAmerica": "North America",

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -84,6 +84,8 @@ export const getShopifyChannelQuery = gql`
       syncEanCodes
       syncPrices
       importOrders
+      apiKey
+      apiSecret
       accessToken
       firstImportComplete
       isImporting


### PR DESCRIPTION
## Summary
- add `apiKey` and `apiSecret` to Shopify integration model
- request and display API credentials in Shopify create step
- show API credentials in Shopify general tab as read-only
- fetch API credentials via GraphQL
- provide English translations for new fields

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bcce658d8832e98740ac5dfae72b9

## Summary by Sourcery

Add support for Shopify API credentials by extending the integration model, UI forms, and GraphQL queries to handle apiKey and apiSecret fields.

New Features:
- Introduce apiKey and apiSecret fields in the ShopifyChannelInfo model with default values.
- Allow entering API credentials in the Shopify channel creation step.
- Display API credentials as read-only fields in the Shopify general settings tab.
- Fetch apiKey and apiSecret via the Salesforce Channels GraphQL query.

Documentation:
- Add English translations for the new apiKey and apiSecret labels and placeholders.