### PR TITLE
Add Amazon default unit configurator tab

### DIFF
--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-amazon/DashboardSectionAmazon.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-amazon/DashboardSectionAmazon.vue
@@ -201,7 +201,7 @@ onMounted(fetchAmazonIntegrations);
           :description="t('dashboard.cards.amazon.unmappedDefaultUnitConfigurators.description')"
           :hide-on-complete="!showCompletedAmazonCards"
           color="red"
-          :url="{ name: 'integrations.integrations.show', params: { type: 'amazon', id: integration.integrationId }, query: { tab: 'general', accordion: 'units' } }"
+          :url="{ name: 'integrations.integrations.show', params: { type: 'amazon', id: integration.integrationId }, query: { tab: 'defaultUnits', mappedLocally: false } }"
         />
         <DashboardCard
           :counter="integration.productsWithIssues"

--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -25,6 +25,7 @@ import { Currencies } from "./containers/currencies";
 import { Rules } from "./containers/rules";
 import { Properties } from "./containers/properties";
 import { PropertySelectValues } from "./containers/property-select-values";
+import { DefaultUnitConfigurators } from "./containers/default-unit-configurators";
 import { Imports } from "./containers/imports";
 import { refreshSalesChannelWebsitesMutation } from "../../../../shared/api/mutations/salesChannels";
 import {Toast} from "../../../../shared/modules/toast";
@@ -55,7 +56,8 @@ if (type.value === IntegrationTypes.Amazon) {
   tabItems.value.push(
     { name: 'productRules', label: t('properties.rule.title'), icon: 'cog' },
     { name: 'properties', label: t('properties.title'), icon: 'screwdriver-wrench' },
-    { name: 'propertySelectValues', label: t('properties.values.title'), icon: 'sitemap' }
+    { name: 'propertySelectValues', label: t('properties.values.title'), icon: 'sitemap' },
+    { name: 'defaultUnits', label: t('integrations.show.sections.defaultUnits'), icon: 'weight-hanging' }
   );
 }
 
