### PR TITLE
Refactor TypeStep modal handling

### DIFF
--- a/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
@@ -10,9 +10,9 @@ import { OptionSelector } from "../../../../../../shared/components/molecules/op
 import { Image } from "../../../../../../shared/components/atoms/image";
 import { Icon } from "../../../../../../shared/components/atoms/icon";
 import { Modal } from "../../../../../../shared/components/atoms/modal";
-import { Card } from "../../../../../../shared/components/atoms/card";
 import {Badge} from "../../../../../../shared/components/atoms/badge";
 import {Button} from "../../../../../../shared/components/atoms/button";
+import { MagentoInfoCard, WoocommerceInfoCard } from "./info-cards";
 
 const props = defineProps<{ type: IntegrationTypes }>();
 const emit = defineEmits<{ (e: 'update:type', value: IntegrationTypes): void }>();
@@ -20,8 +20,8 @@ const emit = defineEmits<{ (e: 'update:type', value: IntegrationTypes): void }>(
 const { t } = useI18n();
 
 const selectedType = ref(props.type);
-const showMagentoInfoModal = ref(false);
-const showWoocommerceInfoModal = ref(false);
+const showInfoModal = ref(false);
+const infoComponent = ref();
 
 watch(selectedType, (newVal) => {
   emit('update:type', newVal);
@@ -42,20 +42,18 @@ const typeChoices = [
 ];
 
 const onModalOpen = () => {
-  showMagentoInfoModal.value = true;
-}
-
-const closeModal = () => {
-  showMagentoInfoModal.value = false;
-}
+  infoComponent.value = MagentoInfoCard;
+  showInfoModal.value = true;
+};
 
 const onWoocommerceModalOpen = () => {
-  showWoocommerceInfoModal.value = true;
-}
+  infoComponent.value = WoocommerceInfoCard;
+  showInfoModal.value = true;
+};
 
-const closeWoocommerceModal = () => {
-  showWoocommerceInfoModal.value = false;
-}
+const closeModal = () => {
+  showInfoModal.value = false;
+};
 
 </script>
 
@@ -64,93 +62,8 @@ const closeWoocommerceModal = () => {
     <h1 class="text-2xl text-center mb-2">
       {{ t('integrations.create.wizard.step1.content') }}
     </h1>
-    <Modal v-if="showMagentoInfoModal" v-model="showMagentoInfoModal" @closed="showMagentoInfoModal = false">
-      <Card class="modal-content w-[80%] px-10 pt-10">
-        <div class="mb-6">
-          <h3 class="text-xl font-semibold leading-7 text-gray-900">
-            {{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationTitle') }}
-          </h3>
-        </div>
-        <div class="space-y-6 pr-2 mb=4 overflow-y-auto max-h-96">
-          <div>
-            <p class="text-sm text-gray-700">
-              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationDescription') }}
-            </p>
-            <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
-              <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationStep1') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationStep2') }}</li>
-            </ul>
-          </div>
-
-          <div>
-            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSettingsTitle') }}</h4>
-            <p class="text-sm text-gray-700">
-              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSettingsDescription') }}
-            </p>
-            <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
-              <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSetting1') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSetting2') }}</li>
-            </ul>
-          </div>
-
-          <div>
-            <h4 class="text-lg font-semibold text-red-500">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.legacyAuthTitle') }}</h4>
-            <p class="text-sm text-gray-700">
-              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.legacyAuthWarning') }}
-            </p>
-          </div>
-
-          <div>
-            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.importTitle') }}</h4>
-            <p class="text-sm text-gray-700">
-              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.importRecommendation') }}
-            </p>
-          </div>
-
-          <div>
-            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.eanTitle') }}</h4>
-            <p class="text-sm text-gray-700">
-              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.eanDescription') }}
-            </p>
-          </div>
-        </div>
-
-        <hr/>
-        <div class="flex justify-end gap-4 mt-4">
-          <Button class="btn btn-outline-dark" @click="closeModal">{{ t('shared.button.cancel') }}</Button>
-        </div>
-      </Card>
-    </Modal>
-    <Modal v-if="showWoocommerceInfoModal" v-model="showWoocommerceInfoModal" @closed="showWoocommerceInfoModal = false">
-      <Card class="modal-content w-[80%] px-10 pt-10">
-        <div class="mb-6">
-          <h3 class="text-xl font-semibold leading-7 text-gray-900">
-            {{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationTitle') }}
-          </h3>
-        </div>
-        <div class="space-y-6 pr-2 mb=4 overflow-y-auto max-h-96">
-          <div>
-            <p class="text-sm text-gray-700">
-              {{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationDescription') }}
-            </p>
-            <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
-              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep1') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep2') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep3') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep4') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep5') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep6') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep7') }}</li>
-              <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep8') }}</li>
-            </ul>
-          </div>
-        </div>
-
-        <hr/>
-        <div class="flex justify-end gap-4 mt-4">
-          <Button class="btn btn-outline-dark" @click="closeWoocommerceModal">{{ t('shared.button.cancel') }}</Button>
-        </div>
-      </Card>
+    <Modal v-if="showInfoModal" v-model="showInfoModal" @closed="showInfoModal = false">
+      <component :is="infoComponent" @close="closeModal" />
     </Modal>
     <hr />
     <!-- OptionSelector uses v-model bound to our local selectedType and the choices array -->

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/MagentoInfoCard.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/MagentoInfoCard.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Card } from '../../../../../../../shared/components/atoms/card';
+import { Button } from '../../../../../../../shared/components/atoms/button';
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+const { t } = useI18n();
+const close = () => emit('close');
+</script>
+
+<template>
+  <Card class="modal-content w-[80%] px-10 pt-10">
+    <div class="mb-6">
+      <h3 class="text-xl font-semibold leading-7 text-gray-900">
+        {{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationTitle') }}
+      </h3>
+    </div>
+    <div class="space-y-6 pr-2 mb=4 overflow-y-auto max-h-96">
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationDescription') }}
+        </p>
+        <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
+          <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationStep1') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationStep2') }}</li>
+        </ul>
+      </div>
+
+      <div>
+        <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSettingsTitle') }}</h4>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSettingsDescription') }}
+        </p>
+        <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
+          <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSetting1') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSetting2') }}</li>
+        </ul>
+      </div>
+
+      <div>
+        <h4 class="text-lg font-semibold text-red-500">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.legacyAuthTitle') }}</h4>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.legacyAuthWarning') }}
+        </p>
+      </div>
+
+      <div>
+        <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.importTitle') }}</h4>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.importRecommendation') }}
+        </p>
+      </div>
+
+      <div>
+        <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.eanTitle') }}</h4>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.eanDescription') }}
+        </p>
+      </div>
+    </div>
+
+    <hr/>
+    <div class="flex justify-end gap-4 mt-4">
+      <Button class="btn btn-outline-dark" @click="close">{{ t('shared.button.cancel') }}</Button>
+    </div>
+  </Card>
+</template>

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/WoocommerceInfoCard.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/WoocommerceInfoCard.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Card } from '../../../../../../../shared/components/atoms/card';
+import { Button } from '../../../../../../../shared/components/atoms/button';
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+const { t } = useI18n();
+const close = () => emit('close');
+</script>
+
+<template>
+  <Card class="modal-content w-[80%] px-10 pt-10">
+    <div class="mb-6">
+      <h3 class="text-xl font-semibold leading-7 text-gray-900">
+        {{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationTitle') }}
+      </h3>
+    </div>
+    <div class="space-y-6 pr-2 mb=4 overflow-y-auto max-h-96">
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationDescription') }}
+        </p>
+        <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
+          <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep1') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep2') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep3') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep4') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep5') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep6') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep7') }}</li>
+          <li>{{ t('integrations.create.wizard.step1.woocommerceInfoModal.section.integrationStep8') }}</li>
+        </ul>
+      </div>
+    </div>
+
+    <hr/>
+    <div class="flex justify-end gap-4 mt-4">
+      <Button class="btn btn-outline-dark" @click="close">{{ t('shared.button.cancel') }}</Button>
+    </div>
+  </Card>
+</template>

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/index.ts
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/index.ts
@@ -1,0 +1,2 @@
+export { default as MagentoInfoCard } from './MagentoInfoCard.vue';
+export { default as WoocommerceInfoCard } from './WoocommerceInfoCard.vue';

