### PR TITLE
Add card for locally unmapped Amazon product types

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -157,6 +157,10 @@
           "title": "Unmapped Product Types",
           "description": "Amazon product types that need mapping."
         },
+        "unmappedLocalProductTypes": {
+          "title": "Unmapped Local Product Types",
+          "description": "Local product types that need mapping to Amazon."
+        },
         "unmappedSelectValues": {
           "title": "Unmapped Select Values",
           "description": "Amazon property values that need mapping."


### PR DESCRIPTION
## Summary
- show unmapped local product types in Amazon dashboard section
- add i18n strings for the new dashboard card

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68761dea4ee0832ea0d40f989bcddcb8

## Summary by Sourcery

Add a new dashboard card to display locally unmapped Amazon product types and include corresponding localization.

New Features:
- Display a card for locally unmapped Amazon product types in the Amazon dashboard section
- Fetch the count of locally unmapped product types via a GraphQL query

Documentation:
- Add i18n strings for the unmapped local product types dashboard card