### PR TITLE
Improve variation generator UI

### DIFF
--- a/src/core/products/products/product-create/containers/select-variations-step/SelectVariationsStep.vue
+++ b/src/core/products/products/product-create/containers/select-variations-step/SelectVariationsStep.vue
@@ -58,7 +58,7 @@ const handleSelectedUpdate = (vals: string[]) => {
     <h1 class="text-2xl text-center mb-2">{{ productDescriptionMap[form.type] }}</h1>
     <hr>
     <div v-if="form.type === PRODUCT_CONFIGURABLE && additionalFieldsForm.productType.id">
-      <OptionSelector v-model="mode" :choices="[{ name: 'manual' }, { name: 'generate' }]" row>
+      <OptionSelector v-model="mode" :choices="[{ name: 'manual' }, { name: 'generate' }]">
         <template #manual>
           <span class="font-medium">{{ t('shared.labels.manual') }}</span>
         </template>

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -14,7 +14,12 @@
     "labels": {
       "message": "Nachricht",
       "severity": "Schweregrad",
-      "validationIssue": "Validierungsfehler"
+      "validationIssue": "Validierungsfehler",
+      "manual": "Manuell",
+      "generate": "Generieren"
+    },
+    "alert": {
+      "noData": "Die Regel hat keine erforderlichen Konfiguratoreigenschaften, daher k\u00f6nnen keine Varianten generiert werden."
     }
   },
   "auth": {
@@ -58,6 +63,20 @@
       },
       "placeholders": {
         "email": "E-Mail eingeben"
+      }
+    }
+  }
+  ,
+  "products": {
+    "products": {
+      "create": {
+        "wizard": {
+          "stepFour": {
+            "configurable": {
+              "generateDescription": "W\u00e4hlen Sie unten die Werte aus. Varianten f\u00fcr diese Werte werden automatisch erstellt."
+            }
+          }
+        }
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -285,9 +285,10 @@
         "tooLongError": "{fieldName} is too long. Reduce to maximum {max} characters!",
         "clipboardFail": "Failed to copy to clipboard.",
         "errorOccurred": "An error occurred.",
-        "bulkDeleteSuccess": "Items deleted successfully.",
-        "bulkDeleteError": "An error occurred while deleting items."
-      }
+      "bulkDeleteSuccess": "Items deleted successfully.",
+      "bulkDeleteError": "An error occurred while deleting items."
+      },
+      "noData": "The rule has no required in configurator properties, therefore we can't generate variation based on that"
     },
     "button": {
       "login": "Log in",
@@ -386,7 +387,9 @@
       "issues": "Issues",
       "message": "Message",
       "severity": "Severity",
-      "validationIssue": "Validation Issue"
+      "validationIssue": "Validation Issue",
+      "manual": "Manual",
+      "generate": "Generate"
     },
     "validations": {
       "quantity": "Please enter a valid quantity"
@@ -1063,10 +1066,11 @@
             }
           },
           "stepFour": {
-            "configurable": {
-              "title": "Variations",
-              "selectVariations": "Please select the variations:"
-            },
+          "configurable": {
+            "title": "Variations",
+            "selectVariations": "Please select the variations:",
+            "generateDescription": "Choose property values below. Variations for all selected values will be generated automatically."
+          },
             "simple": {
               "title": "Buying",
               "whereBuy": "Where do you buy it?",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -14,7 +14,12 @@
     "labels": {
       "message": "Message",
       "severity": "Gravité",
-      "validationIssue": "Problème de validation"
+      "validationIssue": "Problème de validation",
+      "manual": "Manuel",
+      "generate": "Générer"
+    },
+    "alert": {
+      "noData": "La règle ne contient aucune propriété requise dans le configurateur, nous ne pouvons donc pas générer de variations."
     }
   },
   "auth": {
@@ -58,6 +63,20 @@
       },
       "placeholders": {
         "email": "Entrez l'e-mail"
+      }
+    }
+  }
+  ,
+  "products": {
+    "products": {
+      "create": {
+        "wizard": {
+          "stepFour": {
+            "configurable": {
+              "generateDescription": "Choisissez les valeurs ci-dessous. Les variations pour ces valeurs seront g\u00e9n\u00e9r\u00e9es automatiquement."
+            }
+          }
+        }
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -225,7 +225,12 @@
       "discountPrice": "",
       "message": "Bericht",
       "severity": "Ernst",
-      "validationIssue": "Validatiefout"
+      "validationIssue": "Validatiefout",
+      "manual": "Handmatig",
+      "generate": "Genereren"
+    },
+    "alert": {
+      "noData": "De regel bevat geen vereiste configuratoreigenschappen waardoor er geen variaties kunnen worden gegenereerd."
     },
     "validations": {
       "quantity": "Voer een geldige hoeveelheid in"
@@ -771,10 +776,11 @@
             }
           },
           "stepFour": {
-            "configurable": {
-              "title": "Variaties",
-              "selectVariations": "Selecteer de variaties:"
-            },
+          "configurable": {
+            "title": "Variaties",
+            "selectVariations": "Selecteer de variaties:",
+            "generateDescription": "Kies hieronder de waarden. Variaties voor deze waarden worden automatisch gegenereerd."
+          },
             "simple": {
               "title": "Kopen",
               "whereBuy": "Waar koopt u dit item?",

--- a/src/shared/components/organisms/variations-generator/VariationsGenerator.vue
+++ b/src/shared/components/organisms/variations-generator/VariationsGenerator.vue
@@ -2,8 +2,6 @@
 import { ref, onMounted, watch, Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Accordion } from '../../atoms/accordion';
-import { PrimaryButton } from '../../atoms/button-primary';
-import { SecondaryButton } from '../../atoms/button-secondary';
 import apolloClient from '../../../../../apollo-client';
 import { productPropertiesRulesQuery, propertySelectValuesQuery } from '../../../api/queries/properties.js';
 import { ConfigTypes } from '../../../utils/constants';
@@ -104,21 +102,35 @@ const deselectAll = (idx: number) => {
   properties.value[idx].selected = [];
   emitSelected();
 };
+
+const toggleAll = (idx: number) => {
+  if (properties.value[idx].selected.length === properties.value[idx].values.length) {
+    deselectAll(idx);
+  } else {
+    selectAll(idx);
+  }
+};
 </script>
 
 <template>
   <div>
+    <p class="mb-4 text-sm text-gray-500" v-if="!loading && properties.length">
+      {{ t('products.products.create.wizard.stepFour.configurable.generateDescription') }}
+    </p>
     <div v-if="loading" class="text-center my-4">{{ t('shared.labels.loading') }}</div>
-    <Accordion v-else-if="properties.length" :items="properties.map((p, i) => ({ name: 'prop' + i, label: p.propertyName }))">
+    <Accordion v-else-if="properties.length"
+               :items="properties.map((p, i) => ({ name: 'prop' + i, label: `${p.propertyName} (${p.selected.length} / ${p.values.length} ${t('shared.labels.selected')})` }))"
+               default-active="prop0">
       <template v-for="(prop, index) in properties" #[`prop${index}`]="">
-        <div class="mb-2 flex justify-end gap-2">
-          <PrimaryButton class="px-2 py-1" @click="selectAll(index)">
-            {{ t('shared.button.selectAll') }}
-          </PrimaryButton>
-          <SecondaryButton class="px-2 py-1" @click="deselectAll(index)">
-            {{ t('shared.button.deselectAll') }}
-          </SecondaryButton>
+        <div class="mb-2 flex justify-end">
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input type="checkbox" :checked="prop.selected.length === prop.values.length" @change="toggleAll(index)" />
+            <span class="font-medium">
+              {{ prop.selected.length === prop.values.length ? t('shared.button.deselectAll') : t('shared.button.selectAll') }}
+            </span>
+          </label>
         </div>
+        <hr class="mb-2">
         <div class="overflow-y-auto max-h-60">
           <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-2">
             <label v-for="val in prop.values" :key="val.id" class="flex items-center gap-2">
@@ -129,6 +141,8 @@ const deselectAll = (idx: number) => {
         </div>
       </template>
     </Accordion>
-    <div v-else class="text-center text-gray-500">{{ t('shared.alert.noData') }}</div>
+    <div v-else class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 text-center" role="alert">
+      {{ t('shared.alert.noData') }}
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- tweak manual/generate selector layout
- enhance variations generator UI with description, checkbox control, and alert
- add translation strings for generator

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ecdcbc34c832e9114046df01fc9db

## Summary by Sourcery

Enhance the variation generator UI by adding descriptive text, a master toggle control, selected-count indicators, styled alerts for empty states, and refine the manual/generate selector layout with new translations

New Features:
- Show a descriptive paragraph above the variations generator when properties are loaded
- Introduce a master checkbox to toggle select/deselect all values for each property

Enhancements:
- Display selected/total counts in accordion headers and open the first panel by default
- Replace separate select and deselect buttons with a single consolidated checkbox control
- Style the no-data fallback as a colored alert box
- Remove the 'row' prop from the manual/generate OptionSelector to refine layout
- Add translation keys for the new UI elements