### PR TITLE
Add toast message after duplicating product

### DIFF
--- a/src/core/products/products/product-show/ProductShowController.vue
+++ b/src/core/products/products/product-show/ProductShowController.vue
@@ -114,6 +114,7 @@ const handleDuplicate = async (sku: string | null) => {
     });
 
     if (data && data.duplicateProduct) {
+      Toast.success(t('products.products.duplicateSuccessfully'));
       router.push({ name: 'products.products.show', params: { id: data.duplicateProduct.id } });
     }
   } catch (error) {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1092,7 +1092,8 @@
       },
       "duplicateModal": {
         "description": "Provide an SKU for the duplicated product or leave empty to auto generate."
-      }
+      },
+      "duplicateSuccessfully": "Product was successfully duplicated!"
     }
   },
   "inventory": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -799,7 +799,8 @@
       },
       "show": {
         "title": "Product"
-      }
+      },
+      "duplicateSuccessfully": "Product succesvol gedupliceerd!"
     }
   },
   "inventory": {


### PR DESCRIPTION
## Summary
- add success toast when a product is duplicated
- add new `duplicateSuccessfully` i18n key for English and Dutch locales

## Testing
- `npm run build` *(fails: `vue-tsc: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687ea182e488832ea76caf46d26f0e7f

## Summary by Sourcery

Show a success toast after duplicating a product and provide its translation in English and Dutch

New Features:
- Display a success toast when a product is duplicated
- Add a new 'duplicateSuccessfully' i18n key in English and Dutch locales