### PR TITLE
Add brand identity settings

### DIFF
--- a/src/core/settings/brand-identity/brand-custom-prompt-create/BrandCustomPromptCreateController.vue
+++ b/src/core/settings/brand-identity/brand-custom-prompt-create/BrandCustomPromptCreateController.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { GeneralForm } from "../../../../shared/components/organisms/general-form";
+import { FormConfig, FormType } from '../../../../shared/components/organisms/general-form/formConfig';
+import { createBrandCustomPromptMutation } from "../../../../shared/api/mutations/llm.js";
+import { baseFormConfigConstructor } from "../configs";
+import { Breadcrumbs } from "../../../../shared/components/molecules/breadcrumbs";
+import SettingsTemplate from "../../SettingsTemplate.vue";
+import { TabsMenu } from "../../../../shared/components/molecules/tabs-menu";
+import { getTabsConfig } from "../../tabs";
+
+const { t } = useI18n();
+
+const formConfig = {
+  ...baseFormConfigConstructor(
+    t,
+    FormType.CREATE,
+    createBrandCustomPromptMutation,
+    'createBrandCustomPrompt'
+  ),
+  submitAndContinueUrl: { name: 'settings.brandIdentity.edit' }
+};
+</script>
+
+<template>
+  <SettingsTemplate>
+    <template v-slot:tabs>
+      <TabsMenu :tabs="getTabsConfig(t)" :activeName="'brandIdentity'" />
+    </template>
+
+    <template v-slot:breadcrumbs>
+      <Breadcrumbs
+          :links="[{ path: { name: 'settings.brandIdentity.list' }, name: t('settings.brandIdentity.title') },
+                   { path: { name: 'settings.brandIdentity.create' }, name: t('settings.brandIdentity.create.title') }]" />
+    </template>
+
+   <template v-slot:content>
+     <GeneralForm :config="formConfig as FormConfig" />
+   </template>
+  </SettingsTemplate>
+</template>

--- a/src/core/settings/brand-identity/brand-custom-prompt-edit/BrandCustomPromptEditController.vue
+++ b/src/core/settings/brand-identity/brand-custom-prompt-edit/BrandCustomPromptEditController.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { useRoute } from "vue-router";
+import { ref } from "vue";
+import { GeneralForm } from "../../../../shared/components/organisms/general-form";
+import { FormConfig, FormType } from "../../../../shared/components/organisms/general-form/formConfig";
+import { FieldType } from "../../../../shared/utils/constants";
+import { updateBrandCustomPromptMutation } from "../../../../shared/api/mutations/llm.js";
+import { getBrandCustomPromptQuery } from "../../../../shared/api/queries/llm.js";
+import { baseFormConfigConstructor } from "../configs";
+import { Breadcrumbs } from "../../../../shared/components/molecules/breadcrumbs";
+import SettingsTemplate from "../../SettingsTemplate.vue";
+import { TabsMenu } from "../../../../shared/components/molecules/tabs-menu";
+import { getTabsConfig } from "../../tabs";
+
+const { t } = useI18n();
+const route = useRoute();
+const id = ref(String(route.params.id));
+
+const baseForm = baseFormConfigConstructor(
+  t,
+  FormType.EDIT,
+  updateBrandCustomPromptMutation,
+  'updateBrandCustomPrompt'
+);
+
+const formConfig = {
+  ...baseForm,
+  mutationId: id.value.toString(),
+  query: getBrandCustomPromptQuery,
+  queryVariables: { id: id.value },
+  queryDataKey: 'brandCustomPrompt',
+  fields: [
+    {
+      type: FieldType.Hidden,
+      name: 'id',
+      value: id.value.toString(),
+    },
+    ...baseForm.fields,
+  ],
+};
+</script>
+
+<template>
+    <SettingsTemplate>
+      <template v-slot:tabs>
+        <TabsMenu :tabs="getTabsConfig(t)" :activeName="'brandIdentity'" />
+      </template>
+
+      <template v-slot:breadcrumbs>
+        <Breadcrumbs
+            :links="[{ path: { name: 'settings.brandIdentity.list' }, name: t('settings.brandIdentity.title') },
+                     { path: { name: 'settings.brandIdentity.edit' }, name: t('settings.brandIdentity.edit.title') }]" />
+      </template>
+
+     <template v-slot:content>
+       <GeneralForm :config="formConfig as FormConfig" />
+     </template>
+  </SettingsTemplate>
+</template>

