### PR TITLE
Add Amazon dashboard card for products with issues

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -164,6 +164,10 @@
         "unmappedDefaultUnitConfigurators": {
           "title": "Default Unit Configurator",
           "description": "Amazon unit configurators missing a default unit."
+        },
+        "productsWithIssues": {
+          "title": "Products With Issues",
+          "description": "Amazon products that failed to sync correctly."
         }
       }
     },

--- a/src/shared/api/queries/dashboardCards.js
+++ b/src/shared/api/queries/dashboardCards.js
@@ -47,3 +47,11 @@ export const dashboardNotMatchingSalesPricesList = gql`
       }
     }
 `;
+
+export const dashboardAmazonProductsWithIssues = gql`
+  query DashboardAmazonProductsWithIssues($salesChannelId: GlobalID!) {
+    products(filters: { amazonProductsWithIssuesForSalesChannel: $salesChannelId }) {
+      totalCount
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- query count of Amazon products with issues per sales channel
- fetch product issue counts for Amazon integrations
- show new dashboard card for products with issues
- document new card strings

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68704034ff08832e85d6f609be0da710

## Summary by Sourcery

Introduce a new Amazon dashboard card that retrieves the count of products with issues via a GraphQL query and displays it with proper localization.

New Features:
- Add GraphQL query to fetch count of Amazon products with issues per sales channel
- Add a new dashboard card to display products with issues for Amazon integrations

Documentation:
- Add English localization strings for the new Amazon products with issues card