### PR TITLE
Add reusable icon field for status display

### DIFF
--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -12,7 +12,7 @@ import { productsQuery } from "../../../shared/api/queries/products.js"
 import { vatRatesQuery } from "../../../shared/api/queries/vatRates.js";
 import { createVatRateMutation } from "../../../shared/api/mutations/vatRates.js";
 import { baseFormConfigConstructor as baseVatRateConfigConstructor } from '../../settings/vat-rates/configs'
-import { Badge } from "../../../shared/components/organisms/general-show/showConfig";
+import { Badge, Icon } from "../../../shared/components/organisms/general-show/showConfig";
 import { propertySelectValuesQuerySelector } from "../../../shared/api/queries/properties.js";
 import { amazonChannelsQuerySelector } from "../../../shared/api/queries/salesChannels.js";
 import { deleteProductsMutation } from "../../../shared/api/mutations/products.js";
@@ -88,6 +88,22 @@ export const getInspectorStatusBadgeMap = (t?: Function): Record<string, Badge> 
   return {
     ...badgeMap,
     default: defaultBadge,
+  };
+};
+
+export const getInspectorStatusIconMap = (t?: Function): Record<string, Icon> => {
+  const translate = (key: string) => (t ? t(key) : key);
+  const defaultIcon: Icon = { name: 'circle-xmark', color: 'red', hoverText: translate('shared.colors.red') };
+
+  const iconMap: Record<InspectorStatusType, Icon> = {
+    [InspectorStatus.GREEN]: { name: 'circle-check', color: 'green', hoverText: translate('shared.colors.green') },
+    [InspectorStatus.ORANGE]: { name: 'circle-exclamation', color: 'orange', hoverText: translate('shared.colors.orange') },
+    [InspectorStatus.RED]: defaultIcon,
+  };
+
+  return {
+    ...iconMap,
+    default: defaultIcon,
   };
 };
 
@@ -336,8 +352,8 @@ export const listingConfigConstructor = (t: Function, isMainPage: boolean = fals
     },
     {
       name: 'inspectorStatus',
-      type: FieldType.Badge,
-      badgeMap: getInspectorStatusBadgeMap(t),
+      type: FieldType.Icon,
+      iconMap: getInspectorStatusIconMap(t),
     },
     {
       type: FieldType.Badge,

--- a/src/core/products/products/product-show/containers/tabs/alias-parents/containers/alias-parents-list/AliasParentsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/alias-parents/containers/alias-parents-list/AliasParentsList.vue
@@ -5,13 +5,28 @@ import { ProductWithAliasFields } from "../../../../../../configs";
 import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { Badge } from "../../../../../../../../../shared/components/atoms/badge";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
-import { getProductTypeBadgeMap, getInspectorStatusBadgeMap } from "../../../../../../configs";
+import { getProductTypeBadgeMap, getInspectorStatusIconMap } from "../../../../../../configs";
 import { shortenText } from "../../../../../../../../../shared/utils";
 
 const props = defineProps<{ products: ProductWithAliasFields[] }>();
 const { t } = useI18n();
 
 const aliasProducts = computed(() => props.products ?? []);
+
+function iconColorClass(color?: string) {
+  switch (color) {
+    case 'green':
+      return 'text-green-500';
+    case 'yellow':
+      return 'text-yellow-500';
+    case 'orange':
+      return 'text-orange-500';
+    case 'red':
+      return 'text-red-500';
+    default:
+      return '';
+  }
+}
 </script>
 
 <template>
@@ -61,7 +76,12 @@ const aliasProducts = computed(() => props.products ?? []);
             <Icon v-else name="times-circle" class="text-red-500" />
           </td>
           <td>
-            {{ getInspectorStatusBadgeMap(t)[alias.inspectorStatus]?.text || '-' }}
+            <Icon
+              :name="getInspectorStatusIconMap(t)[alias.inspectorStatus]?.name"
+              size="sm"
+              :class="iconColorClass(getInspectorStatusIconMap(t)[alias.inspectorStatus]?.color)"
+              :title="getInspectorStatusIconMap(t)[alias.inspectorStatus]?.hoverText"
+            />
           </td>
         </tr>
       </tbody>

--- a/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getInspectorStatusBadgeMap, Product, getProductTypeBadgeMap } from "../../../../../../configs";
+import { getInspectorStatusIconMap, Product, getProductTypeBadgeMap } from "../../../../../../configs";
 import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { useI18n } from "vue-i18n";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
@@ -15,6 +15,21 @@ const props = defineProps<{ product: Product }>();
 
 const parents = ref<any[]>([]);
 const loading = ref(true);
