### PR TITLE
Add Amazon channel issues filter

### DIFF
--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -14,6 +14,7 @@ import { createVatRateMutation } from "../../../shared/api/mutations/vatRates.js
 import { baseFormConfigConstructor as baseVatRateConfigConstructor } from '../../settings/vat-rates/configs'
 import { Badge } from "../../../shared/components/organisms/general-show/showConfig";
 import { propertySelectValuesQuerySelector } from "../../../shared/api/queries/properties.js";
+import { amazonChannelsQuerySelector } from "../../../shared/api/queries/salesChannels.js";
 import { deleteProductsMutation } from "../../../shared/api/mutations/products.js";
 
 export const vatRateOnTheFlyConfig = (t: Function):CreateOnTheFly => ({
@@ -182,7 +183,7 @@ export const baseFormConfigConstructor = (
   fields: getFields(type, t),
 });
 
-export const searchConfigConstructor = (t: Function): SearchConfig => ({
+export const searchConfigConstructor = (t: Function, hasAmazon: boolean = false): SearchConfig => ({
   search: true,
   orderKey: "sort",
   filters: [
@@ -208,6 +209,19 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
       labelBy: "fullValueName",
       valueBy: "id",
       dataKey: "propertySelectValues",
+      filterable: true,
+      multiple: false,
+      isEdge: true,
+      addLookup: false,
+    },
+    hasAmazon && {
+      type: FieldType.Query,
+      name: 'amazonProductsWithIssuesForSalesChannel',
+      query: amazonChannelsQuerySelector,
+      label: t('salesChannel.amazon.labels.productsWithIssuesForSalesChannel'),
+      labelBy: 'hostname',
+      valueBy: 'id',
+      dataKey: 'amazonChannels',
       filterable: true,
       multiple: false,
       isEdge: true,
@@ -248,7 +262,7 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
       label: t('products.products.inspector.labels.missingInfo'),
       addLookup: true,
     },
-  ],
+  ].filter(Boolean),
   orders: [
     {
       name: 'name',

--- a/src/core/products/products/products-list/ProductsListController.vue
+++ b/src/core/products/products/products-list/ProductsListController.vue
@@ -7,6 +7,7 @@ import { Link } from "../../../../shared/components/atoms/link";
 import GeneralTemplate  from "../../../../shared/templates/GeneralTemplate.vue"
 import { GeneralListing } from "../../../../shared/components/organisms/general-listing";
 import { searchConfigConstructor, listingConfigConstructor, listingQueryKey, listingQuery } from "../configs";
+import { injectAuth } from "../../../../shared/modules/auth";
 import { AiBulkTranslator } from "../../../../shared/components/organisms/ai-bulk=translator";
 import { ref } from "vue";
 import apolloClient from "../../../../../apollo-client";
@@ -16,7 +17,8 @@ import {BulkProductPropertyAssigner} from "../../../../shared/components/organis
 
 const { t } = useI18n();
 
-const searchConfig = searchConfigConstructor(t);
+const auth = injectAuth();
+const searchConfig = searchConfigConstructor(t, auth.user.company?.hasAmazonIntegration);
 const listingConfig = listingConfigConstructor(t, true);
 const generalListingRef = ref<any>(null);
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2421,6 +2421,9 @@
           "success": "Your Amazon store was successfully connected!",
           "genericError": "Something went wrong while connecting your store.",
           "missingParams": "Missing required query parameters. Please retry the installation."
+        },
+        "labels": {
+          "productsWithIssuesForSalesChannel": "Products With Issues"
         }
       },
       "toast": {

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -219,6 +219,41 @@ export const amazonChannelsQuery = gql`
   }
 `;
 
+export const amazonChannelsQuerySelector = gql`
+  query AmazonChannels(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: AmazonSalesChannelOrder
+    $filters: AmazonSalesChannelFilter
+  ) {
+    amazonChannels(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filters
+    ) {
+      edges {
+        node {
+          id
+          hostname
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 
 
 // Sales Channel Integration Pricelist Queries


### PR DESCRIPTION
## Summary
- add `amazonChannelsQuerySelector` query to fetch Amazon channels for selectors
- allow `searchConfigConstructor` to accept `hasAmazon` and include an Amazon issues filter
- pass company integration state to product list search config
- localize Amazon filter label

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870379e40f8832ea67425a40de28474