### PR TITLE
Add Shopify info modal

### DIFF
--- a/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
+++ b/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
@@ -6,7 +6,7 @@ import { Breadcrumbs } from "../../../../shared/components/molecules/breadcrumbs
 import { Wizard } from "../../../../shared/components/molecules/wizard";
 import { Icon } from "../../../../shared/components/atoms/icon";
 import { Modal } from "../../../../shared/components/atoms/modal";
-import { MagentoInfoCard, WoocommerceInfoCard } from "./containers/type-step/info-cards";
+import { MagentoInfoCard, WoocommerceInfoCard, ShopifyInfoCard } from "./containers/type-step/info-cards";
 import GeneralTemplate from "../../../../shared/templates/GeneralTemplate.vue";
 import {useRoute, useRouter} from "vue-router";
 import {
@@ -122,6 +122,8 @@ const updateStep = (val) => {
 const openInfoModal = () => {
   if (selectedIntegrationType.value === IntegrationTypes.Magento) {
     infoComponent.value = MagentoInfoCard;
+  } else if (selectedIntegrationType.value === IntegrationTypes.Shopify) {
+    infoComponent.value = ShopifyInfoCard;
   } else if (selectedIntegrationType.value === IntegrationTypes.Woocommerce) {
     infoComponent.value = WoocommerceInfoCard;
   } else {

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
@@ -12,7 +12,7 @@ import { Icon } from "../../../../../../shared/components/atoms/icon";
 import { Modal } from "../../../../../../shared/components/atoms/modal";
 import {Badge} from "../../../../../../shared/components/atoms/badge";
 import {Button} from "../../../../../../shared/components/atoms/button";
-import { MagentoInfoCard, WoocommerceInfoCard } from "./info-cards";
+import { MagentoInfoCard, WoocommerceInfoCard, ShopifyInfoCard } from "./info-cards";
 
 const props = defineProps<{ type: IntegrationTypes }>();
 const emit = defineEmits<{ (e: 'update:type', value: IntegrationTypes): void }>();
@@ -43,6 +43,11 @@ const typeChoices = [
 
 const onModalOpen = () => {
   infoComponent.value = MagentoInfoCard;
+  showInfoModal.value = true;
+};
+
+const onShopifyModalOpen = () => {
+  infoComponent.value = ShopifyInfoCard;
   showInfoModal.value = true;
 };
 
@@ -84,7 +89,14 @@ const closeModal = () => {
       </template>
       <template #shopify>
         <div>
-          <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.shopifyTitle') }}</h3>
+          <Flex gap="2">
+            <FlexCell center>
+              <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.shopifyTitle') }}</h3>
+            </FlexCell>
+            <FlexCell center>
+              <Icon class="text-gray-500" @click.stop="onShopifyModalOpen" name="circle-info" size="lg" />
+            </FlexCell>
+          </Flex>
           <p class="mb-4">{{ t('integrations.create.wizard.step1.shopifyExample') }}</p>
           <Image :source="shopifyType" alt="Shopify" class="w-full max-h-[35rem]" />
         </div>

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/ShopifyInfoCard.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/ShopifyInfoCard.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Card } from '../../../../../../../shared/components/atoms/card';
+import { Button } from '../../../../../../../shared/components/atoms/button';
+import { Icon } from '../../../../../../../shared/components/atoms/icon';
+import { Toast } from '../../../../../../../shared/modules/toast';
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+const { t } = useI18n();
+const close = () => emit('close');
+
+const copyToClipboard = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText(text);
+    Toast.success(t('shared.alert.toast.clipboardSuccess'));
+  } catch (err) {
+    console.error('Failed to copy:', err);
+    Toast.error(t('shared.alert.toast.clipboardFail'));
+  }
+};
+</script>
+
+<template>
+  <Card class="modal-content w-[80%] px-10 pt-10">
+    <div class="mb-6">
+      <h3 class="text-xl font-semibold leading-7 text-gray-900">
+        {{ t('integrations.create.wizard.step1.shopifyInfoModal.title') }}
+      </h3>
+    </div>
+    <div class="space-y-8 pr-2 mb-4 overflow-y-auto max-h-96">
+      <!-- Step 1 -->
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.integrationStep1') }}
+        </p>
+      </div>
+
+      <!-- Step 2 -->
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.integrationStep2') }}
+        </p>
+      </div>
+
+      <!-- Step 3 -->
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.integrationStep3') }}
+        </p>
+      </div>
+
+      <!-- Step 4 -->
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.integrationStep4') }}
+        </p>
+      </div>
+
+      <!-- Step 5 -->
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.integrationStep5') }}
+        </p>
+      </div>
+
+      <!-- Step 6 with URLs -->
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.integrationStep6') }}
+        </p>
+        <div class="mt-2 space-y-2">
+          <label class="text-sm font-semibold block text-gray-900">
+            {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.appUrlLabel') }}
+          </label>
+          <div class="relative mt-1 rounded-lg shadow-sm">
+            <input disabled type="text" value="https://onesila.app/integrations/shopify/entry" class="w-full rounded-lg border-0 py-1.5 pl-2 pr-12 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" />
+            <div class="absolute inset-y-0 right-0 flex items-center pr-3">
+              <Button @click="copyToClipboard('https://onesila.app/integrations/shopify/entry')" class="ml-4 flex-shrink-0">
+                <Icon name="clipboard" class="h-5 w-5 text-gray-500" aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
+          <label class="text-sm font-semibold block text-gray-900">
+            {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.allowedRedirectUrlLabel') }}
+          </label>
+          <div class="relative mt-1 rounded-lg shadow-sm">
+            <input disabled type="text" value="https://onesila.app/integrations/shopify/installed" class="w-full rounded-lg border-0 py-1.5 pl-2 pr-12 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" />
+            <div class="absolute inset-y-0 right-0 flex items-center pr-3">
+              <Button @click="copyToClipboard('https://onesila.app/integrations/shopify/installed')" class="ml-4 flex-shrink-0">
+                <Icon name="clipboard" class="h-5 w-5 text-gray-500" aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Step 7 -->
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.integrationStep7') }}
+        </p>
+      </div>
+
+      <!-- Step 8 -->
+      <div>
+        <p class="text-sm text-gray-700">
+          {{ t('integrations.create.wizard.step1.shopifyInfoModal.section.integrationStep8') }}
+        </p>
+      </div>
+    </div>
+
+    <hr />
+    <div class="flex justify-end gap-4 mt-4">
+      <Button class="btn btn-outline-dark" @click="close">{{ t('shared.button.cancel') }}</Button>
+    </div>
+  </Card>
+</template>

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/index.ts
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/index.ts
@@ -1,2 +1,3 @@
 export { default as MagentoInfoCard } from './MagentoInfoCard.vue';
 export { default as WoocommerceInfoCard } from './WoocommerceInfoCard.vue';
+export { default as ShopifyInfoCard } from './ShopifyInfoCard.vue';

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2305,6 +2305,23 @@
               "eanTitle": "EAN codes support",
               "eanDescription": "If you want to sync EAN codes, make sure you have an attribute with global scope in Magento. Don't worry, missing ones can also be created during the import process."
             }
+          },
+          "shopifyInfoModal": {
+            "title": "How to connect your Shopify store",
+            "section": {
+              "integrationTitle": "Create your Shopify app",
+              "integrationDescription": "Follow these steps to set up a custom app in Shopify:",
+              "integrationStep1": "From the sidebar click Apps and then All apps.",
+              "integrationStep2": "Click Create app.",
+              "integrationStep3": "Select 'Create app manually', choose a name like 'OneSila' and click Create.",
+                "integrationStep4": "In another tab go to your admin store and in the Sales channels sidebar click 'View your online store'. This opens your website. Copy the URL from the browser.",
+                "integrationStep5": "Click 'Choose distribution', select 'Custom distribution', click Select and confirm. When prompted for Store domain, paste the domain from the previous step.",
+              "integrationStep6": "Go to Configuration and set the App URL and Allowed redirection URL(s) below, then save.",
+                "integrationStep7": "At step 2 of the Shopify wizard you will need the URL from step 4. Go to Overview and follow the wizard until step 4, then copy the Client ID and Client Secret into the fields.",
+              "integrationStep8": "After the final step you will be redirected to Shopify admin. Click Install.",
+              "appUrlLabel": "App URL",
+              "allowedRedirectUrlLabel": "Allowed redirection URL(s)"
+            }
           }
         },
         "step2": {


### PR DESCRIPTION
## Summary
- implement ShopifyInfoCard component with clipboard-friendly URLs
- wire Shopify modal into type step chooser and create controller
- export ShopifyInfoCard and update English translations
- remove placeholder Shopify images and tweak instructions

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd713a2c8832e86b84b8b80a606a8

## Summary by Sourcery

Introduce a Shopify info modal in the integration creation flow to display setup instructions with clipboard-friendly URLs.

New Features:
- Add ShopifyInfoCard component showing step-by-step Shopify integration instructions and copy-to-clipboard URLs
- Integrate ShopifyInfoCard into the type-step chooser and the IntegrationCreateController to trigger the info modal

Enhancements:
- Update English translations for Shopify modal content
- Remove placeholder Shopify images and refine setup instructions styling