### PR TITLE
Add loader and error handling to Amazon product type import

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2198,6 +2198,9 @@
           "productTypeCode": "Amazon identifier for this product type.",
           "name": "Name of a product using this type, if available.",
           "productRule": "Select the local product rule to link with this Amazon product type."
+        },
+        "errors": {
+          "noSuggestions": "No recommended product types found."
         }
       },
       "properties": {


### PR DESCRIPTION
## Summary
- improve Amazon product type import UI
- show loader and inline errors on search
- display "no recommended product types" message when none found

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687610fefe60832eb471cceb6018e176