### PR TITLE
Fix Amazon integration SSL option

### DIFF
--- a/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
+++ b/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
@@ -386,7 +386,10 @@ const handleSalesChannelSuccess = async (channelData: any, integrationType: stri
               :general-info="form.generalInfo"
               :integration-type="selectedIntegrationType"
               :max-requests-per-minute="selectedIntegrationType === IntegrationTypes.Shopify ? 120 : undefined"
-              :show-ssl="selectedIntegrationType !== IntegrationTypes.Shopify"
+              :show-ssl="
+                selectedIntegrationType !== IntegrationTypes.Shopify &&
+                selectedIntegrationType !== IntegrationTypes.Amazon
+              "
           />
         </template>
 
@@ -400,5 +403,4 @@ const handleSalesChannelSuccess = async (channelData: any, integrationType: stri
 
       </Wizard>
    </template>
-  </GeneralTemplate>
-</template>
+  </GeneralTemplate></template>


### PR DESCRIPTION
## Summary
- hide the Verify SSL toggle when creating Amazon integrations

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e509cc06c832eace424187219655b

## Summary by Sourcery

Bug Fixes:
- Hide SSL verification toggle for Amazon integrations