@@ -241,6 +243,11 @@ const pullData = async () => {
           <!-- Property Select Values Tab -->
           <template #propertySelectValues>
             <PropertySelectValues v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" :type="type" @pull-data="pullData()" />
+          </template>
+
+          <!-- Default Units Tab -->
+          <template #defaultUnits>
+            <DefaultUnitConfigurators v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" :type="type" @pull-data="pullData()" />
           </template>
         </Tabs>
       </Card>

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/DefaultUnitConfigurators.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/DefaultUnitConfigurators.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { IntegrationTypes } from '../../../integrations';
+import { AmazonDefaultUnitConfigurators } from './containers/amazon-unit-configurators';
+
+const props = defineProps<{ id: string; salesChannelId: string; type: string }>();
+const emit = defineEmits(['pull-data']);
+
+const currentComponent = computed(() => {
+  switch (props.type) {
+    case IntegrationTypes.Amazon:
+      return AmazonDefaultUnitConfigurators;
+    default:
+      return null;
+  }
+});
+</script>
+
+<template>
+  <component
+    v-if="currentComponent"
+    :is="currentComponent"
+    :id="id"
+    :sales-channel-id="salesChannelId"
+    @pull-data="emit('pull-data')"
+  />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/AmazonDefaultUnitConfigurators.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/AmazonDefaultUnitConfigurators.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import { ref, onMounted } from 'vue';
+import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
+import { GeneralListing } from "../../../../../../../../shared/components/organisms/general-listing";
+import { Button } from "../../../../../../../../shared/components/atoms/button";
+import { amazonDefaultUnitConfiguratorsSearchConfigConstructor, amazonDefaultUnitConfiguratorsListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
+import apolloClient from "../../../../../../../../../apollo-client";
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const emit = defineEmits(['pull-data']);
+const { t } = useI18n();
+const router = useRouter();
+
+const canStartMapping = ref(false);
+const generalListingRef = ref<any>(null);
+
+const fetchFirstUnmapped = async () => {
+  const { data } = await apolloClient.query({
+    query: listingQuery,
+    variables: {
+      first: 1,
+      filter: {
+        salesChannel: { id: { exact: props.salesChannelId } },
+        mappedLocally: false,
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+  const edges = data?.amazonDefaultUnitConfigurators?.edges || [];
+  canStartMapping.value = edges.length > 0;
+  return edges.length > 0 ? edges[0].node.id : null;
+};
+
+onMounted(fetchFirstUnmapped);
+
+const startMapping = async () => {
+  const id = await fetchFirstUnmapped();
+  if (id) {
+    router.push({
+      name: 'integrations.amazonDefaultUnitConfigurators.edit',
+      params: { type: 'amazon', id },
+      query: { integrationId: props.id, salesChannelId: props.salesChannelId, wizard: '1' },
+    });
+  }
+};
+
+const clearSelection = (query?: any) => {
+  generalListingRef.value?.clearSelected?.();
+  query?.refetch?.();
+};
+
+const searchConfig = amazonDefaultUnitConfiguratorsSearchConfigConstructor(t, props.salesChannelId);
+const listingConfig = amazonDefaultUnitConfiguratorsListingConfigConstructor(t, props.id);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:buttons>
+      <Button type="button" class="btn btn-secondary" :disabled="!canStartMapping" @click="startMapping">
+        {{ t('integrations.show.mapping.startMapping') }}
+      </Button>
+    </template>
+
+    <template v-slot:content>
+      <GeneralListing
+        ref="generalListingRef"
+        :search-config="searchConfig"
+        :config="listingConfig"
+        :query="listingQuery"
+        :query-key="listingQueryKey"
+        :fixed-filter-variables="{'salesChannel': {'id': {exact: salesChannelId}}}"
+      />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/configs.ts
@@ -1,0 +1,66 @@
+import { FieldType } from "../../../../../../../../shared/utils/constants";
+import { amazonDefaultUnitConfiguratorsQuery, getAmazonDefaultUnitConfiguratorQuery, salesChannelViewsQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
+import { updateAmazonDefaultUnitConfiguratorMutation } from "../../../../../../../../shared/api/mutations/salesChannels.js";
+import { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { FormConfig, FormType } from '../../../../../../../../shared/components/organisms/general-form/formConfig';
+import { SearchConfig } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
+
+export const amazonDefaultUnitConfiguratorEditFormConfigConstructor = (
+  t: Function,
+  type: string,
+  configuratorId: string,
+  integrationId: string,
+): FormConfig => ({
+  cols: 1,
+  type: FormType.EDIT,
+  mutation: updateAmazonDefaultUnitConfiguratorMutation,
+  mutationKey: "updateAmazonDefaultUnitConfigurator",
+  query: getAmazonDefaultUnitConfiguratorQuery,
+  queryVariables: { id: configuratorId },
+  queryDataKey: "amazonDefaultUnitConfigurator",
+  submitUrl: { name: 'integrations.integrations.show', params: { type: type, id: integrationId }, query: { tab: 'defaultUnits' } },
+  fields: [
+    { type: FieldType.Hidden, name: 'id', value: configuratorId },
+    { type: FieldType.Text, name: 'name', label: t('shared.labels.name'), disabled: true },
+    { type: FieldType.Text, name: 'code', label: t('integrations.show.properties.labels.code'), disabled: true },
+    { type: FieldType.Text, name: 'marketplace', label: t('integrations.show.propertySelectValues.labels.marketplace'), disabled: true },
+    { type: FieldType.Choice, name: 'selectedUnit', label: t('shared.labels.unit'), labelBy: 'name', valueBy: 'value', options: [], removable: false }
+  ]
+});
+
+export const amazonDefaultUnitConfiguratorsSearchConfigConstructor = (t: Function, salesChannelId: string): SearchConfig => ({
+  search: true,
+  orderKey: "sort",
+  filters: [
+    { type: FieldType.Boolean, name: 'mappedLocally', label: t('integrations.show.mapping.mappedLocally'), strict: true },
+    { type: FieldType.Query, name: 'marketplace', label: t('integrations.show.propertySelectValues.labels.marketplace'), labelBy: 'name', valueBy: 'id', query: salesChannelViewsQuery, dataKey: 'salesChannelViews', filterable: true, isEdge: true, addLookup: true, lookupKeys: ['id'], queryVariables: { filters: { salesChannel: { id: { exact: salesChannelId } } } } }
+  ],
+  orders: []
+});
+
+export const amazonDefaultUnitConfiguratorsListingConfigConstructor = (t: Function, specificIntegrationId): ListingConfig => ({
+  headers: [
+    t('shared.labels.name'),
+    t('integrations.show.properties.labels.code'),
+    t('integrations.show.propertySelectValues.labels.marketplace'),
+    t('shared.labels.unit')
+  ],
+  fields: [
+    { name: 'name', type: FieldType.Text },
+    { name: 'code', type: FieldType.Text },
+    { name: 'marketplace', type: FieldType.NestedText, keys: ['name'], showLabel: true },
+    { name: 'selectedUnit', type: FieldType.Text }
+  ],
+  identifierKey: 'id',
+  urlQueryParams: {integrationId: specificIntegrationId },
+  addActions: true,
+  addEdit: true,
+  addShow: true,
+  editUrlName: 'integrations.amazonDefaultUnitConfigurators.edit',
+  showUrlName: 'integrations.amazonDefaultUnitConfigurators.edit',
+  addDelete: false,
+  addPagination: true,
+});
+
+export const listingQueryKey = 'amazonDefaultUnitConfigurators';
+export const listingQuery = amazonDefaultUnitConfiguratorsQuery;

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/containers/IntegrationsAmazonDefaultUnitConfiguratorEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/containers/IntegrationsAmazonDefaultUnitConfiguratorEditController.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter, useRoute } from 'vue-router';
+import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
+import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
+import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
+import { amazonDefaultUnitConfiguratorEditFormConfigConstructor } from '../configs';
+import { FormConfig } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
+
+const { t } = useI18n();
+const router = useRouter();
+const route = useRoute();
+
+const configuratorId = ref(String(route.params.id));
+const type = ref(String(route.params.type));
+const integrationId = route.query.integrationId?.toString() || '';
+const salesChannelId = route.query.salesChannelId?.toString() || '';
+const isWizard = route.query.wizard === '1';
+const formConfig = ref<FormConfig | null>(null);
+
+onMounted(() => {
+  formConfig.value = amazonDefaultUnitConfiguratorEditFormConfigConstructor(t, type.value, configuratorId.value, integrationId);
+  if (isWizard) {
+    formConfig.value.addSubmitAndContinue = false;
+    formConfig.value.cancelUrl = { name: 'integrations.integrations.show', params: { type: type.value, id: integrationId }, query: { tab: 'defaultUnits' } };
+    formConfig.value.submitUrl = { name: 'integrations.integrations.show', params: { type: type.value, id: integrationId }, query: { tab: 'defaultUnits' } };
+  }
+});
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:breadcrumbs>
+      <Breadcrumbs
+        :links="[
+          { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
+          { path: { name: 'integrations.integrations.show', params: {id: integrationId, type: type}, query: {tab: 'defaultUnits'} }, name: t('integrations.show.amazon.title') },
+          { name: t('integrations.show.mapSelectValue') }
+        ]" />
+    </template>
+    <template v-slot:content>
+      <GeneralForm v-if="formConfig" :config="formConfig" />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/index.ts
@@ -1,0 +1,1 @@
+export { default as AmazonDefaultUnitConfigurators } from './AmazonDefaultUnitConfigurators.vue';

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/index.ts
@@ -1,0 +1,1 @@
+export { default as DefaultUnitConfigurators } from './DefaultUnitConfigurators.vue';

--- a/src/core/integrations/routes.ts
+++ b/src/core/integrations/routes.ts
@@ -55,6 +55,12 @@ export const routes = [
     component: () => import('./integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue'),
   },
   {
+    path: '/integrations/:type/amazon-default-unit-configurator/:id',
+    name: 'integrations.amazonDefaultUnitConfigurators.edit',
+    meta: { title: 'integrations.show.sections.defaultUnits' },
+    component: () => import('./integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/containers/IntegrationsAmazonDefaultUnitConfiguratorEditController.vue'),
+  },
+  {
     path: '/integrations/:type/import/:integrationId',
     name: 'integrations.imports.create',
     meta: { title: 'integrations.imports.create.title' },


### PR DESCRIPTION
## Summary
- move Amazon unit configurators management into a dedicated tab
- provide listing and edit controller for default unit configurators
- update dashboard card to link to the new tab
- remove units section from Amazon general tab

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68750bfa623c832ebe643a9d91c5a38c

## Summary by Sourcery

Extract Amazon default unit configurator management into its own tab and implement listing and edit interfaces, remove the units section from the general Amazon tab, and update navigation links and dashboard cards to point to the new tab.

New Features:
- Add a dedicated Default Units tab in the Amazon integration view
- Implement listing interface for Amazon default unit configurators
- Implement edit screen for individual Amazon default unit configurators with form configuration

Enhancements:
- Remove unit configurator logic and UI from the Amazon general tab