### PR TITLE
Revamp auth colors

### DIFF
--- a/src/core/auth/AuthTemplate.vue
+++ b/src/core/auth/AuthTemplate.vue
@@ -11,7 +11,7 @@
           class="relative flex w-full max-w-[1502px] flex-col justify-between overflow-hidden rounded-md bg-white/60 backdrop-blur-lg dark:bg-black/50 lg:min-h-[758px] lg:flex-row lg:gap-10 xl:gap-0"
       >
         <div
-            class="relative hidden w-full items-center justify-center bg-[linear-gradient(225deg,rgba(239,18,98,1)_0%,rgba(67,97,238,1)_100%)] p-5 lg:inline-flex lg:max-w-[835px] xl:-ms-28 ltr:xl:skew-x-[14deg] rtl:xl:skew-x-[-14deg]"
+            class="relative hidden w-full items-center justify-center bg-[linear-gradient(225deg,#4646e5_0%,#968abe_50%,#68baa5_100%)] p-5 lg:inline-flex lg:max-w-[835px] xl:-ms-28 ltr:xl:skew-x-[14deg] rtl:xl:skew-x-[-14deg]"
         >
           <div
               class="absolute inset-y-0 w-8 from-primary/10 via-transparent to-transparent ltr:-right-10 ltr:bg-gradient-to-r rtl:-left-10 rtl:bg-gradient-to-l xl:w-16 ltr:xl:-right-20 rtl:xl:-left-20"

--- a/src/core/auth/login-token/containers/login-token-form/LoginTokenForm.vue
+++ b/src/core/auth/login-token/containers/login-token-form/LoginTokenForm.vue
@@ -82,7 +82,7 @@ const onError = (error) => {
 
     <ApolloMutation :mutation="acceptUserInvitationMutation" :variables="{ password: form.password, language: locale }" @done="onAcceptInvitationCompleted" @error="onError">
       <template v-slot="{ mutate, loading, error }">
-        <Button :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(67,97,238,0.44)]'"
+        <Button :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(70,70,229,0.44)]'"
                 :disabled="loading || !isFormValid"
                 @click="mutate">
           {{ t('auth.acceptInvitation.button.setPassword') }}

--- a/src/core/auth/login/containers/new-login-form/NewLoginForm.vue
+++ b/src/core/auth/login/containers/new-login-form/NewLoginForm.vue
@@ -73,7 +73,7 @@ useEnterKeyboardListener(onLoginClicked);
     </TextInputPrepend>
 
     <div>
-      <Button :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(67,97,238,0.44)]'" @click="onLoginClicked()">
+      <Button :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(70,70,229,0.44)]'" @click="onLoginClicked()">
         {{ t('shared.button.login') }}
       </Button>
 

--- a/src/core/auth/recover/containers/recover-form/RecoverForm.vue
+++ b/src/core/auth/recover/containers/recover-form/RecoverForm.vue
@@ -97,7 +97,7 @@ useEnterKeyboardListener(onSubmit);
       <div>
       <ApolloMutation :mutation="requestLoginLinkMutation" :variables="{ username: form.email }" @done="onRecoverClicked" @error="onError">
         <template v-slot="{ mutate, loading, error }">
-          <Button ref="submitButtonRef" :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(67,97,238,0.44)]'" :disabled="loading" @click="mutate()">          {{ t('shared.button.recover') }}
+          <Button ref="submitButtonRef" :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(70,70,229,0.44)]'" :disabled="loading" @click="mutate()">          {{ t('shared.button.recover') }}
           </Button>
         </template>
       </ApolloMutation>

--- a/src/core/auth/register/containers/register-company-form/RegisterCompanyForm.vue
+++ b/src/core/auth/register/containers/register-company-form/RegisterCompanyForm.vue
@@ -109,7 +109,7 @@ useEnterKeyboardListener(onSubmit);
         @error="onError"
       >
         <template v-slot="{ loading, error, mutate }">
-        <Button ref="submitButtonRef" :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(67,97,238,0.44)]'"
+        <Button ref="submitButtonRef" :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(70,70,229,0.44)]'"
                 :disabled="loading || !isFormValid"
                 @click="mutate()"
         >

