### PR TITLE
Fix LogsInfoModal integration type

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/products/Products.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/products/Products.vue
@@ -22,8 +22,9 @@ import {Badge} from "../../../../../../shared/components/atoms/badge";
 
 const { t } = useI18n();
 const props = defineProps<{ salesChannelId: string }>();
-const infoId = ref(null);
+const infoId = ref<string | null>(null);
 const showInfoModal = ref(false);
+const infoIntegrationType = ref<string | undefined>(undefined);
 const router = useRouter();
 
 const searchConfig: SearchConfig = {
@@ -41,13 +42,15 @@ const onResyncSuccess = () => {
   Toast.success(t('integrations.salesChannel.toast.resyncSuccess'))
 };
 
-const setInfoId = (id) => {
+const setInfoId = (id: string | null, type: string | null) => {
   infoId.value = id;
+  infoIntegrationType.value = type || undefined;
   showInfoModal.value = true;
 }
 
 const modalColsed = () => {
   infoId.value = null;
+  infoIntegrationType.value = undefined;
   showInfoModal.value = false;
 }
 
@@ -125,7 +128,7 @@ const getStatusText = (item) => {
                       <td>
                         <div class="flex gap-4 items-center justify-end">
 
-                          <Button :disabled="!item.node.remoteProduct?.id" @click="setInfoId(item.node.remoteProduct?.id)">
+                          <Button :disabled="!item.node.remoteProduct?.id" @click="setInfoId(item.node.remoteProduct?.id, item.node.integrationType)">
                             <Icon name="clipboard-list" size="lg" class="text-gray-500" />
                           </Button>
 
@@ -173,6 +176,6 @@ const getStatusText = (item) => {
           </ApolloQuery>
         </template>
       </FilterManager>
-    <LogsInfoModal v-model="showInfoModal" :id="infoId" @modal-closed="modalColsed()" />
+    <LogsInfoModal v-model="showInfoModal" :id="infoId" :integration-type="infoIntegrationType" @modal-closed="modalColsed()" />
   </div>
 </template>

--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -400,6 +400,7 @@ export interface SalesChannelViewAssign {
   id: string;
   remoteUrl: string;
   remoteProductPercentage: number;
+  integrationType: string;
   formattedIssues?: { message?: string | null; severity?: string | null }[];
   product: SalesChannelViewAssignProduct;
   salesChannelView: SalesChannelView;

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
@@ -18,8 +18,9 @@ import { IssuesInfoModal } from "../issues-info-modal";
 
 const { t } = useI18n();
 const props = defineProps<{ product: Product }>();
-const infoId = ref(null);
+const infoId = ref<string | null>(null);
 const showInfoModal = ref(false);
+const infoIntegrationType = ref<string | undefined>(undefined);
 const issuesList = ref<SalesChannelViewAssign['formattedIssues'] | null>(null);
 const showIssuesModal = ref(false);
 const issuesAssignId = ref(null);
@@ -32,8 +33,9 @@ const onResyncSuccess = () => {
   Toast.success(t('integrations.salesChannel.toast.resyncSuccess'))
 };
 
-const setInfoId = (id) => {
+const setInfoId = (id: string | null, type: string | null) => {
   infoId.value = id;
+  infoIntegrationType.value = type || undefined;
   showInfoModal.value = true;
 }
 
@@ -45,6 +47,7 @@ const setIssues = (issues, id) => {
 
 const modalColsed = () => {
   infoId.value = null;
+  infoIntegrationType.value = undefined;
   showInfoModal.value = false;
 }
 
@@ -85,7 +88,7 @@ const issuesModalClosed = () => {
                   <Icon name="exclamation-triangle" size="lg" class="text-red-500" />
                 </Button>
 
-                <Button :disabled="!item.remoteProduct?.id" @click="setInfoId(item.remoteProduct?.id)">
+                <Button :disabled="!item.remoteProduct?.id" @click="setInfoId(item.remoteProduct?.id, item.integrationType)">
                   <Icon name="clipboard-list" size="lg" class="text-gray-500" />
                 </Button>
 
@@ -124,7 +127,7 @@ const issuesModalClosed = () => {
           </tbody>
         </table>
       </div>
-      <LogsInfoModal v-model="showInfoModal" :id="infoId" @modal-closed="modalColsed()" />
+      <LogsInfoModal v-model="showInfoModal" :id="infoId" :integration-type="infoIntegrationType" @modal-closed="modalColsed()" />
       <IssuesInfoModal v-model="showIssuesModal" :issues="issuesList" :id="issuesAssignId" @modal-closed="issuesModalClosed()" />
     </div>
 </template>

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -306,6 +306,7 @@ export const salesChannelViewAssignsQuery = gql`
           id
           remoteUrl
           remoteProductPercentage
+          integrationType
           product {
             id
             name
@@ -410,6 +411,7 @@ export const getSalesChannelViewAssignQuery = gql`
   query getSalesChannelViewAssign($id: GlobalID!) {
     salesChannelViewAssign(id: $id) {
       id
+      integrationType
       product {
         id
         name

--- a/src/shared/api/subscriptions/products.js
+++ b/src/shared/api/subscriptions/products.js
@@ -65,6 +65,7 @@ export const productSubscription = gql`
           id
           remoteUrl
           remoteProductPercentage
+          integrationType
           formattedIssues {
             message
             severity

--- a/src/shared/api/subscriptions/salesChannels.js
+++ b/src/shared/api/subscriptions/salesChannels.js
@@ -38,6 +38,7 @@ export const salesChannelViewAssignSubscription = gql`
   subscription getSalesChannelViewAssignSubscription($pk: String!) {
     salesChannelViewAssign(pk: $pk) {
       id
+      integrationType
       product {
         id
         name


### PR DESCRIPTION
## Summary
- include `integrationType` in `SalesChannelViewAssign` queries and subscription
- extend `SalesChannelViewAssign` interface with `integrationType`
- pass integration type to `LogsInfoModal` and handle in components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870c5b20610832eb69b97be6725aec6