--- a/src/shared/components/molecules/wizard/Wizard.vue
+++ b/src/shared/components/molecules/wizard/Wizard.vue
@@ -111,26 +111,29 @@ useEnterKeyboardListener(onNextPressed);
   <div class="tab-content mt-4">
     <slot :name="steps[currentStep].name"></slot>
   </div>
-  <div v-if="showButtons" class="flex justify-end mt-8">
-    <CancelButton
-      v-if="addSkip"
-      @click="goToStep(steps.length - 1)"
-    >
-      {{ t('shared.button.skip') }}
-    </CancelButton>
-    <CancelButton
-      v-if="currentStep > 0"
-      @click="previousStep"
-    >
-      {{ t('shared.button.back') }}
-    </CancelButton>
-    <PrimaryButton
-      ref="nextButtonRef"
-      :disabled="!allowNextStep"
-      @click="nextStep"
-    >
-      {{ currentStep === steps.length - 1 ? t('shared.button.finish') : t('shared.button.next') }}
-    </PrimaryButton>
+  <div v-if="showButtons" class="flex justify-between items-center mt-8">
+    <slot name="additionalButtons"></slot>
+    <div class="flex justify-end gap-2">
+      <CancelButton
+        v-if="addSkip"
+        @click="goToStep(steps.length - 1)"
+      >
+        {{ t('shared.button.skip') }}
+      </CancelButton>
+      <CancelButton
+        v-if="currentStep > 0"
+        @click="previousStep"
+      >
+        {{ t('shared.button.back') }}
+      </CancelButton>
+      <PrimaryButton
+        ref="nextButtonRef"
+        :disabled="!allowNextStep"
+        @click="nextStep"
+      >
+        {{ currentStep === steps.length - 1 ? t('shared.button.finish') : t('shared.button.next') }}
+      </PrimaryButton>
+    </div>
   </div>
   </Card>
 </template>


### PR DESCRIPTION
## Summary
- replace separate Magento/WooCommerce modals with a single dynamic modal
- move modal card content into new components
- wire icons to open the modal with the right content
- expose an additionalButtons slot in the wizard component
- surface the info icon across all wizard steps

## Testing
- `npm install --ignore-scripts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bcd95ae08832e957a95f73402432f

## Summary by Sourcery

Refactor integration wizard to consolidate separate Magento/WooCommerce modals into one dynamic modal driven by new info-card components and expose an info button via a new Wizard slot for consistent access across steps.

New Features:
- Introduce a single dynamic modal to display Magento and WooCommerce integration info
- Expose an additionalButtons slot in the Wizard component to allow custom buttons
- Surface an info icon on all wizard steps to trigger the info modal

Enhancements:
- Extract Magento and WooCommerce modal content into reusable info-card components
- Refactor TypeStep and IntegrationCreateController to use the dynamic info modal
- Unify modal open/close logic by using a component reference instead of separate flags