--- a/src/core/auth/register/containers/register-form/RegisterForm.vue
+++ b/src/core/auth/register/containers/register-form/RegisterForm.vue
@@ -113,7 +113,7 @@ useEnterKeyboardListener(onSubmit);
     <div>
       <ApolloMutation :mutation="registerMutation" :variables="{ username: form.username, password: form.password, language: locale }" @done="afterRegister" @error="onError">
         <template v-slot="{ mutate, loading, error }">
-          <Button ref="submitButtonRef" :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(67,97,238,0.44)]'"
+          <Button ref="submitButtonRef" :customClass="'btn btn-gradient !mt-6 w-full border-0 uppercase shadow-[0_10px_20px_-10px_rgba(70,70,229,0.44)]'"
                   :disabled="loading || !isFormValid"
                   @click="mutate()">
             {{ t('shared.button.register') }}

--- a/src/shared/theme/default/file-upload-preview.css
+++ b/src/shared/theme/default/file-upload-preview.css
@@ -7,7 +7,7 @@
     box-sizing: border-box;
 }
 .custom-file-container label {
-    color: #4361ee;
+    color: #4646e5;
     font-size: 16px;
 }
 .custom-file-container .label-container {
@@ -84,7 +84,7 @@
     padding: 10px 16px;
     line-height: 1.25;
     background-color: rgba(27, 85, 226, 0.239216);
-    color: #4361ee;
+    color: #4646e5;
     border-left: 1px solid #e0e6ed;
     box-sizing: border-box;
 }
@@ -156,7 +156,7 @@
 }
 
 .dark .custom-file-container__custom-file__custom-file-control__button {
-    background-color: #4361ee;
+    background-color: #4646e5;
     border-color: #253b5c;
     color: #fff;
 }

--- a/src/shared/theme/default/form-elements.css
+++ b/src/shared/theme/default/form-elements.css
@@ -32,7 +32,7 @@ input[type='range']::-webkit-slider-thumb {
     height: 16px;
     width: 16px;
     border-radius: 50%;
-    background: #4361ee;
+    background: #4646e5;
     margin-top: -4px;
 }
 
@@ -49,7 +49,7 @@ input[type='range']:focus {
 }
 
 input[type='range']:active::-webkit-slider-thumb {
-    background: #4361eec2;
+    background: #4646e5c2;
     cursor: pointer;
 }
 

