### PR TITLE
Add validation issue column to issues modal

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/websites/containers/issues-info-modal/IssuesInfoModal.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/issues-info-modal/IssuesInfoModal.vue
@@ -3,6 +3,7 @@ import { Ref, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Card } from "../../../../../../../../../shared/components/atoms/card";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { Modal } from "../../../../../../../../../shared/components/atoms/modal";
 import { Loader } from "../../../../../../../../../shared/components/atoms/loader";
 import apolloClient from "../../../../../../../../../../apollo-client";
@@ -11,6 +12,7 @@ import { refreshLatestAmazonIssuesMutation } from "../../../../../../../../../sh
 export interface FormattedIssue {
   message?: string | null;
   severity?: string | null;
+  validationIssue?: boolean | null;
 }
 
 const props = defineProps<{ modelValue: boolean; issues?: FormattedIssue[] | null; id?: string | null }>();
@@ -62,12 +64,33 @@ const closeModal = () => {
             {{ t('integrations.salesChannel.modal.issues.title') }}
           </h3>
         </div>
-        <ul class="space-y-2 max-h-96 overflow-y-auto">
-          <li v-for="(issue, index) in issues" :key="index" class="flex justify-between">
-            <span class="break-words">{{ issue.message }}</span>
-            <span class="font-semibold capitalize ml-4">{{ issue.severity }}</span>
-          </li>
-        </ul>
+        <div class="mb-4 overflow-y-auto max-h-96" :class="issues.length > 0 ? 'table-responsive custom-table-scroll' : ''">
+          <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+            <thead>
+              <tr>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                  {{ t('shared.labels.message') }}
+                </th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                  {{ t('shared.labels.severity') }}
+                </th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                  {{ t('shared.labels.validationIssue') }}
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <tr v-for="(issue, index) in issues" :key="index">
+                <td class="break-words">{{ issue.message }}</td>
+                <td class="capitalize">{{ issue.severity }}</td>
+                <td>
+                  <Icon v-if="issue.validationIssue" name="check-circle" class="text-green-500" />
+                  <Icon v-else name="times-circle" class="text-red-500" />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         <hr />
         <div class="flex justify-end gap-4 mt-4">
           <Button class="btn btn-primary" @click="fetchIssues">{{ t('shared.button.refresh') }}</Button>


### PR DESCRIPTION
## Summary
- add Icon import and new `validationIssue` field
- show issues in a table layout
- display a boolean icon for validationIssue

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687667b1d164832ea2329a31d7ccc5ee

## Summary by Sourcery

Replace the issues list with a table in the Issues modal, add a validationIssue field, and render its status using boolean icons.

New Features:
- Use a table layout to display issues with columns for message, severity, and validation status
- Introduce a validationIssue boolean field in the issues data model

Enhancements:
- Import and utilize the Icon component to render check-circle or times-circle icons based on validationIssue