### PR TITLE
Add inspector progress listing field

### DIFF
--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -351,9 +351,8 @@ export const listingConfigConstructor = (t: Function, isMainPage: boolean = fals
       name: 'sku'
     },
     {
-      name: 'inspectorStatus',
-      type: FieldType.Icon,
-      iconMap: getInspectorStatusIconMap(t),
+      name: 'percentageInspectorStatus',
+      type: FieldType.InspectorProgress,
     },
     {
       type: FieldType.Badge,
@@ -469,6 +468,11 @@ export interface ProductWithAliasFields extends Product {
   name: string;
   thumbnailUrl?: string;
   inspectorStatus: number;
+  percentageInspectorStatus?: {
+    percentage: number;
+    inspectorStatus: number;
+    blocks: { code: string | number; completed: boolean }[];
+  };
 }
 
 

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -12,7 +12,14 @@ query Products($first: Int, $last: Int, $after: String, $before: String, $order:
           type
           proxyId
           thumbnailUrl
-          inspectorStatus
+          percentageInspectorStatus {
+            percentage
+            inspectorStatus
+            blocks {
+              code
+              completed
+            }
+          }
           vatRate {
             id
             name

--- a/src/shared/components/organisms/general-show/containers/field-inspector-progress/FieldInspectorProgress.vue
+++ b/src/shared/components/organisms/general-show/containers/field-inspector-progress/FieldInspectorProgress.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed, ref, onMounted, onUnmounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Popover } from '../../../../atoms/popover';
+import { Icon } from '../../../../atoms/icon';
+import { InspectorProgressField } from '../../showConfig';
+import { InspectorStatus } from '../../../../../utils/constants';
+
+const props = defineProps<{
+  field: InspectorProgressField;
+  modelValue: {
+    percentage: number;
+    inspectorStatus: number;
+    blocks: { code: string | number; completed: boolean }[];
+  } | null;
+}>();
+
+const { t } = useI18n();
+
+const isMobile = ref(false);
+const updateIsMobile = () => {
+  isMobile.value = window.innerWidth <= 768;
+};
+
+onMounted(() => {
+  updateIsMobile();
+  window.addEventListener('resize', updateIsMobile);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateIsMobile);
+});
+
+const label = computed(() => {
+  if (!props.modelValue) return '';
+  return props.modelValue.percentage < 100
+    ? t('shared.labels.processing')
+    : t('shared.labels.completed');
+});
+
+const labelColor = computed(() => {
+  if (!props.modelValue) return '';
+  if (props.modelValue.percentage < 100) return 'text-yellow-500';
+  switch (props.modelValue.inspectorStatus) {
+    case InspectorStatus.GREEN:
+      return 'text-green-600';
+    case InspectorStatus.ORANGE:
+      return 'text-orange-600';
+    case InspectorStatus.RED:
+      return 'text-red-600';
+    default:
+      return '';
+  }
+});
+
+const barColor = computed(() => {
+  if (!props.modelValue) return '';
+  if (props.modelValue.percentage < 100) return 'bg-yellow-400';
+  switch (props.modelValue.inspectorStatus) {
+    case InspectorStatus.GREEN:
+      return 'bg-green-500';
+    case InspectorStatus.ORANGE:
+      return 'bg-orange-500';
+    case InspectorStatus.RED:
+      return 'bg-red-500';
+    default:
+      return 'bg-gray-400';
+  }
+});
+</script>
+
+<template>
+  <div :class="field.customCssClass" :style="field.customCss">
+    <Popover position="bottom" :hover="!isMobile">
+      <template #trigger>
+        <div>
+          <div class="flex justify-between mb-1">
+            <span :class="['text-base', 'font-medium', labelColor, 'hidden sm:block']">
+              {{ label }}
+            </span>
+            <span :class="[labelColor, 'text-sm', 'font-medium', 'block sm:hidden']">
+              {{ Math.floor(modelValue?.percentage ?? 0) }}%
+            </span>
+          </div>
+          <div class="hidden sm:block w-full bg-gray-200 rounded-full dark:bg-gray-700">
+            <div
+              :class="[barColor, 'text-xs', 'font-medium', 'text-white', 'text-center', 'p-0.5', 'leading-none', 'rounded-full']"
+              :style="{ width: (modelValue?.percentage ?? 0) + '%' }"
+            >
+              <span>{{ Math.floor(modelValue?.percentage ?? 0) }}%</span>
+            </div>
+          </div>
+        </div>
+      </template>
+      <div class="bg-white p-2 rounded shadow-md text-left">
+        <ul>
+          <li v-for="block in modelValue?.blocks" :key="block.code" class="flex items-center gap-2 py-1">
+            <Icon :name="block.completed ? 'circle-check' : 'circle-xmark'" size="sm"
+                  :class="block.completed ? 'text-green-600' : 'text-red-600'" />
+            <span>{{ t(`dashboard.cards.products.inspector.${block.code}.title`) }}</span>
+          </li>
+        </ul>
+      </div>
+    </Popover>
+  </div>
+</template>

--- a/src/shared/components/organisms/general-show/containers/field-inspector-progress/index.ts
+++ b/src/shared/components/organisms/general-show/containers/field-inspector-progress/index.ts
@@ -1,0 +1,1 @@
+export { default as FieldInspectorProgress } from './FieldInspectorProgress.vue';

--- a/src/shared/components/organisms/general-show/showConfig.ts
+++ b/src/shared/components/organisms/general-show/showConfig.ts
@@ -12,6 +12,7 @@ import {FieldWebsite} from "./containers/field-website";
 import {FieldBadge} from "./containers/field-badge";
 import {FieldIcon} from "./containers/field-icon";
 import {FieldIndividualFile} from "./containers/field-individual-file";
+import {FieldInspectorProgress} from "./containers/field-inspector-progress";
 
 export interface ShowBaseField {
   name: string;
@@ -97,7 +98,11 @@ export interface IconField extends ShowBaseField {
   iconMap: Record<string, Icon>;
 }
 
-export type ShowField = DateField | PhoneField | ArrayField | TextField | BooleanField | ImageField | NestedTextField | EmailField | WebsiteField | BadgeField | IconField | IndividualFileField;
+export interface InspectorProgressField extends ShowBaseField {
+  type: FieldType.InspectorProgress;
+}
+
+export type ShowField = DateField | PhoneField | ArrayField | TextField | BooleanField | ImageField | NestedTextField | EmailField | WebsiteField | BadgeField | IconField | IndividualFileField | InspectorProgressField;
 
 export const updateField = (showConfig, fieldName, newConfig) => {
   const fieldIndex = showConfig.fields.findIndex(field => field.name === fieldName);
@@ -120,6 +125,7 @@ export const getFieldComponent = (type) => {
     case FieldType.Icon: return FieldIcon;
     case FieldType.Badge: return FieldBadge;
     case FieldType.IndividualFile: return FieldIndividualFile;
+    case FieldType.InspectorProgress: return FieldInspectorProgress;
     default: return null;
   }
 };

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -27,6 +27,7 @@ export enum FieldType {
   Website = "Website",
   Icon = "Icon",
   Badge = "Badge",
+  InspectorProgress = "InspectorProgress",
   InlineItems = "InlineItems",
   IndividualFile = "IndividualFile", // not from the media app but adding individually
 }


### PR DESCRIPTION
## Summary
- introduce `InspectorProgress` field type
- create FieldInspectorProgress component
- wire new field into product listing config
- extend GraphQL products query to retrieve progress data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e75c2e8bc832ebe499c631171b2cf

## Summary by Sourcery

Add a new InspectorProgress field to product listings and detail views to display inspection progress bars and status popovers.

New Features:
- Introduce FieldType.InspectorProgress and FieldInspectorProgress component for rendering inspection progress
- Integrate the InspectorProgress field into listingConfig and showConfig to display progress in product listings and detail views
- Extend the GraphQL Products query to fetch percentageInspectorStatus data including percentage, inspectorStatus, and blocks

Enhancements:
- Add percentageInspectorStatus field to ProductWithAliasFields interface and update ShowField type to include InspectorProgressField