### PR TITLE
Add translation for Shopify info card headers

### DIFF
--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/ShopifyInfoCard.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/ShopifyInfoCard.vue
@@ -40,7 +40,13 @@ const copyToClipboard = async (text: string) => {
     <div class="space-y-10 pr-2 mb-4 overflow-y-auto max-h-96">
       <!-- Create custom app -->
       <div class="space-y-4">
-        <h4 class="text-lg font-semibold">Create Custom App</h4>
+        <h4 class="text-lg font-semibold">
+          {{
+            t(
+              "integrations.create.wizard.step1.shopifyInfoModal.section.customAppTitle",
+            )
+          }}
+        </h4>
         <p class="text-sm text-gray-700">
           {{
             t(
@@ -76,7 +82,13 @@ const copyToClipboard = async (text: string) => {
 
       <!-- Detect website url -->
       <div class="space-y-2">
-        <h4 class="text-lg font-semibold">Detect Website URL</h4>
+        <h4 class="text-lg font-semibold">
+          {{
+            t(
+              "integrations.create.wizard.step1.shopifyInfoModal.section.detectWebsiteUrlTitle",
+            )
+          }}
+        </h4>
         <div class="md:grid md:grid-cols-12 md:gap-4 items-start">
           <p class="text-sm text-gray-700 md:col-span-9">
             {{
@@ -95,7 +107,13 @@ const copyToClipboard = async (text: string) => {
 
       <!-- Configure distribution -->
       <div class="space-y-4">
-        <h4 class="text-lg font-semibold">Configure Distribution</h4>
+        <h4 class="text-lg font-semibold">
+          {{
+            t(
+              "integrations.create.wizard.step1.shopifyInfoModal.section.configureDistributionTitle",
+            )
+          }}
+        </h4>
 
         <div class="md:grid md:grid-cols-2 md:gap-4 items-start">
           <p class="text-sm text-gray-700">
@@ -145,7 +163,13 @@ const copyToClipboard = async (text: string) => {
 
       <!-- Configure urls -->
       <div class="space-y-4">
-        <h4 class="text-lg font-semibold">Configure URLs</h4>
+        <h4 class="text-lg font-semibold">
+          {{
+            t(
+              "integrations.create.wizard.step1.shopifyInfoModal.section.configureUrlsTitle",
+            )
+          }}
+        </h4>
         <div class="md:grid md:grid-cols-12 md:gap-4 items-start">
           <Image
             :source="step6Image"
@@ -230,7 +254,13 @@ const copyToClipboard = async (text: string) => {
 
       <!-- Finish wizard -->
       <div class="space-y-2">
-        <h4 class="text-lg font-semibold">Finish Current Wizard</h4>
+        <h4 class="text-lg font-semibold">
+          {{
+            t(
+              "integrations.create.wizard.step1.shopifyInfoModal.section.finishWizardTitle",
+            )
+          }}
+        </h4>
         <p class="text-sm text-gray-700">
           {{
             t(

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2322,7 +2322,12 @@
               "integrationStep7": "At step 2 of the Shopify wizard you will need the URL from step 4. Go to Overview and follow the wizard until step 4, then copy the Client ID and Client Secret into the fields.",
               "integrationStep8": "After the final step you will be redirected to Shopify admin. Click Install.",
               "appUrlLabel": "App URL",
-              "allowedRedirectUrlLabel": "Allowed redirection URL(s)"
+              "allowedRedirectUrlLabel": "Allowed redirection URL(s)",
+              "customAppTitle": "Create Custom App",
+              "detectWebsiteUrlTitle": "Detect Website URL",
+              "configureDistributionTitle": "Configure Distribution",
+              "configureUrlsTitle": "Configure URLs",
+              "finishWizardTitle": "Finish Current Wizard"
             }
           }
         },


### PR DESCRIPTION
## Summary
- make headers in ShopifyInfoCard.vue translatable
- add corresponding keys to `en.json`

## Testing
- `npm install`
- `npm run build` *(fails: TypeScript errors in TextInput.vue)*

------
https://chatgpt.com/codex/tasks/task_e_686bf469cff4832e83dc732adc1edb6e