### PR TITLE
Make AmazonImporter strings translatable

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/amazon/amazon-importer/AmazonImporter.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/amazon/amazon-importer/AmazonImporter.vue
@@ -1,27 +1,31 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { useRouter } from 'vue-router';
-import { Wizard } from '../../../../../../../../../../../shared/components/molecules/wizard';
-import { OptionSelector } from '../../../../../../../../../../../shared/components/molecules/option-selector';
-import { Icon } from '../../../../../../../../../../../shared/components/atoms/icon';
-import apolloClient from '../../../../../../../../../../../../apollo-client';
-import { Toast } from '../../../../../../../../../../../shared/modules/toast';
-import { createAmazonImportProcessMutation } from '../../../../../../../../../../../shared/api/mutations/salesChannels';
-import { amazonImportProcessesQuery } from '../../../../../../../../../../../shared/api/queries/salesChannels';
-import {processGraphQLErrors} from "../../../../../../../../../../../shared/utils";
+import { ref, onMounted, computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import { Wizard } from "../../../../../../../../../../../shared/components/molecules/wizard";
+import { OptionSelector } from "../../../../../../../../../../../shared/components/molecules/option-selector";
+import { Icon } from "../../../../../../../../../../../shared/components/atoms/icon";
+import apolloClient from "../../../../../../../../../../../../apollo-client";
+import { Toast } from "../../../../../../../../../../../shared/modules/toast";
+import { createAmazonImportProcessMutation } from "../../../../../../../../../../../shared/api/mutations/salesChannels";
+import { amazonImportProcessesQuery } from "../../../../../../../../../../../shared/api/queries/salesChannels";
+import { processGraphQLErrors } from "../../../../../../../../../../../shared/utils";
 
 const props = defineProps<{ integrationId: string; type: string }>();
 const router = useRouter();
 const { t } = useI18n();
 
-const importType = ref('schema');
+const importType = ref("schema");
 const hasFinishedSchema = ref(false);
 const loading = ref(false);
 
 const typeChoices = computed(() => [
-  { name: 'schema' },
-  { name: 'products', disabled: !hasFinishedSchema.value, hideDisabledBanner: true },
+  { name: "schema" },
+  {
+    name: "products",
+    disabled: !hasFinishedSchema.value,
+    hideDisabledBanner: true,
+  },
 ]);
 
 const fetchImports = async () => {
@@ -32,11 +36,11 @@ const fetchImports = async () => {
       variables: {
         filter: {
           salesChannel: { id: { exact: props.integrationId } },
-          type: { exact: 'schema' },
-          status: { exact: 'success' },
-        }
+          type: { exact: "schema" },
+          status: { exact: "success" },
+        },
       },
-      fetchPolicy: 'network-only',
+      fetchPolicy: "network-only",
     });
     const edges = data?.amazonImportProcesses?.edges || [];
     hasFinishedSchema.value = edges.length > 0;
@@ -46,7 +50,6 @@ const fetchImports = async () => {
     loading.value = false;
   }
 };
-
 
 onMounted(fetchImports);
 
@@ -58,22 +61,27 @@ const createImport = async () => {
         data: {
           salesChannel: { id: props.integrationId },
           type: importType.value,
-          status: 'pending',
+          status: "pending",
         },
       },
     });
-    Toast.success(t('integrations.imports.create.success'));
-    router.push({ name: 'integrations.integrations.show', params: { id: props.integrationId, type: props.type }, query: { tab: 'imports' } });
+    Toast.success(t("integrations.imports.create.success"));
+    router.push({
+      name: "integrations.integrations.show",
+      params: { id: props.integrationId, type: props.type },
+      query: { tab: "imports" },
+    });
   } catch (err) {
     const validationErrors = processGraphQLErrors(err, t);
-    if (validationErrors['__all__']) {
-      Toast.error(validationErrors['__all__']);
+    if (validationErrors["__all__"]) {
+      Toast.error(validationErrors["__all__"]);
     }
   }
 };
 