+
+function iconColorClass(color?: string) {
+  switch (color) {
+    case 'green':
+      return 'text-green-500';
+    case 'yellow':
+      return 'text-yellow-500';
+    case 'orange':
+      return 'text-orange-500';
+    case 'red':
+      return 'text-red-500';
+    default:
+      return '';
+  }
+}
 
 const fetchConfigurableVariations = async () => {
   const { data } = await apolloClient.query({
@@ -111,7 +126,12 @@ onMounted(async () => {
               <Icon v-else name="times-circle" class="text-red-500" />
             </td>
             <td>
-              {{ getInspectorStatusBadgeMap(t)[parent.inspectorStatus]?.text || '-' }}
+              <Icon
+                :name="getInspectorStatusIconMap(t)[parent.inspectorStatus]?.name"
+                size="sm"
+                :class="iconColorClass(getInspectorStatusIconMap(t)[parent.inspectorStatus]?.color)"
+                :title="getInspectorStatusIconMap(t)[parent.inspectorStatus]?.hoverText"
+              />
             </td>
           </tr>
         </tbody>

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import {getInspectorStatusBadgeMap, Product} from "../../../../../../configs";
+import {getInspectorStatusIconMap, Product} from "../../../../../../configs";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
 import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import {useI18n} from "vue-i18n";
@@ -32,6 +32,21 @@ const localQuantities = ref<{ [key: string]: number }>({});
 const isAlias = computed(() => props.product.type === ProductType.Alias);
 const parentId = computed(() => isAlias.value ? props.product.aliasParentProduct.id : props.product.id);
 const parentType = computed(() => isAlias.value ? props.product.aliasParentProduct.type : props.product.type);
+
+function iconColorClass(color?: string) {
+  switch (color) {
+    case 'green':
+      return 'text-green-500';
+    case 'yellow':
+      return 'text-yellow-500';
+    case 'orange':
+      return 'text-orange-500';
+    case 'red':
+      return 'text-red-500';
+    default:
+      return '';
+  }
+}
 
 const initializeLocalQuantities = (data) => {
   if (
@@ -164,7 +179,12 @@ const handleQuantityChanged = debounce(async (event, id) => {
                     <Icon v-else name="times-circle" class="ml-2 text-red-500" />
                   </td>
                   <td>
-                    {{ getInspectorStatusBadgeMap(t)[item.node.variation.inspectorStatus].text }}
+                    <Icon
+                      :name="getInspectorStatusIconMap(t)[item.node.variation.inspectorStatus].name"
+                      size="sm"
+                      :class="iconColorClass(getInspectorStatusIconMap(t)[item.node.variation.inspectorStatus].color)"
+                      :title="getInspectorStatusIconMap(t)[item.node.variation.inspectorStatus].hoverText"
+                    />
                   </td>
                   <td v-if="parentType != ProductType.Configurable">
                     <template v-if="isAlias">

--- a/src/shared/components/organisms/general-show/containers/field-icon/FieldIcon.vue
+++ b/src/shared/components/organisms/general-show/containers/field-icon/FieldIcon.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { Icon } from '../../../../atoms/icon';
+import { IconField } from '../../showConfig';
+
+const props = defineProps<{
+  field: IconField;
+  modelValue: string | number;
+}>();
+
+function getIconData(key: string | number) {
+  return props.field.iconMap[key];
+}
+
+function colorClass(color?: string) {
+  switch (color) {
+    case 'green':
+      return 'text-green-500';
+    case 'yellow':
+      return 'text-yellow-500';
+    case 'orange':
+      return 'text-orange-500';
+    case 'red':
+      return 'text-red-500';
+    default:
+      return '';
+  }
+}
+</script>
+
+<template>
+  <div :class="field.customCssClass" :style="field.customCss">
+    <Icon
+      v-if="modelValue && getIconData(modelValue)"
+      :name="getIconData(modelValue).name"
+      :size="getIconData(modelValue).size || 'sm'"
+      :class="colorClass(getIconData(modelValue).color)"
+      :title="getIconData(modelValue).hoverText" />
+    <span v-else>{{ modelValue }}</span>
+  </div>
+</template>

--- a/src/shared/components/organisms/general-show/containers/field-icon/index.ts
+++ b/src/shared/components/organisms/general-show/containers/field-icon/index.ts
@@ -1,0 +1,1 @@
+export { default as FieldIcon } from './FieldIcon.vue';

--- a/src/shared/components/organisms/general-show/showConfig.ts
+++ b/src/shared/components/organisms/general-show/showConfig.ts
@@ -10,6 +10,7 @@ import {FieldDate} from "./containers/field-date";
 import {FieldEmail} from "./containers/field-email";
 import {FieldWebsite} from "./containers/field-website";
 import {FieldBadge} from "./containers/field-badge";
+import {FieldIcon} from "./containers/field-icon";
 import {FieldIndividualFile} from "./containers/field-individual-file";
 
 export interface ShowBaseField {
@@ -79,12 +80,24 @@ export interface Badge {
   hoverText?: string;
 }
 
+export interface Icon {
+  name: string;
+  size?: string;
+  color?: 'green' | 'yellow' | 'orange' | 'red';
+  hoverText?: string;
+}
+
 export interface BadgeField extends ShowBaseField {
   type: FieldType.Badge;
   badgeMap: Record<string, Badge>;
 }
 
-export type ShowField = DateField | PhoneField | ArrayField | TextField | BooleanField | ImageField | NestedTextField | EmailField | WebsiteField | BadgeField | IndividualFileField;
+export interface IconField extends ShowBaseField {
+  type: FieldType.Icon;
+  iconMap: Record<string, Icon>;
+}
+
+export type ShowField = DateField | PhoneField | ArrayField | TextField | BooleanField | ImageField | NestedTextField | EmailField | WebsiteField | BadgeField | IconField | IndividualFileField;
 
 export const updateField = (showConfig, fieldName, newConfig) => {
   const fieldIndex = showConfig.fields.findIndex(field => field.name === fieldName);
@@ -104,6 +117,7 @@ export const getFieldComponent = (type) => {
     case FieldType.Date: return FieldDate;
     case FieldType.Email: return FieldEmail;
     case FieldType.Website: return FieldWebsite;
+    case FieldType.Icon: return FieldIcon;
     case FieldType.Badge: return FieldBadge;
     case FieldType.IndividualFile: return FieldIndividualFile;
     default: return null;

--- a/src/shared/components/organisms/variations-adder/VariationsAdder.vue
+++ b/src/shared/components/organisms/variations-adder/VariationsAdder.vue
@@ -14,7 +14,7 @@ import Swal from 'sweetalert2';
 import {Pagination} from "../../molecules/pagination";
 import {Link} from "../../atoms/link";
 import {Image} from "../../atoms/image";
-import {getInspectorStatusBadgeMap} from "../../../../core/products/products/configs";
+import {getInspectorStatusIconMap} from "../../../../core/products/products/configs";
 import {Label} from "../../atoms/label";
 import { shortenText } from "../../../utils";
 
@@ -36,6 +36,21 @@ const limit = ref(10);
 const filterSameProductType = ref(true);
 const fetchPaginationData = ref({});
 fetchPaginationData.value['first'] = limit.value;
+
+function iconColorClass(color?: string) {
+  switch (color) {
+    case 'green':
+      return 'text-green-500';
+    case 'yellow':
+      return 'text-yellow-500';
+    case 'orange':
+      return 'text-orange-500';
+    case 'red':
+      return 'text-red-500';
+    default:
+      return '';
+  }
+}
 
 const fetchData = async () => {
   const excludedIds = props.addedVariations.map(product => product.id);
@@ -303,7 +318,12 @@ onMounted(fetchData);
               <Icon v-else name="times-circle" class="ml-2 text-red-500" />
             </td>
             <td>
-              {{ getInspectorStatusBadgeMap(t)[variation.inspectorStatus].text }}
+              <Icon
+                :name="getInspectorStatusIconMap(t)[variation.inspectorStatus].name"
+                size="sm"
+                :class="iconColorClass(getInspectorStatusIconMap(t)[variation.inspectorStatus].color)"
+                :title="getInspectorStatusIconMap(t)[variation.inspectorStatus].hoverText"
+              />
             </td>
           </tr>
         </tbody>
@@ -357,7 +377,12 @@ onMounted(fetchData);
               <Icon v-else name="times-circle" class="ml-2 text-red-500" />
             </td>
             <td>
-              {{ getInspectorStatusBadgeMap(t)[item.inspectorStatus].text }}
+              <Icon
+                :name="getInspectorStatusIconMap(t)[item.inspectorStatus].name"
+                size="sm"
+                :class="iconColorClass(getInspectorStatusIconMap(t)[item.inspectorStatus].color)"
+                :title="getInspectorStatusIconMap(t)[item.inspectorStatus].hoverText"
+              />
             </td>
             <td v-if="hasQty()">{{ item.quantity }}</td>
           </tr>

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -25,6 +25,7 @@ export enum FieldType {
   Phone = "Phone",
   Email = "Email",
   Website = "Website",
+  Icon = "Icon",
   Badge = "Badge",
   InlineItems = "InlineItems",
   IndividualFile = "IndividualFile", // not from the media app but adding individually


### PR DESCRIPTION
## Summary
- support `Icon` field type for general shows
- map inspector status values to colored icons
- show status icons in listings and variation components

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab38ceb74832ea60941abac4bc3c1

## Summary by Sourcery

Add a reusable icon field and inspector status icon mapping, and replace status badges with colored icons across various product components.

New Features:
- Introduce IconField type and FieldIcon component to support icon-based fields in general-show
- Add getInspectorStatusIconMap to map inspector statuses to icon names, colors, and hover texts

Enhancements:
- Replace inspector status badges with icons in VariationsAdder, AliasParentsList, ParentsList, VariationsList, and listingConfigConstructor