### PR TITLE
Add Amazon logs to product modal

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -373,7 +373,10 @@
       "new": "New",
       "beta": "BETA",
       "url": "URL",
-      "default": "Default"
+      "default": "Default",
+      "submissionId": "Submission ID",
+      "processingStatus": "Processing Status",
+      "issues": "Issues"
     },
     "validations": {
       "quantity": "Please enter a valid quantity"

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -367,6 +367,45 @@ export const remoteLogsQuery = gql`
   }
 `;
 
+export const amazonRemoteLogsQuery = gql`
+  query AmazonRemoteLogs(
+    $first: Int,
+    $last: Int,
+    $after: String,
+    $before: String,
+    $order: AmazonRemoteLogOrder,
+    $filter: AmazonRemoteLogFilter
+  ) {
+    amazonRemoteLogs(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          type
+          action
+          status
+          frontendName
+          frontendError
+          createdAt
+          submissionId
+          processingStatus
+          formattedIssues {
+            message
+            severity
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 export const getSalesChannelViewAssignQuery = gql`
   query getSalesChannelViewAssign($id: GlobalID!) {
     salesChannelViewAssign(id: $id) {


### PR DESCRIPTION
## Summary
- add `amazonRemoteLogsQuery` for retrieving Amazon-specific log data
- support optional `integrationType` prop in `LogsInfoModal`
- display additional Amazon log fields with a bullet list of issues
- translate new table headers

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870469a9900832ea0be63925dbb952b

## Summary by Sourcery

Add support for fetching and displaying Amazon-specific logs in the product LogsInfoModal.

New Features:
- Add amazonRemoteLogsQuery GraphQL query to retrieve Amazon-specific log data

Enhancements:
- Support integrationType prop in LogsInfoModal to switch between default and Amazon log queries
- Display Amazon-specific fields (submission ID, processing status, and issues list) in the logs table