### PR TITLE
Disable Shopify OAuth path

### DIFF
--- a/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
+++ b/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
@@ -309,6 +309,7 @@ const handleFinish = async () => {
 const handleShopifySalesChannelSuccess = async (channelData: any) => {
   const id = channelData.id;
 
+  /*
   const { data } = await apolloClient.mutate({
     mutation: getShopifyRedirectUrlMutation,
     variables: {
@@ -328,6 +329,7 @@ const handleShopifySalesChannelSuccess = async (channelData: any) => {
   messages.forEach((msg: any) => {
     Toast.error(msg.message);
   });
+  */
 
   // Redirect to show page anyway
   router.push({

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/shopify/ShopifyChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/shopify/ShopifyChannelInfoStep.vue
@@ -56,6 +56,7 @@ const propertyField = computed(() => ({
         <Flex class="mt-4 gap-4" center>
           <FlexCell center>
             <Flex vertical class="gap-2">
+              <!--
               <FlexCell>
                 <Label class="font-semibold block text-sm leading-6 text-gray-900">
                   {{ t('integrations.labels.apiKey') }}
@@ -79,6 +80,20 @@ const propertyField = computed(() => ({
                     v-model="channelInfo.apiSecret"
                     :placeholder="t('integrations.placeholders.apiSecret')"
                     :secret="true"
+                />
+              </FlexCell>
+              -->
+
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.accessToken') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                    class="w-96"
+                    v-model="channelInfo.accessToken"
+                    :placeholder="t('integrations.placeholders.accessToken')"
                 />
               </FlexCell>
 

--- a/src/core/integrations/integrations/integrations-shopify-entry/ShopifyEntryController.vue
+++ b/src/core/integrations/integrations/integrations-shopify-entry/ShopifyEntryController.vue
@@ -81,6 +81,7 @@ const createShopifySalesChannel = async (queryParams: Record<string, any>, hostn
 const handleShopifySalesChannelSuccess = async (channelData: any) => {
   const id = channelData.id;
 
+  /*
   const { data } = await apolloClient.mutate({
     mutation: getShopifyRedirectUrlMutation,
     variables: { data: { id } },
@@ -97,6 +98,7 @@ const handleShopifySalesChannelSuccess = async (channelData: any) => {
   messages.forEach((msg: any) => {
     Toast.error(msg.message);
   });
+  */
 
   router.push({
     name: 'integrations.integrations.show',

--- a/src/core/integrations/integrations/integrations-show/containers/general/shopify-general-tab/ShopifyGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/shopify-general-tab/ShopifyGeneralInfoTab.vue
@@ -37,8 +37,10 @@ interface EditShopifyForm {
   syncEanCodes: boolean;
   syncPrices: boolean;
   importOrders: boolean;
+  /*
   apiKey: string;
   apiSecret: string;
+  */
   accessToken?: string;
   state?: string;
   vendorProperty: {
@@ -196,6 +198,7 @@ useShiftBackspaceKeyboardListener(goBack);
     </div>
   </div>
 
+  <!--
   <div class="grid grid-cols-12 gap-4">
     <div class="md:col-span-6 col-span-12">
       <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
@@ -208,6 +211,16 @@ useShiftBackspaceKeyboardListener(goBack);
         {{ t('integrations.labels.apiSecret') }}
       </Label>
       <TextInput v-model="formData.apiSecret" disabled :secret="true" class="w-full" />
+    </div>
+  </div>
+  -->
+
+  <div class="grid grid-cols-12 gap-4">
+    <div class="md:col-span-12 col-span-12">
+      <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+        {{ t('integrations.labels.accessToken') }}
+      </Label>
+      <TextInput v-model="formData.accessToken" class="w-full" />
     </div>
   </div>
 

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -84,8 +84,11 @@ export interface MagentoChannelInfo extends SpecificChannelInfo {
 
 export interface ShopifyChannelInfo extends SpecificChannelInfo {
   vendorProperty: { id: string | null };
+  /*
   apiKey: string;
   apiSecret: string;
+  */
+  accessToken: string;
   hmac?: string;
   host?: string;
   timestamp?: string;
@@ -119,8 +122,11 @@ export function getMagentoDefaultFields(): MagentoChannelInfo {
 export function getShopifyDefaultFields(): ShopifyChannelInfo {
   return {
     vendorProperty: { id: null },
+    /*
     apiKey: '',
     apiSecret: '',
+    */
+    accessToken: '',
   };
 }
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2370,6 +2370,7 @@
       "vendorProperty": "Vendor Property",
       "apiKey": "API Key",
       "apiSecret": "API Secret",
+      "accessToken": "Access Token",
       "region": "Region",
       "country": "Country",
       "expirationDate": "Access Token Expiration",
@@ -2382,7 +2383,8 @@
       "attributeSetSkeletonId": "Enter attribute set skeleton ID",
       "eanCodeAttribute": "Enter EAN code attribute",
       "apiKey": "Enter API Key",
-      "apiSecret": "Enter API Secret"
+      "apiSecret": "Enter API Secret",
+      "accessToken": "Enter Access Token"
     },
     "regions": {
       "northAmerica": "North America",


### PR DESCRIPTION
## Summary
- comment out OAuth redirect logic and always go to integration show page
- switch Shopify wizard last step to use Access Token
- add Access Token field on Shopify general tab
- add `accessToken` type and default field
- include new translation labels

## Testing
- `npm run build` *(fails: vue-tsc not found / TS2322)*

------
https://chatgpt.com/codex/tasks/task_e_686c0834ca9c832ebbe38f0ffdf5a862

## Summary by Sourcery

Disable the Shopify OAuth redirect path and migrate Shopify integrations to use an access token instead of API key and secret.

New Features:
- Add access token input to the Shopify integration creation wizard
- Add access token field in the Shopify integration general settings tab

Enhancements:
- Comment out OAuth redirect logic to always route to the integration show page
- Update ShopifyChannelInfo model and defaults to replace apiKey/apiSecret with accessToken

Documentation:
- Add translation labels and placeholders for the access token