### PR TITLE
Add pull local rules button for Amazon product types

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2264,6 +2264,7 @@
       },
       "generateProperty": "Generate Property",
       "generateProductType": "Generate Product Type",
+      "pullLocalRules": "Pull Local Rules",
       "generatePropertySelectValue": "Generate Select Value",
       "mapProperty": "Map Property",
       "mapProductType": "Map Product Type",

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -526,6 +526,14 @@ export const updateAmazonProductTypeMutation = gql`
   }
 `;
 
+export const createAmazonProductTypesFromLocalRulesMutation = gql`
+  mutation createAmazonProductTypesFromLocalRules($data: AmazonSalesChannelPartialInput!) {
+    createAmazonProductTypesFromLocalRules(instance: $data) {
+      id
+    }
+  }
+`;
+
 export const suggestAmazonProductTypeMutation = gql`
   mutation suggestAmazonProductType($name: String, $marketplace: SalesChannelViewPartialInput!) {
     suggestAmazonProductType(name: $name, marketplace: $marketplace) {


### PR DESCRIPTION
## Summary
- add GraphQL mutation to create Amazon product types from local rules
- expose new translation key
- add pull local rules button in Amazon product type listing

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68764e222bf4832eb94b476e13fd747f

## Summary by Sourcery

Add functionality to pull local rules for Amazon product types via a new GraphQL mutation and UI control

New Features:
- Introduce createAmazonProductTypesFromLocalRules GraphQL mutation
- Add “Pull Local Rules” button to the Amazon product types listing
- Implement pullLocalRules handler to invoke the mutation, show success/error toasts, and refresh the listing

Documentation:
- Add new translation key for pullLocalRules button label