-const wizardSteps = [{ title: t('integrations.imports.create.title'), name: 'selectType' }];
-
+const wizardSteps = [
+  { title: t("integrations.imports.create.title"), name: "selectType" },
+];
 </script>
 
 <template>
@@ -84,20 +92,33 @@ const wizardSteps = [{ title: t('integrations.imports.create.title'), name: 'sel
           <template #schema>
             <div class="flex flex-col gap-2">
               <div class="flex items-center gap-2">
-                <h3 class="text-lg font-bold">{{ t('integrations.imports.types.schema') }}</h3>
+                <h3 class="text-lg font-bold">
+                  {{ t("integrations.imports.types.schema") }}
+                </h3>
               </div>
-              <p class="text-sm text-gray-500">Initial setup required to enable product imports.</p>
+              <p class="text-sm text-gray-500">
+                {{ t("integrations.imports.types.schemaDescription") }}
+              </p>
             </div>
           </template>
           <template #products>
             <div class="flex flex-col gap-2">
               <div class="flex items-center gap-2">
-                <h3 class="text-lg font-bold">{{ t('integrations.imports.types.products') }}</h3>
+                <h3 class="text-lg font-bold">
+                  {{ t("integrations.imports.types.products") }}
+                </h3>
               </div>
-              <p class="text-sm text-gray-500">Imports actual product data from Amazon.</p>
-              <div v-if="!hasFinishedSchema" class="text-sm text-gray-400 flex items-center gap-1">
+              <p class="text-sm text-gray-500">
+                {{ t("integrations.imports.types.productsDescription") }}
+              </p>
+              <div
+                v-if="!hasFinishedSchema"
+                class="text-sm text-gray-400 flex items-center gap-1"
+              >
                 <Icon name="exclamation-circle" class="text-gray-400" />
-                <span>Please complete the schema import first.</span>
+                <span>{{
+                  t("integrations.imports.types.schemaRequired")
+                }}</span>
               </div>
             </div>
           </template>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -115,7 +115,6 @@
             "title": "Configurable Products with No Applicable Configurator Rules",
             "description": "Define at least one configurator required item for these configurable products."
           }
-
         }
       },
       "orders": {
@@ -458,26 +457,26 @@
           }
         },
         "aiContentGenerator": {
-            "title": "Generating content...",
-            "success": "Content successfully generated. It cost {points} SilAI Credit(s).",
-            "step1": "Gathering product information",
-            "step2": "Evaluating product features",
-            "step3": "Generating description",
-            "step4": "Finalizing content"
+          "title": "Generating content...",
+          "success": "Content successfully generated. It cost {points} SilAI Credit(s).",
+          "step1": "Gathering product information",
+          "step2": "Evaluating product features",
+          "step3": "Generating description",
+          "step4": "Finalizing content"
         },
         "aiContentTranslator": {
-            "title": "Translating content...",
-            "success": "Content successfully translated. It cost {points} SilAI Credit(s).",
-            "step1": "Analyzing original text",
-            "step2": "Performing translation",
-            "step3": "Finalizing translation"
+          "title": "Translating content...",
+          "success": "Content successfully translated. It cost {points} SilAI Credit(s).",
+          "step1": "Analyzing original text",
+          "step2": "Performing translation",
+          "step3": "Finalizing translation"
         },
         "aiBulletPointsGenerator": {
-            "title": "Generating bullet points...",
-            "success": "Bullet points successfully generated. It cost {points} SilAI Credit(s).",
-            "step1": "Gathering product information",
-            "step2": "Generating bullet points",
-            "step3": "Finalizing"
+          "title": "Generating bullet points...",
+          "success": "Bullet points successfully generated. It cost {points} SilAI Credit(s).",
+          "step1": "Gathering product information",
+          "step2": "Generating bullet points",
+          "step3": "Finalizing"
         },
         "remotePropertiesDetector": {
           "step1": "Analyzing remote attributes",
@@ -835,14 +834,14 @@
           "bulkDeleteSuccess": "EAN codes deleted successfully.",
           "bulkDeleteError": "Failed to delete EAN codes. Please try again.",
           "success": {
-                "assignBulk": "Successfully assigned EAN codes to {count} product(s)"
-              },
-              "warning": {
-                "noAvailable": "No EAN codes could be assigned"
-              },
-              "error": {
-                "assignBulk": "An error occurred while assigning EAN codes"
-              }
+            "assignBulk": "Successfully assigned EAN codes to {count} product(s)"
+          },
+          "warning": {
+            "noAvailable": "No EAN codes could be assigned"
+          },
+          "error": {
+            "assignBulk": "An error occurred while assigning EAN codes"
+          }
         }
       }
     },