--- a/src/shared/theme/default/fullcalendar.css
+++ b/src/shared/theme/default/fullcalendar.css
@@ -80,8 +80,8 @@
 
 .calendar-wrapper .fc-button-primary,
 .calendar-wrapper .fc-button-primary:disabled {
-  color: #4361ee !important;
-  border-color: #4361ee !important;
+  color: #4646e5 !important;
+  border-color: #4646e5 !important;
   background: transparent !important;
   box-shadow: none !important;
   font-weight: 600 !important;
@@ -90,7 +90,7 @@
 
 .calendar-wrapper .fc-button-primary:not(:disabled):hover,
 .calendar-wrapper .fc-button-primary:not(:disabled).fc-button-active {
-  background-color: #4361ee !important;
+  background-color: #4646e5 !important;
   color: white !important;
 }
 
@@ -114,8 +114,8 @@
 
 .calendar-wrapper .fc-daygrid-event.primary:hover,
 .calendar-wrapper .fc-timegrid-event.primary:hover {
-  background-color: #4361ee;
-  border-color: #4361ee;
+  background-color: #4646e5;
+  border-color: #4646e5;
 }
 
 .calendar-wrapper .fc-daygrid-event.success,
@@ -162,8 +162,8 @@
 .calendar-wrapper  .fc-button.fc-next-button:hover,
 .dark .calendar-wrapper  .fc-button.fc-prev-button:hover,
 .dark .calendar-wrapper  .fc-button.fc-next-button:hover {
-  color: #4361ee !important;
-  border-color: #4361ee !important;
+  color: #4646e5 !important;
+  border-color: #4646e5 !important;
   background: transparent !important;
 }
 

--- a/src/shared/theme/default/index.css
+++ b/src/shared/theme/default/index.css
@@ -336,7 +336,7 @@ hover:text-primary hover:before:!bg-primary ltr:before:mr-2 rtl:before:ml-2 dark
     }
 
     .btn-gradient {
-        @apply bg-gradient-to-r from-[#EF1262] to-[#4361EE] hover:to-[#EF1262] hover:from-[#4361EE] text-white;
+        @apply bg-gradient-to-r from-[#4646e5] via-[#968abe] to-[#68baa5] hover:from-[#68baa5] hover:to-[#4646e5] text-white;
     }
 
     /* Badge */

--- a/src/shared/theme/default/markdown-editor.css
+++ b/src/shared/theme/default/markdown-editor.css
@@ -23,5 +23,5 @@
 .dark .markdown-editor .editor-toolbar button.active, .editor-toolbar button:hover {
     background-color: transparent !important;
     border-color: transparent !important;
-    color: #4361ee;
+    color: #4646e5;
 }

--- a/src/shared/theme/default/sweetalert.css
+++ b/src/shared/theme/default/sweetalert.css
@@ -40,7 +40,7 @@ body.swal2-toast-shown .swal2-container.toast {
 
 .swal2-popup .swal2-styled.swal2-cancel {
     background-color: #fff !important;
-    color: #4361ee;
+    color: #4646e5;
     border: 1px solid #e8e8e8;
     box-shadow: none;
     padding: 7px 20px;
@@ -53,7 +53,7 @@ body.swal2-toast-shown .swal2-container.toast {
 }
 
 .swal2-popup .swal2-styled.swal2-confirm {
-    background-color: #4361ee;
+    background-color: #4646e5;
 }
 
 .swal2-popup .swal2-styled.swal2-confirm:focus {
@@ -161,7 +161,7 @@ body.swal2-toast-shown .swal2-container.toast {
 }
 
 .swal2-icon.swal2-info {
-    color: #4361ee !important;
+    color: #4646e5 !important;
     border: 4px solid #f1f2f3 !important;
     box-shadow: 0px 3px 25px 0px rgba(113, 106, 202, 0.2);
     text-align: center;

--- a/src/shared/theme/default/swiper.css
+++ b/src/shared/theme/default/swiper.css
@@ -8,7 +8,7 @@
 }
 
 .swiper-button-next {
-    color: #4361ee;
+    color: #4646e5;
 }
 
 #slider3 .swiper-wrapper,
@@ -49,7 +49,7 @@
 }
 
 #slider3 .swiper-pagination .swiper-pagination-bullet.swiper-pagination-bullet-active {
-    background: #4361ee;
+    background: #4646e5;
 }
 
 #slider4 .swiper-pagination {

--- a/src/shared/theme/default/tippy.css
+++ b/src/shared/theme/default/tippy.css
@@ -1,9 +1,9 @@
 .tippy-box[data-theme~='primary'] {
-    background-color: #4361ee;
+    background-color: #4646e5;
 }
 
 .tippy-box[data-theme~='primary'][data-placement^='top'] > .tippy-arrow::before {
-    border-top-color: #4361ee;
+    border-top-color: #4646e5;
 }
 
 .tippy-box[data-theme~='success'] {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,9 +16,9 @@ module.exports = {
     extend: {
       colors: {
                 primary: {
-                    DEFAULT: '#4361ee',
+                    DEFAULT: '#4646e5',
                     light: '#eaf1ff',
-                    'dark-light': 'rgba(67,97,238,.15)',
+                    'dark-light': 'rgba(70,70,229,.15)',
                 },
                 secondary: {
                     DEFAULT: '#805dca',


### PR DESCRIPTION
## Summary
- switch auth backgrounds to new gradient
- use OneSila palette for gradient buttons
- update primary color values

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f4b835560832e95d16cf5e3dbfa3c

## Summary by Sourcery

Revamp the primary color palette and gradient styles across authentication and shared UI components

Enhancements:
- Replace the primary color (#4361ee) with the new value (#4646e5) throughout theme styles
- Apply a new multi-stop gradient from the OneSila palette to authentication backgrounds and the .btn-gradient utility
- Update button shadow and hover color values to align with the updated primary palette