### PR TITLE
Add property duplicate check modal

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -320,7 +320,9 @@
       "translate": "Translate",
       "deleteAll": "Delete all",
       "editAll": "Edit all",
-      "change": "Change"
+      "change": "Change",
+      "createAnyway": "Create anyway",
+      "abort": "Abort"
     },
     "colors": {
       "red": "Red",
@@ -2042,8 +2044,12 @@
         "date": "Date",
         "datetime": "Date and Time",
         "select": "Single Select",
-        "multiselect": "Multiselect"
+      "multiselect": "Multiselect"
       }
+    },
+    "duplicateModal": {
+      "title": "Properties with similar name found",
+      "content": "Select an existing property below or create the new one anyway."
     },
     "values": {
       "title": "Select Values",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -177,7 +177,9 @@
       "generate": "Genereren",
       "change": "Wijzig",
       "fix": "Fixen",
-      "downloadConfirmation": ""
+      "downloadConfirmation": "",
+      "createAnyway": "Toch aanmaken",
+      "abort": "Afbreken"
     },
     "colors": {
       "red": "Rood",
@@ -1708,8 +1710,12 @@
         "date": "Datum",
         "datetime": "Datum en Tijd",
         "select": "Enkele keuze",
-        "multiselect": "Meerdere keuzes"
+      "multiselect": "Meerdere keuzes"
       }
+    },
+    "duplicateModal": {
+      "title": "Eigenschappen met gelijkaardige naam gevonden",
+      "content": "Selecteer een bestaande eigenschap of maak toch een nieuwe aan."
     },
     "values": {
       "title": "Selectie Waardes",

--- a/src/shared/api/mutations/properties.js
+++ b/src/shared/api/mutations/properties.js
@@ -10,6 +10,18 @@ export const createPropertyMutation = gql`
   }
 `;
 
+export const checkPropertyForDuplicatesMutation = gql`
+  mutation checkPropertyForDuplicates($data: PropertyInput!) {
+    checkPropertyForDuplicates(data: $data) {
+      duplicateFound
+      duplicates {
+        id
+        name
+      }
+    }
+  }
+`;
+
 export const createPropertiesMutation = gql`
   mutation createProperties($data: [PropertyInput!]!) {
     createProperties(data: $data) {

--- a/src/shared/components/molecules/duplicate-modal/DuplicateModal.vue
+++ b/src/shared/components/molecules/duplicate-modal/DuplicateModal.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { Modal } from '../../../../shared/components/atoms/modal';
+import { Card } from '../../../../shared/components/atoms/card';
+import { Button } from '../../../../shared/components/atoms/button';
+
+interface DuplicateItem {
+  label: string;
+  urlParam: any;
+}
+
+const props = withDefaults(defineProps<{
+  modelValue: boolean;
+  title: string;
+  content?: string;
+  items?: DuplicateItem[];
+}>(), {
+  content: '',
+  items: () => [],
+});
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'create-anyway'): void;
+}>();
+
+const router = useRouter();
+const { t } = useI18n();
+const localShowModal = ref(props.modelValue);
+
+watch(() => props.modelValue, (val) => {
+  localShowModal.value = val;
+});
+
+const close = () => {
+  localShowModal.value = false;
+  emit('update:modelValue', false);
+};
+
+const createAnyway = () => {
+  emit('create-anyway');
+  close();
+};
+
+const openItem = (item: DuplicateItem) => {
+  router.push(item.urlParam);
+  close();
+};
+</script>
+
+<template>
+  <Modal v-model="localShowModal" @closed="close">
+    <Card class="modal-content w-1/3">
+      <h1 class="text-xl font-semibold text-center mb-4">{{ title }}</h1>
+      <p v-if="content" class="mb-4">{{ content }}</p>
+      <ul v-if="items.length" class="list-disc pl-5 mb-4">
+        <li v-for="(item, index) in items" :key="index">
+          <button type="button" class="text-primary underline" @click="openItem(item)">
+            {{ item.label }}
+          </button>
+        </li>
+      </ul>
+      <div class="flex justify-end gap-4 mt-4">
+        <Button class="btn btn-primary" @click="createAnyway">{{ t('shared.button.createAnyway') }}</Button>
+        <Button class="btn btn-outline-dark" @click="close">{{ t('shared.button.abort') }}</Button>
+      </div>
+    </Card>
+  </Modal>
+</template>

--- a/src/shared/components/molecules/duplicate-modal/index.ts
+++ b/src/shared/components/molecules/duplicate-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as DuplicateModal } from './DuplicateModal.vue';


### PR DESCRIPTION
## Summary
- add `checkPropertyForDuplicatesMutation`
- create `DuplicateModal` component for listing similar items
- check for duplicates before creating properties
- update locales with duplicate modal strings

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dff55b554832e99b1e4b67715f5a9

## Summary by Sourcery

Add a pre-creation duplicate check to the property creation flow by introducing a new GraphQL mutation and a reusable modal for handling detected duplicates.

New Features:
- Introduce checkPropertyForDuplicatesMutation GraphQL mutation
- Implement DuplicateModal component to list and navigate to similar properties
- Integrate duplicate checking into the property creation controller before actual creation

Enhancements:
- Extract dedicated createProperty function and adjust flow to allow forced creation
- Update English and Dutch locales with duplicate modal strings