### PR TITLE
Fix issues modal labels

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/websites/containers/issues-info-modal/IssuesInfoModal.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/issues-info-modal/IssuesInfoModal.vue
@@ -81,7 +81,7 @@ const closeModal = () => {
             </thead>
             <tbody class="divide-y divide-gray-200 bg-white">
               <tr v-for="(issue, index) in issues" :key="index">
-                <td class="break-words">{{ issue.message }}</td>
+                <td class="break-words max-w-xs">{{ issue.message }}</td>
                 <td class="capitalize">{{ issue.severity }}</td>
                 <td>
                   <Icon v-if="issue.validationIssue" name="check-circle" class="text-green-500" />

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -9,6 +9,11 @@
       "red": "Rot",
       "green": "Grün",
       "orange": "Orange"
+    },
+    "labels": {
+      "message": "Nachricht",
+      "severity": "Schweregrad",
+      "validationIssue": "Validierungsfehler"
     }
   },
   "auth": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -380,7 +380,10 @@
       "default": "Default",
       "submissionId": "Submission ID",
       "processingStatus": "Processing Status",
-      "issues": "Issues"
+      "issues": "Issues",
+      "message": "Message",
+      "severity": "Severity",
+      "validationIssue": "Validation Issue"
     },
     "validations": {
       "quantity": "Please enter a valid quantity"

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -9,6 +9,11 @@
       "red": "Rouge",
       "green": "Vert",
       "orange": "Orange"
+    },
+    "labels": {
+      "message": "Message",
+      "severity": "Gravité",
+      "validationIssue": "Problème de validation"
     }
   },
   "auth": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -219,7 +219,10 @@
       "image": "Afbeelding",
       "preview": "Preview",
       "discount": "Korting",
-      "discountPrice": ""
+      "discountPrice": "",
+      "message": "Bericht",
+      "severity": "Ernst",
+      "validationIssue": "Validatiefout"
     },
     "validations": {
       "quantity": "Voer een geldige hoeveelheid in"


### PR DESCRIPTION
## Summary
- add translations for message, severity, and validation issue labels
- cap the message column width in IssuesInfoModal

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68766b52ba98832ea81b200746e04c16

## Summary by Sourcery

Provide translations for issues modal labels and constrain the message column width in IssuesInfoModal

Enhancements:
- Add locale entries for message, severity, and validation issue labels
- Apply a max width (max-w-xs) to the message cell in the IssuesInfoModal table