### PR TITLE
Fix alias product variation tab

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
@@ -83,7 +83,7 @@ const getQueryKey = () => {
                       @refetched="handleRefeched"
                       @update-ids="getIds" />
 
-      <div class="mt-2">
+      <div v-if="product.type !== ProductType.Alias" class="mt-2">
         <VariationCreate :product="product" :variation-ids="ids" @variation-added="handleVariationAdded" />
       </div>
     </template>


### PR DESCRIPTION
## Summary
- show variations for alias products from the target product
- disable editing bundle items/variations on alias products

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687aa107a25c832e97bd9967c86d58fb

## Summary by Sourcery

Adapt the product variations tab to correctly handle alias products by showing the parent product's variations and disabling modification controls on aliases.

Bug Fixes:
- Display variations from the parent product when viewing an alias product.
- Prevent editing or deleting bundle items and variation quantities on alias products.

Enhancements:
- Introduce computed properties (isAlias, parentId, parentType) to unify type/ID logic and simplify queries and mutations.
- Hide the variation creation form and action buttons for alias products.