@@ -1079,135 +1078,135 @@
   "inventory": {
     "title": "Warehouse",
     "packages": {
-       "title": "Packages",
-        "create": {
-          "title": "Create Packages",
-          "virtual": {
-            "title": "Guided Virtual Tour Packaging",
-            "description": "Use your mobile device to get step-by-step directions through the warehouse, guiding you to pick and pack items in real-time.",
-            "selectPackageType": "Please select the package type you gonna use",
-            "actions": {
-              "start": "Let's Start",
-              "arrived": "I Arrived",
-              "addAll": "Add All",
-              "quantityInputPlaceholder": "Enter quantity to add",
-              "addQuantity": "Add Quantity",
-              "packageFull": "Package Full",
-              "finish": "Finish"
-            },
-            "instructions": {
-              "prepare": {
-                "title": "Prepare Your Way",
-                "description": "Optimize the item picking sequence by reordering the items to be shipped. Follow the guided process step-by-step for a smooth packaging experience."
-              },
-              "move": {
-                "title": "Go to {location}",
-                "description": "Navigate to the designated location {location}."
-              },
-              "collect": {
-                "title": "Add to Package",
-                "description": "Place {quantity} of {item} into {package}.",
-                "general": {
-                  "addAll": "If all the products fit in the package, press Add.",
-                  "packageFull": "If the package is full and you cannot add anymore, press Package Full."
-                },
-                "extra": {
-                  "partialAdd": "If only some items fit in the package, add the quantity that fits, then press Package Full and add the remaining."
-                }
-              },
-              "confirm": {
-                "title": "Confirm the Shipment",
-                "description": "Ensure all items are collected and packed properly. You can also adjust the tracking codes and finalize package details."
-              }
-            },
-            "virtualTour": {
-              "itemsToShip": "Items to Ship",
-              "packages": "Packages",
-              "noPackagesYet": "No packages created yet.",
-              "prepare": "Prepare your way",
-              "collect": "Collect the products",
-              "confirm": "Confirm the shipment",
-              "packageName": "Package {index}"
-            },
-            "error": {
-              "cannotRemoveWithItems": "You cannot remove a package that contains items. Remove the items first.",
-              "noStockForProduct": "There is no stock for the selected product in the location. Please restock and try again. The process cannot continue!",
-              "inventoryMovementFailed": "Failed to move inventory for the package. Please try again.",
-              "quantityExceedsAvailable": "The quantity entered exceeds the available quantity. Please adjust the quantity."
-            },
-            "packageType": {
-              "error": "Please select a valid package type."
-            },
-            "packageFull": {
-              "error": "The package is full. You cannot add more items."
-            },
-            "packageSave": {
-              "success": "The package has been saved successfully.",
-              "error": "Failed to save the package. Please try again."
-            },
-          "confirmationSuccess": "The package has been confirmed successfully."
+      "title": "Packages",
+      "create": {
+        "title": "Create Packages",
+        "virtual": {
+          "title": "Guided Virtual Tour Packaging",
+          "description": "Use your mobile device to get step-by-step directions through the warehouse, guiding you to pick and pack items in real-time.",
+          "selectPackageType": "Please select the package type you gonna use",
+          "actions": {
+            "start": "Let's Start",
+            "arrived": "I Arrived",
+            "addAll": "Add All",
+            "quantityInputPlaceholder": "Enter quantity to add",
+            "addQuantity": "Add Quantity",
+            "packageFull": "Package Full",
+            "finish": "Finish"
           },
-          "manual": {
-            "button": {
-              "add": "Add package",
-              "remove": "Remove package"
+          "instructions": {
+            "prepare": {
+              "title": "Prepare Your Way",
+              "description": "Optimize the item picking sequence by reordering the items to be shipped. Follow the guided process step-by-step for a smooth packaging experience."
             },
-            "title": "Manual Packaging Entry",
-            "description": "Ideal for logging already packed items. Create packages and assign items to them after packing is completed.",
-              "createStep": {
-                "title": "Create Your Packages",
-                "description": "In this step, you can create and organize your packages. Add boxes or pallets and define their details such as tracking information, shipping label, and customs documents."
+            "move": {
+              "title": "Go to {location}",
+              "description": "Navigate to the designated location {location}."
+            },
+            "collect": {
+              "title": "Add to Package",
+              "description": "Place {quantity} of {item} into {package}.",
+              "general": {
+                "addAll": "If all the products fit in the package, press Add.",
+                "packageFull": "If the package is full and you cannot add anymore, press Package Full."
               },
-            "assignItemsStep": {
-              "title": "Assign Items to Packages",
-              "description": "In this step, you will assign items to each package based on your shipment. Drag and drop items into the respective packages, and confirm quantities where necessary.",
-              "noItemsToShip": "No items left to assign.",
-              "emptyPackage": "This package is currently empty.",
-              "packageName": "Package {index}",
-              "success": "Items have been successfully assigned to the package.",
-              "error": {
-                "noItemsInPackage": "You cannot finish the process. At least one package has no items assigned. Add items or remove the package.",
-                "cannotRemoveWithItems": "Cannot remove the package because it contains assigned items.",
-                "packageCreationFailed": "Failed to create the package. Please try again.",
-                "inventoryMovementFailed": "Failed to move inventory for the package. Please try again."
-              },
-              "modal": {
-                "title": "Assign Item to Package",
-                "quantity": "Quantity",
-                "package": "Package"
+              "extra": {
+                "partialAdd": "If only some items fit in the package, add the quantity that fits, then press Package Full and add the remaining."
               }
+            },
+            "confirm": {
+              "title": "Confirm the Shipment",
+              "description": "Ensure all items are collected and packed properly. You can also adjust the tracking codes and finalize package details."
+            }
+          },
+          "virtualTour": {
+            "itemsToShip": "Items to Ship",
+            "packages": "Packages",
+            "noPackagesYet": "No packages created yet.",
+            "prepare": "Prepare your way",
+            "collect": "Collect the products",
+            "confirm": "Confirm the shipment",
+            "packageName": "Package {index}"
+          },
+          "error": {
+            "cannotRemoveWithItems": "You cannot remove a package that contains items. Remove the items first.",
+            "noStockForProduct": "There is no stock for the selected product in the location. Please restock and try again. The process cannot continue!",
+            "inventoryMovementFailed": "Failed to move inventory for the package. Please try again.",
+            "quantityExceedsAvailable": "The quantity entered exceeds the available quantity. Please adjust the quantity."
+          },
+          "packageType": {
+            "error": "Please select a valid package type."
+          },
+          "packageFull": {
+            "error": "The package is full. You cannot add more items."
+          },
+          "packageSave": {
+            "success": "The package has been saved successfully.",
+            "error": "Failed to save the package. Please try again."
+          },
+          "confirmationSuccess": "The package has been confirmed successfully."
+        },
+        "manual": {
+          "button": {
+            "add": "Add package",
+            "remove": "Remove package"
+          },
+          "title": "Manual Packaging Entry",
+          "description": "Ideal for logging already packed items. Create packages and assign items to them after packing is completed.",
+          "createStep": {
+            "title": "Create Your Packages",
+            "description": "In this step, you can create and organize your packages. Add boxes or pallets and define their details such as tracking information, shipping label, and customs documents."
+          },
+          "assignItemsStep": {
+            "title": "Assign Items to Packages",
+            "description": "In this step, you will assign items to each package based on your shipment. Drag and drop items into the respective packages, and confirm quantities where necessary.",
+            "noItemsToShip": "No items left to assign.",
+            "emptyPackage": "This package is currently empty.",
+            "packageName": "Package {index}",
+            "success": "Items have been successfully assigned to the package.",
+            "error": {
+              "noItemsInPackage": "You cannot finish the process. At least one package has no items assigned. Add items or remove the package.",
+              "cannotRemoveWithItems": "Cannot remove the package because it contains assigned items.",
+              "packageCreationFailed": "Failed to create the package. Please try again.",
+              "inventoryMovementFailed": "Failed to move inventory for the package. Please try again."
+            },
+            "modal": {
+              "title": "Assign Item to Package",
+              "quantity": "Quantity",
+              "package": "Package"
             }
           }
-        },
-        "edit": {
-          "title": "Edit Package"
-        },
-        "show": {
-          "title": "Package Details"
-        },
-       "type": {
-          "box": "Box",
-          "pallet": "Pallet"
-       },
-       "status": {
-          "new": "New",
-          "inProgress": "In Progress",
-          "packed": "Packed",
-          "dispatched": "Dispatched"
-       },
-       "placeholders": {
-          "trackingCode": "Enter tracking code",
-          "trackingLink": "Enter tracking link URL"
-       },
-       "labels": {
-          "trackingCode": "Tracking Code",
-          "trackingLink": "Tracking Link",
-          "type": "Package Type",
-          "status": "Package Status",
-          "shippingLabel": "Shipping Label",
-          "customsDocument": "Customs Document"
-       }
-     },
+        }
+      },
+      "edit": {
+        "title": "Edit Package"
+      },
+      "show": {
+        "title": "Package Details"
+      },
+      "type": {
+        "box": "Box",
+        "pallet": "Pallet"
+      },
+      "status": {
+        "new": "New",
+        "inProgress": "In Progress",
+        "packed": "Packed",
+        "dispatched": "Dispatched"
+      },
+      "placeholders": {
+        "trackingCode": "Enter tracking code",
+        "trackingLink": "Enter tracking link URL"
+      },
+      "labels": {
+        "trackingCode": "Tracking Code",
+        "trackingLink": "Tracking Link",
+        "type": "Package Type",
+        "status": "Package Status",
+        "shippingLabel": "Shipping Label",
+        "customsDocument": "Customs Document"
+      }
+    },
     "shipments": {
       "title": "Shipments",
       "button": {
@@ -2288,7 +2287,7 @@
             }
           },
           "magentoInfoModal": {
-          "title": "How to connect your Magento store",
+            "title": "How to connect your Magento store",
             "section": {
               "integrationTitle": "Create an integration in Magento",
               "integrationDescription": "Before connecting your store, make sure to create and activate an integration in your Magento Admin Panel.",
@@ -2456,7 +2455,10 @@
       },
       "types": {
         "schema": "Schema",
-        "products": "Products"
+        "products": "Products",
+        "schemaDescription": "Initial setup required to enable product imports.",
+        "productsDescription": "Imports actual product data from Amazon.",
+        "schemaRequired": "Please complete the schema import first."
       },
       "create": {
         "success": "Create import process success",
@@ -2484,9 +2486,9 @@
           },
           "step3": {
             "title": "Default Attribute Set",
-              "content": "Select the default attribute set",
-              "attributeSetSelected": "Default Set",
-              "helpText": "The selected attribute set defines the initial structure of your product attributes. Additional properties managed in OneSila will be added afterwards."
+            "content": "Select the default attribute set",
+            "attributeSetSelected": "Default Set",
+            "helpText": "The selected attribute set defines the initial structure of your product attributes. Additional properties managed in OneSila will be added afterwards."
           },
           "finish": {
             "title": "Finalizing Import",


### PR DESCRIPTION
## Summary
- add new translation keys for Amazon importer
- replace hard-coded text with i18n in `AmazonImporter.vue`

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb630efbc832eb75e9cf8affbd9a1

## Summary by Sourcery

Replace hardcoded text in the AmazonImporter component with i18n calls and add corresponding translation keys

Enhancements:
- Extract UI labels, descriptions, and prompts in AmazonImporter.vue into vue-i18n translation calls
- Add new translation keys in locale file for importer types, descriptions, and validation messages