### PR TITLE
Improve Amazon product type mapping UI

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2192,12 +2192,18 @@
         "title": "Amazon Rules",
         "labels": {
           "productTypeCode": "Product Type Code",
-          "productRule": "Product Rule"
+          "productRule": "Product Rule",
+          "productName": "Product name",
+          "selectedProductType": "Selected product type"
         },
         "help": {
           "productTypeCode": "Amazon identifier for this product type.",
-          "name": "Name of a product using this type, if available.",
+          "productName": "Provide a product name and Amazon will suggest matching types.",
           "productRule": "Select the local product rule to link with this Amazon product type."
+        },
+        "titles": {
+          "suggestUsingName": "Get suggestion using product name",
+          "searchInAll": "Search in all"
         },
         "errors": {
           "noSuggestions": "No recommended product types found."


### PR DESCRIPTION
## Summary
- show selected Amazon product type
- support searching all product types and selecting from a filterable selector
- use product type name when saving
- add translations for new labels and help text

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876193b5404832e8c972da509fb2f9f

## Summary by Sourcery

Improve the Amazon product type mapping UI by supporting both name-based suggestions and full-list browsing, displaying the chosen product type, and persisting its code and display name with updated translations.

New Features:
- Add full-list browsing of Amazon product types via a filterable selector scoped to the selected marketplace
- Provide name-based search suggestions for Amazon product types
- Show the selected product type’s display name in the mapping form
- Store the selected product type code and name when saving

Enhancements:
- Refactor the Amazon product type mapping component to streamline selection logic and payload construction

Documentation:
- Include translations for new UI labels, help text, and section headings