### PR TITLE
Improve field inspector popover style

### DIFF
--- a/src/shared/components/atoms/popover/Popover.vue
+++ b/src/shared/components/atoms/popover/Popover.vue
@@ -59,3 +59,17 @@ onBeforeUnmount(() => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.popover-content.bottom {
+  top: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.popover-content.middle {
+  top: 50%;
+  left: calc(100% + 0.5rem);
+  transform: translateY(-50%);
+}
+</style>

--- a/src/shared/components/organisms/general-show/containers/field-inspector-progress/FieldInspectorProgress.vue
+++ b/src/shared/components/organisms/general-show/containers/field-inspector-progress/FieldInspectorProgress.vue
@@ -69,7 +69,7 @@ const barColor = computed(() => {
 
 <template>
   <div :class="field.customCssClass" :style="field.customCss">
-    <Popover position="bottom" :hover="!isMobile">
+    <Popover position="middle" :hover="!isMobile">
       <template #trigger>
         <div>
           <div class="w-20 mb-1">
@@ -89,7 +89,11 @@ const barColor = computed(() => {
       </template>
       <div class="bg-white p-4 rounded shadow-md text-left">
         <ul>
-          <li v-for="block in modelValue?.blocks" :key="block.code" class="flex items-center gap-2 py-2 z-50">
+          <li
+            v-for="block in modelValue?.blocks"
+            :key="block.code"
+            class="flex items-center gap-2 py-2 z-50 hover:bg-gray-100 border-b border-gray-200 last:border-b-0"
+          >
             <Icon :name="block.completed ? 'circle-check' : 'circle-xmark'" size="sm"
                   :class="block.completed ? 'text-green-600' : 'text-red-600'" />
             <span>{{ t(`dashboard.cards.products.inspector.${block.code}.title`) }}</span>


### PR DESCRIPTION
## Summary
- adjust popover position to appear beside progress bar
- add hover and separator styles for progress list items
- provide styles for new popover positions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e7f763148832eb6f751cc8a22b0c2