--- a/src/core/settings/brand-identity/brand-custom-prompts-list/BrandCustomPromptsListController.vue
+++ b/src/core/settings/brand-identity/brand-custom-prompts-list/BrandCustomPromptsListController.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Breadcrumbs } from "../../../../shared/components/molecules/breadcrumbs";
+import { Button } from "../../../../shared/components/atoms/button";
+import { Link } from "../../../../shared/components/atoms/link";
+import { GeneralListing } from "../../../../shared/components/organisms/general-listing";
+import { searchConfigConstructor, listingConfigConstructor, listingQueryKey, listingQuery } from '../configs';
+import SettingsTemplate from "../../SettingsTemplate.vue";
+import { TabsMenu } from "../../../../shared/components/molecules/tabs-menu";
+import { getTabsConfig } from "../../tabs";
+import { Alert } from "../../../../shared/components/atoms/alert";
+
+const { t } = useI18n();
+
+const searchConfig = searchConfigConstructor(t);
+const listingConfig = listingConfigConstructor(t);
+</script>
+
+<template>
+  <SettingsTemplate>
+    <template v-slot:tabs>
+      <TabsMenu :tabs="getTabsConfig(t)" :activeName="'brandIdentity'" />
+    </template>
+
+    <template v-slot:breadcrumbs>
+      <Breadcrumbs :links="[{ path: { name: 'settings.brandIdentity.list' }, name: t('settings.brandIdentity.title') }]" />
+    </template>
+
+    <template v-slot:buttons>
+      <div>
+        <Link :path="{ name: 'settings.brandIdentity.create' }">
+          <Button type="button" class="btn btn-primary">
+            {{ t('settings.brandIdentity.create.title') }}
+          </Button>
+        </Link>
+      </div>
+    </template>
+
+    <template v-slot:content>
+      <Alert variant="info" class="mb-4">
+        <template #title>{{ t('settings.brandIdentity.descriptionCard.title') }}</template>
+        {{ t('settings.brandIdentity.descriptionCard.content') }}
+      </Alert>
+      <GeneralListing
+        :searchConfig="searchConfig"
+        :config="listingConfig"
+        :query="listingQuery"
+        :query-key="listingQueryKey"
+      />
+    </template>
+  </SettingsTemplate>
+</template>

