### PR TITLE
Add duplicate product feature

### DIFF
--- a/src/core/products/products/product-show/containers/duplicate-product-modal/DuplicateProductModal.vue
+++ b/src/core/products/products/product-show/containers/duplicate-product-modal/DuplicateProductModal.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Modal } from '../../../../../shared/components/atoms/modal';
+import { Card } from '../../../../../shared/components/atoms/card';
+import { TextInput } from '../../../../../shared/components/atoms/input-text';
+import { Button } from '../../../../../shared/components/atoms/button';
+
+const props = defineProps<{ modelValue: boolean }>();
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'duplicate', sku: string | null): void;
+}>();
+
+const { t } = useI18n();
+const localShowModal = ref(props.modelValue);
+const sku = ref('');
+
+watch(() => props.modelValue, (val) => {
+  localShowModal.value = val;
+});
+
+const closeModal = () => {
+  localShowModal.value = false;
+  emit('update:modelValue', false);
+};
+
+const submit = () => {
+  emit('duplicate', sku.value.trim() === '' ? null : sku.value.trim());
+  closeModal();
+};
+</script>
+
+<template>
+  <div>
+    <Modal v-model="localShowModal" @closed="closeModal">
+      <Card class="modal-content w-1/3">
+        <h3 class="text-xl font-semibold text-center mb-4">{{ t('shared.button.duplicate') }}</h3>
+        <p class="mb-4">{{ t('products.products.duplicateModal.description') }}</p>
+        <TextInput v-model="sku" :placeholder="t('products.products.labels.sku')" class="w-full" />
+        <div class="flex justify-end gap-4 mt-4">
+          <Button class="btn btn-outline-dark" @click="closeModal">{{ t('shared.button.cancel') }}</Button>
+          <Button class="btn btn-primary" @click="submit">{{ t('shared.button.duplicate') }}</Button>
+        </div>
+      </Card>
+    </Modal>
+  </div>
+</template>

--- a/src/core/products/products/product-show/containers/duplicate-product-modal/index.ts
+++ b/src/core/products/products/product-show/containers/duplicate-product-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as DuplicateProductModal } from './DuplicateProductModal.vue';

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -3,7 +3,8 @@
     "button": {
       "login": "Anmelden",
       "register": "Registrieren",
-    "recover": "Wiederherstellen"
+      "recover": "Wiederherstellen",
+      "duplicate": "Duplizieren"
     },
     "colors": {
       "red": "Rot",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -318,6 +318,7 @@
       "skip": "Skip",
       "generate": "Generate",
       "translate": "Translate",
+      "duplicate": "Duplicate",
       "deleteAll": "Delete all",
       "editAll": "Edit all",
       "change": "Change",
@@ -1088,6 +1089,9 @@
       },
       "show": {
         "title": "Product"
+      },
+      "duplicateModal": {
+        "description": "Provide an SKU for the duplicated product or leave empty to auto generate."
       }
     }
   },

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -3,7 +3,8 @@
     "button": {
       "login": "Se connecter",
       "register": "S'inscrire",
-    "recover": "Récupérer"
+      "recover": "Récupérer",
+      "duplicate": "Dupliquer"
     },
     "colors": {
       "red": "Rouge",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -175,6 +175,7 @@
       "create": "Aanmaken",
       "skip": "Overslaan",
       "generate": "Genereren",
+      "duplicate": "Dupliceren",
       "change": "Wijzig",
       "fix": "Fixen",
       "downloadConfirmation": "",

--- a/src/shared/api/mutations/products.js
+++ b/src/shared/api/mutations/products.js
@@ -597,3 +597,11 @@ export const deleteProductTranslationBulletPointsMutation = gql`
     }
   }
 `;
+
+export const duplicateProductMutation = gql`
+  mutation duplicateProduct($id: GlobalID!, $sku: String) {
+    duplicateProduct(id: $id, sku: $sku) {
+      id
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- allow duplicating a product from the show view
- add `DuplicateProductModal` component
- support duplicate product mutation
- add translations for Duplicate button and modal

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e922a6420832ebc85e8d9c42501f1

## Summary by Sourcery

Implement a new product duplication feature in the product show page, including a modal UI for SKU entry, GraphQL mutation support, and navigation to the duplicated product.

New Features:
- Add DuplicateProductModal component for entering an optional SKU and confirming duplication
- Introduce duplicateProductMutation and handleDuplicate logic to perform product duplication and redirect to the new product
- Add Duplicate button to the product show view to open the duplication modal

Documentation:
- Add translation keys for the Duplicate button and duplication modal text across locale files