--- a/src/core/settings/brand-identity/configs.ts
+++ b/src/core/settings/brand-identity/configs.ts
@@ -1,0 +1,88 @@
+import { FormConfig, FormType } from '../../../shared/components/organisms/general-form/formConfig';
+import { FieldType } from '../../../shared/utils/constants.js';
+import { SearchConfig } from '../../../shared/components/organisms/general-search/searchConfig';
+import { ListingConfig } from '../../../shared/components/organisms/general-listing/listingConfig';
+import { brandCustomPromptsQuery } from '../../../shared/api/queries/llm.js';
+import { deleteBrandCustomPromptMutation } from '../../../shared/api/mutations/llm.js';
+import { companyLanguagesQuery } from '../../../shared/api/queries/languages.js';
+import { propertySelectValuesQuerySimpleSelector } from '../../../shared/api/queries/properties.js';
+
+export const baseFormConfigConstructor = (
+  t: Function,
+  type: FormType,
+  mutation: any,
+  mutationKey: string
+): FormConfig => ({
+  cols: 1,
+  type,
+  mutation,
+  mutationKey,
+  submitUrl: { name: 'settings.brandIdentity.list' },
+  deleteMutation: deleteBrandCustomPromptMutation,
+  fields: [
+    {
+      type: FieldType.Query,
+      name: 'brandValue',
+      label: t('settings.brandIdentity.labels.brand'),
+      labelBy: 'value',
+      valueBy: 'id',
+      query: propertySelectValuesQuerySimpleSelector,
+      queryVariables: { filter: { property: { internalName: { exact: 'brand' } } } },
+      dataKey: 'propertySelectValues',
+      isEdge: true,
+      multiple: false,
+      filterable: true,
+      formMapIdentifier: 'id',
+    },
+    {
+      type: FieldType.Query,
+      name: 'language',
+      label: t('shared.labels.language'),
+      labelBy: 'name',
+      valueBy: 'code',
+      query: companyLanguagesQuery,
+      dataKey: 'companyLanguages',
+      isEdge: false,
+      multiple: false,
+      filterable: true,
+      optional: true,
+    },
+    {
+      type: FieldType.Textarea,
+      name: 'prompt',
+      label: t('settings.brandIdentity.labels.prompt'),
+      placeholder: t('settings.brandIdentity.placeholders.prompt'),
+    },
+  ],
+});
+
+export const searchConfigConstructor = (t: Function): SearchConfig => ({
+  search: false,
+  orderKey: 'sort',
+  filters: [],
+  orders: [],
+});
+
+export const listingConfigConstructor = (t: Function): ListingConfig => ({
+  headers: [
+    t('settings.brandIdentity.labels.brand'),
+    t('shared.labels.language'),
+    t('settings.brandIdentity.labels.prompt'),
+  ],
+  fields: [
+    { name: 'brandValue', type: FieldType.NestedText, keys: ['value'] },
+    { name: 'language', type: FieldType.Text },
+    { name: 'prompt', type: FieldType.Text },
+  ],
+  identifierKey: 'id',
+  addActions: true,
+  addEdit: true,
+  editUrlName: 'settings.brandIdentity.edit',
+  addShow: false,
+  addDelete: true,
+  addPagination: true,
+  deleteMutation: deleteBrandCustomPromptMutation,
+});
+
+export const listingQueryKey = 'brandCustomPrompts';
+export const listingQuery = brandCustomPromptsQuery;

--- a/src/core/settings/routes.ts
+++ b/src/core/settings/routes.ts
@@ -37,6 +37,25 @@ export const routes = [
         component: () => import('./vat-rates/vat-rate-edit/VatRateEditController.vue')
     },
 
+    {
+        path: '/settings/brand-identity',
+        name: 'settings.brandIdentity.list',
+        meta: { title: 'settings.title' },
+        component: () => import('./brand-identity/brand-custom-prompts-list/BrandCustomPromptsListController.vue')
+    },
+    {
+        path: '/settings/brand-identity/create',
+        name: 'settings.brandIdentity.create',
+        meta: { title: 'settings.title' },
+        component: () => import('./brand-identity/brand-custom-prompt-create/BrandCustomPromptCreateController.vue')
+    },
+    {
+        path: '/settings/brand-identity/edit/:id',
+        name: 'settings.brandIdentity.edit',
+        meta: { title: 'settings.title' },
+        component: () => import('./brand-identity/brand-custom-prompt-edit/BrandCustomPromptEditController.vue')
+    },
+
     // {
     //     path: '/settings/units',
     //     name: 'settings.units.list',

--- a/src/core/settings/tabs.ts
+++ b/src/core/settings/tabs.ts
@@ -23,4 +23,10 @@ export const getTabsConfig = (t: Function): TabItem[] => [
     icon: 'database',
     url: 'settings.demoData.show',
   },
+  {
+    name: 'brandIdentity',
+    label: t('settings.brandIdentity.title'),
+    icon: 'comment-dots',
+    url: 'settings.brandIdentity.list',
+  },
 ];

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1961,6 +1961,26 @@
         "week": "Week",
         "month": "Month"
       }
+    },
+    "brandIdentity": {
+      "title": "Brand Identity",
+      "create": {
+        "title": "Add Brand Description"
+      },
+      "edit": {
+        "title": "Edit Brand Description"
+      },
+      "labels": {
+        "brand": "Brand",
+        "prompt": "Description"
+      },
+      "placeholders": {
+        "prompt": "Enter description"
+      },
+      "descriptionCard": {
+        "title": "Give your brands a voice",
+        "content": "Add a custom description for this brand to guide how it's represented in AI-generated content. You can create different descriptions for different languages. If the language is left empty, this will act as the default description for the brand."
+      }
     }
   },
   "network": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1633,6 +1633,26 @@
         "week": "Week",
         "month": "Maand"
       }
+    },
+    "brandIdentity": {
+      "title": "Merkidentiteit",
+      "create": {
+        "title": "Merkbeschrijving toevoegen"
+      },
+      "edit": {
+        "title": "Merkbeschrijving bewerken"
+      },
+      "labels": {
+        "brand": "Merk",
+        "prompt": "Beschrijving"
+      },
+      "placeholders": {
+        "prompt": "Voer beschrijving in"
+      },
+      "descriptionCard": {
+        "title": "Geef je merken een stem",
+        "content": "Voeg een aangepaste beschrijving toe voor dit merk om te bepalen hoe het wordt weergegeven in AI-gegenereerde inhoud. Je kunt verschillende beschrijvingen maken voor verschillende talen. Als de taal leeg blijft, wordt dit de standaardbeschrijving voor het merk."
+      }
     }
   },
   "network": {

--- a/src/shared/api/mutations/llm.js
+++ b/src/shared/api/mutations/llm.js
@@ -95,3 +95,64 @@ export const generateProductAiBulletPointsMutation = gql`
     }
   }
 `;
+
+export const createBrandCustomPromptMutation = gql`
+  mutation createBrandCustomPrompt($data: BrandCustomPromptInput!) {
+    createBrandCustomPrompt(data: $data) {
+      id
+      language
+      prompt
+      brandValue {
+        id
+        value
+        fullValueName
+      }
+    }
+  }
+`;
+
+export const createBrandCustomPromptsMutation = gql`
+  mutation createBrandCustomPrompts($data: [BrandCustomPromptInput!]!) {
+    createBrandCustomPrompts(data: $data) {
+      id
+      language
+      prompt
+      brandValue {
+        id
+        value
+        fullValueName
+      }
+    }
+  }
+`;
+
+export const updateBrandCustomPromptMutation = gql`
+  mutation updateBrandCustomPrompt($data: BrandCustomPromptPartialInput!) {
+    updateBrandCustomPrompt(data: $data) {
+      id
+      language
+      prompt
+      brandValue {
+        id
+        value
+        fullValueName
+      }
+    }
+  }
+`;
+
+export const deleteBrandCustomPromptMutation = gql`
+  mutation deleteBrandCustomPrompt($id: GlobalID!) {
+    deleteBrandCustomPrompt(data: { id: $id }) {
+      id
+    }
+  }
+`;
+
+export const deleteBrandCustomPromptsMutation = gql`
+  mutation deleteBrandCustomPrompts($ids: [GlobalID!]!) {
+    deleteBrandCustomPrompts(data: { ids: $ids }) {
+      id
+    }
+  }
+`;

--- a/src/shared/api/queries/llm.js
+++ b/src/shared/api/queries/llm.js
@@ -1,0 +1,43 @@
+import { gql } from 'graphql-tag';
+
+export const brandCustomPromptsQuery = gql`
+  query BrandCustomPrompts($first: Int, $last: Int, $after: String, $before: String, $order: BrandCustomPromptOrder, $filter: BrandCustomPromptFilter) {
+    brandCustomPrompts(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          language
+          prompt
+          brandValue {
+            id
+            value
+            fullValueName
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getBrandCustomPromptQuery = gql`
+  query getBrandCustomPrompt($id: GlobalID!) {
+    brandCustomPrompt(id: $id) {
+      id
+      language
+      prompt
+      brandValue {
+        id
+        value
+        fullValueName
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- add Brand Identity tab in Settings
- create Brand Custom Prompt pages with create/edit/listing
- support brand custom prompt GraphQL queries and mutations
- provide translations in English and Dutch

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ec6b2f570832ebb009b27f0751efa

## Summary by Sourcery

Introduce a Brand Identity settings section to manage custom AI prompts for different brands.

New Features:
- Add a Brand Identity tab in the settings UI
- Implement listing, creation, and editing pages for brand custom prompts

Enhancements:
- Provide GraphQL queries and mutations for brand custom prompts (list, get, create, update, delete)

Documentation:
- Add English and Dutch translations for brand identity labels and placeholders