### PR TITLE
Add Ebay integration

### DIFF
--- a/src/core/integrations/integrations/configs.ts
+++ b/src/core/integrations/integrations/configs.ts
@@ -31,7 +31,8 @@ export const listingIntegrationTypeBadgeMap = (t: Function) => ({
   [IntegrationTypes.Magento]: { text: 'Magento', color: 'red' },
   [IntegrationTypes.Shopify]: { text: 'Shopify', color: 'green' },
   [IntegrationTypes.Woocommerce]: { text: 'Woocommerce', color: 'blue' },
-  [IntegrationTypes.Amazon]: { text: 'Amazon', color: 'yellow' }
+  [IntegrationTypes.Amazon]: { text: 'Amazon', color: 'yellow' },
+  [IntegrationTypes.Ebay]: { text: 'Ebay', color: 'purple' }
 });
 
 export const listingConfigConstructor = (t: Function): ListingConfig => ({

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/ebay/EbayChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/ebay/EbayChannelInfoStep.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { defineProps, watch, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Label } from "../../../../../../../shared/components/atoms/label";
+import { Selector } from "../../../../../../../shared/components/atoms/selector";
+import { Toggle } from "../../../../../../../shared/components/atoms/toggle";
+import { EbayChannelInfo, AmazonRegions, AmazonCountries } from '../../../../integrations';
+
+const props = defineProps<{
+  channelInfo: EbayChannelInfo
+}>();
+
+const { t } = useI18n();
+
+const regionChoices = [
+  { id: AmazonRegions.NORTH_AMERICA, text: t('integrations.regions.northAmerica') },
+  { id: AmazonRegions.EUROPE, text: t('integrations.regions.europe') },
+  { id: AmazonRegions.FAR_EAST, text: t('integrations.regions.farEast') },
+];
+
+const countryChoices = computed(() => {
+  switch (props.channelInfo.region) {
+    case AmazonRegions.NORTH_AMERICA:
+      return [
+        { id: AmazonCountries.CANADA, text: t('integrations.countries.canada') },
+        { id: AmazonCountries.UNITED_STATES, text: t('integrations.countries.unitedStates') },
+        { id: AmazonCountries.MEXICO, text: t('integrations.countries.mexico') },
+        { id: AmazonCountries.BRAZIL, text: t('integrations.countries.brazil') },
+      ];
+    case AmazonRegions.EUROPE:
+      return [
+        { id: AmazonCountries.IRELAND, text: t('integrations.countries.ireland') },
+        { id: AmazonCountries.SPAIN, text: t('integrations.countries.spain') },
+        { id: AmazonCountries.UNITED_KINGDOM, text: t('integrations.countries.unitedKingdom') },
+        { id: AmazonCountries.FRANCE, text: t('integrations.countries.france') },
+        { id: AmazonCountries.BELGIUM, text: t('integrations.countries.belgium') },
+        { id: AmazonCountries.NETHERLANDS, text: t('integrations.countries.netherlands') },
+        { id: AmazonCountries.GERMANY, text: t('integrations.countries.germany') },
+        { id: AmazonCountries.ITALY, text: t('integrations.countries.italy') },
+        { id: AmazonCountries.SWEDEN, text: t('integrations.countries.sweden') },
+        { id: AmazonCountries.SOUTH_AFRICA, text: t('integrations.countries.southAfrica') },
+        { id: AmazonCountries.POLAND, text: t('integrations.countries.poland') },
+        { id: AmazonCountries.EGYPT, text: t('integrations.countries.egypt') },
+        { id: AmazonCountries.TURKEY, text: t('integrations.countries.turkey') },
+        { id: AmazonCountries.SAUDI_ARABIA, text: t('integrations.countries.saudiArabia') },
+        { id: AmazonCountries.UNITED_ARAB_EMIRATES, text: t('integrations.countries.unitedArabEmirates') },
+        { id: AmazonCountries.INDIA, text: t('integrations.countries.india') },
+      ];
+    case AmazonRegions.FAR_EAST:
+      return [
+        { id: AmazonCountries.SINGAPORE, text: t('integrations.countries.singapore') },
+        { id: AmazonCountries.AUSTRALIA, text: t('integrations.countries.australia') },
+        { id: AmazonCountries.JAPAN, text: t('integrations.countries.japan') },
+      ];
+    default:
+      return [];
+  }
+});
+
+watch(
+  () => props.channelInfo.region,
+  () => {
+    props.channelInfo.country = null;
+  }
+);
+</script>
+
+<template>
+  <div>
+    <h1 class="text-2xl text-center mb-2">
+      {{ t('integrations.create.wizard.step4.ebay.content') }}
+    </h1>
+    <hr />
+    <Flex vertical>
+      <FlexCell>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.region') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <div class="w-96">
+                  <Selector
+                    class="w-full"
+                    v-model="channelInfo.region"
+                    :options="regionChoices"
+                    value-by="id"
+                    label-by="text"
+                    :removable="false"
+                  />
+                </div>
+              </FlexCell>
+            </Flex>
+          </FlexCell>
+        </Flex>
+      </FlexCell>
+
+      <FlexCell>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.country') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <div class="w-96">
+                  <Selector
+                    class="w-full"
+                    v-model="channelInfo.country"
+                    :options="countryChoices"
+                    value-by="id"
+                    label-by="text"
+                    :removable="false"
+                  />
+                </div>
+              </FlexCell>
+            </Flex>
+          </FlexCell>
+        </Flex>
+      </FlexCell>
+
+      <FlexCell>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.listingOwner') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <Toggle v-model="channelInfo.listingOwner" />
+              </FlexCell>
+            </Flex>
+            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+              <p>{{ t('integrations.salesChannel.helpText.listingOwner') }}</p>
+            </div>
+          </FlexCell>
+        </Flex>
+      </FlexCell>
+    </Flex>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/ebay/index.ts
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/ebay/index.ts
@@ -1,0 +1,1 @@
+export { default as EbayChannelInfoStep } from './EbayChannelInfoStep.vue';

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
@@ -38,7 +38,8 @@ const typeChoices = [
   { name: IntegrationTypes.Magento, disabled: false },
   { name: IntegrationTypes.Shopify, disabled: false, banner: t('shared.labels.beta') },
   { name: IntegrationTypes.Amazon, banner: t('shared.labels.beta') },
-  { name: IntegrationTypes.Woocommerce, banner: t('shared.labels.beta') }
+  { name: IntegrationTypes.Woocommerce, banner: t('shared.labels.beta') },
+  { name: IntegrationTypes.Ebay, banner: t('shared.labels.beta') }
 ];
 
 const onModalOpen = () => {
@@ -120,6 +121,12 @@ const closeModal = () => {
           </Flex>
           <p class="mb-4">{{ t('integrations.create.wizard.step1.woocommerceExample') }}</p>
           <Image :source="woocomerceType" alt="woocommerce" class="w-full max-h-[35rem]" />
+        </div>
+      </template>
+      <template #ebay>
+        <div>
+          <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.ebayTitle') }}</h3>
+          <p class="mb-4">{{ t('integrations.create.wizard.step1.ebayExample') }}</p>
         </div>
       </template>
     </OptionSelector>

--- a/src/core/integrations/integrations/integrations-installed/ebay-installed/EbayInstalledController.vue
+++ b/src/core/integrations/integrations/integrations-installed/ebay-installed/EbayInstalledController.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+import { onMounted, ref } from 'vue';
+import { Breadcrumbs } from '../../../../../shared/components/molecules/breadcrumbs';
+import { Loader } from "../../../../../shared/components/atoms/loader";
+import apolloClient from "../../../../../../apollo-client";
+import { Card } from "../../../../../shared/components/atoms/card";
+import { Link } from "../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../shared/components/atoms/button";
+import { IntegrationTypes } from "../../integrations";
+import GeneralTemplate from "../../../../../shared/templates/GeneralTemplate.vue";
+import {validateEbayAuthMutation} from "../../../../../shared/api/mutations/salesChannels";
+
+const { t } = useI18n();
+const route = useRoute();
+
+const errors = ref<string[]>([]);
+const loading = ref(true);
+const id = ref<string | null>(null);
+
+onMounted(async () => {
+  const { code, state } = route.query;
+
+  if (!code || !state) {
+    errors.value.push(t('integrations.salesChannel.ebay.installed.missingParams'));
+    loading.value = false;
+    return;
+  }
+
+  try {
+    const { data } = await apolloClient.mutate({
+      mutation: validateEbayAuthMutation,
+      variables: {
+        data: {
+          code,
+          state,
+        }
+      }
+    });
+
+    const result = data?.validateEbayAuth;
+    if (result?.id) {
+      id.value = result.id;
+    } else if (result?.messages?.length) {
+      errors.value = result.messages.map((m: any) => m.message);
+    }
+  } catch (e) {
+    errors.value.push(t('integrations.salesChannel.ebay.installed.genericError'));
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template #breadcrumbs>
+      <Breadcrumbs :links="[{ path: { name: 'integrations.integrations.list' }, name: t('integrations.title') }]" />
+    </template>
+
+    <template #content>
+      <Card class="p-4">
+        <Loader :loading="loading" />
+        <div>
+          <div v-if="id">
+            <div class="p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50" role="alert">
+              ✅ {{ t('integrations.salesChannel.ebay.installed.success') }}
+            </div>
+            <Link class="mt-2" :path="{ name: 'integrations.integrations.show', params: { id, type: IntegrationTypes.Ebay } }">
+              <Button
+                type="button"
+                class="button rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm btn-info"
+              >
+                {{ t('integrations.salesChannel.shopify.labels.goToStore') }}
+              </Button>
+            </Link>
+          </div>
+
+          <div v-else>
+            <div v-if="!loading" class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50" role="alert">
+              <span class="font-medium flex items-center gap-1">
+                ⚠️ {{ t('integrations.show.ebayNotConnectedBanner.title') }}
+              </span>
+              <ul class="mt-2 ml-4 list-disc">
+                <li v-for="(error, index) in errors" :key="index">{{ error }}</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -12,12 +12,14 @@ import {
   getSalesChannelQuery,
   getShopifyChannelQuery,
   getWoocommerceChannelQuery,
-  getAmazonChannelQuery
+  getAmazonChannelQuery,
+  getEbayChannelQuery
 } from "../../../../shared/api/queries/salesChannels.js";
 import { AmazonGeneralInfoTab } from "./containers/general/amazon-general-tab";
 import { MagentoGeneralInfoTab } from "./containers/general/magento-general-tab";
 import { ShopifyGeneralInfoTab } from "./containers/general/shopify-general-tab";
 import { WoocommerceGeneralInfoTab } from "./containers/general/woocommerce-general-tab";
+import { EbayGeneralInfoTab } from "./containers/general/ebay-general-tab";
 import apolloClient from "../../../../../apollo-client";
 import { Loader } from "../../../../shared/components/atoms/loader";
 import { Products } from "./containers/products";
@@ -76,6 +78,8 @@ const getIntegrationQuery = () => {
       return getWoocommerceChannelQuery;
     case IntegrationTypes.Amazon:
       return getAmazonChannelQuery;
+    case IntegrationTypes.Ebay:
+      return getEbayChannelQuery;
     default:
       return getSalesChannelQuery;
   }
@@ -91,6 +95,8 @@ const getIntegrationQueryKey = () => {
       return "woocommerceChannel";
     case IntegrationTypes.Amazon:
       return "amazonChannel";
+    case IntegrationTypes.Ebay:
+      return "ebayChannel";
     default:
       return "salesChannel";
   }
@@ -106,6 +112,8 @@ const getGeneralComponent = () => {
       return WoocommerceGeneralInfoTab;
     case IntegrationTypes.Amazon:
       return AmazonGeneralInfoTab;
+    case IntegrationTypes.Ebay:
+      return EbayGeneralInfoTab;
     default:
       return null;
   }

--- a/src/core/integrations/integrations/integrations-show/containers/general/ebay-general-tab/EbayGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/ebay-general-tab/EbayGeneralInfoTab.vue
@@ -1,0 +1,317 @@
+<script setup lang="ts">
+import { computed, ref, watch, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { TextInput } from "../../../../../../../shared/components/atoms/input-text";
+import { Label } from "../../../../../../../shared/components/atoms/label";
+import { Toggle } from "../../../../../../../shared/components/atoms/toggle";
+import { Accordion } from "../../../../../../../shared/components/atoms/accordion";
+import { Selector } from "../../../../../../../shared/components/atoms/selector";
+
+import { PrimaryButton } from "../../../../../../../shared/components/atoms/button-primary";
+import { SecondaryButton } from "../../../../../../../shared/components/atoms/button-secondary";
+import { CancelButton } from "../../../../../../../shared/components/atoms/button-cancel";
+import { Toast } from "../../../../../../../shared/modules/toast";
+import { useEnterKeyboardListener, useShiftBackspaceKeyboardListener, useShiftEnterKeyboardListener } from "../../../../../../../shared/modules/keyboard";
+import { useRouter, useRoute } from 'vue-router';
+import { updateEbaySalesChannelMutation } from "../../../../../../../shared/api/mutations/salesChannels.js";
+import { processGraphQLErrors } from "../../../../../../../shared/utils";
+import { AmazonRegions, AmazonCountries } from "../../../../integrations";
+import {FieldDate} from "../../../../../../../shared/components/organisms/general-show/containers/field-date";
+import { FieldType } from "../../../../../../../shared/utils/constants";
+import apolloClient from "../../../../../../../../apollo-client";
+
+interface EditEbayForm {
+  id: string;
+  hostname: string;
+  active: boolean;
+  verifySsl: boolean;
+  requestsPerMinute: number;
+  maxRetries: number;
+  useConfigurableName: boolean;
+  syncContents: boolean;
+  syncEanCodes: boolean;
+  syncPrices: boolean;
+  importOrders: boolean;
+  listingOwner: boolean;
+  accessToken?: string;
+  expirationDate?: string;
+  region: string | null;
+  country: string | null;
+}
+
+const props = defineProps<{ data: EditEbayForm }>();
+const { t } = useI18n();
+const router = useRouter();
+const route = useRoute();
+
+const formData = ref<EditEbayForm>({ ...props.data });
+const fieldErrors = ref<Record<string, string>>({});
+const submitButtonRef = ref();
+const submitContinueButtonRef = ref();
+watch(() => props.data, (newData) => {
+  formData.value = { ...newData };
+}, { deep: true });
+
+const openAccordionItem = computed(() => String(route.query.accordion || ''));
+
+const accordionItems = [
+  { name: 'throttling', label: t('integrations.show.sections.throttling'), icon: 'gauge' },
+  { name: 'sync', label: t('integrations.show.sections.syncPreferences'), icon: 'sync' },
+];
+
+const regionLabel = computed(() => {
+  switch (formData.value.region) {
+    case AmazonRegions.NORTH_AMERICA:
+      return t('integrations.regions.northAmerica');
+    case AmazonRegions.EUROPE:
+      return t('integrations.regions.europe');
+    case AmazonRegions.FAR_EAST:
+      return t('integrations.regions.farEast');
+    default:
+      return '';
+  }
+});
+
+const countryLabel = computed(() => {
+  switch (formData.value.country) {
+    case AmazonCountries.CANADA:
+      return t('integrations.countries.canada');
+    case AmazonCountries.UNITED_STATES:
+      return t('integrations.countries.unitedStates');
+    case AmazonCountries.MEXICO:
+      return t('integrations.countries.mexico');
+    case AmazonCountries.BRAZIL:
+      return t('integrations.countries.brazil');
+    case AmazonCountries.IRELAND:
+      return t('integrations.countries.ireland');
+    case AmazonCountries.SPAIN:
+      return t('integrations.countries.spain');
+    case AmazonCountries.UNITED_KINGDOM:
+      return t('integrations.countries.unitedKingdom');
+    case AmazonCountries.FRANCE:
+      return t('integrations.countries.france');
+    case AmazonCountries.BELGIUM:
+      return t('integrations.countries.belgium');
+    case AmazonCountries.NETHERLANDS:
+      return t('integrations.countries.netherlands');
+    case AmazonCountries.GERMANY:
+      return t('integrations.countries.germany');
+    case AmazonCountries.ITALY:
+      return t('integrations.countries.italy');
+    case AmazonCountries.SWEDEN:
+      return t('integrations.countries.sweden');
+    case AmazonCountries.SOUTH_AFRICA:
+      return t('integrations.countries.southAfrica');
+    case AmazonCountries.POLAND:
+      return t('integrations.countries.poland');
+    case AmazonCountries.EGYPT:
+      return t('integrations.countries.egypt');
+    case AmazonCountries.TURKEY:
+      return t('integrations.countries.turkey');
+    case AmazonCountries.SAUDI_ARABIA:
+      return t('integrations.countries.saudiArabia');
+    case AmazonCountries.UNITED_ARAB_EMIRATES:
+      return t('integrations.countries.unitedArabEmirates');
+    case AmazonCountries.INDIA:
+      return t('integrations.countries.india');
+    case AmazonCountries.SINGAPORE:
+      return t('integrations.countries.singapore');
+    case AmazonCountries.AUSTRALIA:
+      return t('integrations.countries.australia');
+    case AmazonCountries.JAPAN:
+      return t('integrations.countries.japan');
+    default:
+      return '';
+  }
+});
+
+const refreshClass = computed(() => {
+  if (!formData.value.expirationDate) return '';
+  const expiration = new Date(formData.value.expirationDate);
+  const now = new Date();
+  const diff = expiration.getTime() - now.getTime();
+  const months = diff / (1000 * 60 * 60 * 24 * 30);
+  if (months > 6) return 'text-green-600';
+  if (months >= 1) return 'text-yellow-600';
+  return 'text-red-600';
+});
+
+const cleanupAndMutate = async (mutate) => {
+  fieldErrors.value = {};
+  try {
+    await mutate({ variables: { data: formData.value } });
+  } catch (e) {
+    handleError(e);
+  }
+};
+
+const handleError = (errors) => {
+  const validationErrors = processGraphQLErrors(errors, t);
+  fieldErrors.value = validationErrors;
+  if (validationErrors['__all__']) {
+    Toast.error(validationErrors['__all__']);
+  }
+};
+
+const goBack = () => router.push({ name: 'integrations.integrations.list' });
+const handleSubmitDone = () => Toast.success(t('shared.alert.toast.submitSuccessUpdate'));
+const handleSubmitAndContinueDone = () => Toast.success(t('shared.alert.toast.submitSuccessUpdate'));
+
+const onSubmitPressed = () => submitButtonRef.value?.$el.click();
+const onSubmitAndContinuePressed = () => submitContinueButtonRef.value?.$el.click();
+const handleRefresh = () => {
+  alert('Refresh token');
+};
+
+useEnterKeyboardListener(onSubmitPressed);
+useShiftEnterKeyboardListener(onSubmitAndContinuePressed);
+useShiftBackspaceKeyboardListener(goBack);
+</script>
+
+<template>
+  <div class="space-y-12">
+
+    <div class="grid grid-cols-12 gap-4">
+<!--      <div class="md:col-span-6 col-span-12">-->
+<!--        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">-->
+<!--          {{ t('integrations.labels.expirationDate') }}-->
+<!--        </Label>-->
+<!--        <div class="flex items-center gap-4">-->
+<!--          <FieldDate :class="refreshClass" :field="{ name: 'expirationDate', type: FieldType.Date }" :model-value="formData.expirationDate || ''" />-->
+<!--          <PrimaryButton @click="handleRefresh">{{ t('shared.button.refresh') }}</PrimaryButton>-->
+<!--        </div>-->
+<!--      </div>-->
+    </div>
+
+    <div class="grid grid-cols-12 gap-4">
+      <div class="md:col-span-8 col-span-12">
+        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+          {{ t('shared.labels.name') }}
+        </Label>
+        <TextInput v-model="formData.hostname" :placeholder="t('shared.placeholders.name')" class="w-full" />
+      </div>
+      <div class="md:col-span-2 col-span-6">
+        <Flex class="mt-8" gap="2">
+          <FlexCell>
+            <Label class="font-semibold text-sm text-gray-900 mb-1">
+              {{ t('shared.labels.active') }}
+            </Label>
+          </FlexCell>
+          <FlexCell>
+            <Toggle v-model="formData.active" />
+          </FlexCell>
+        </Flex>
+      </div>
+
+      <div class="md:col-span-2 col-span-6">
+        <Flex class="mt-8" gap="2">
+          <FlexCell>
+            <Label class="font-semibold text-sm text-gray-900 mb-1">
+              {{ t('integrations.labels.listingOwner') }}
+            </Label>
+          </FlexCell>
+          <FlexCell>
+            <Toggle v-model="formData.listingOwner" />
+          </FlexCell>
+        </Flex>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-12 gap-4">
+      <div class="md:col-span-6 col-span-12">
+        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+          {{ t('integrations.labels.region') }}
+        </Label>
+        <TextInput :model-value="regionLabel" disabled class="w-full" />
+      </div>
+      <div class="md:col-span-6 col-span-12">
+        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+          {{ t('integrations.labels.country') }}
+        </Label>
+        <TextInput :model-value="countryLabel" disabled class="w-full" />
+      </div>
+    </div>
+
+    <Accordion class="mt-8" :items="accordionItems" :default-active="openAccordionItem" :key="openAccordionItem">
+      <template #throttling>
+        <div class="grid grid-cols-12 gap-4">
+          <div class="md:col-span-6 col-span-12">
+            <Label class="font-semibold block text-sm text-gray-900 mb-1">
+              {{ t('integrations.labels.requestsPerMinute') }}
+            </Label>
+            <TextInput v-model="formData.requestsPerMinute" :number="true" placeholder="60" class="w-full" />
+            <div class="mt-1 text-sm leading-6 text-gray-400">
+              <p class="text-red-500" v-if="fieldErrors['requestsPerMinute']">{{ fieldErrors['requestsPerMinute'] }}</p>
+              <p>{{ t('integrations.salesChannel.helpText.requestsPerMinute') }}</p>
+            </div>
+          </div>
+
+          <div class="md:col-span-6 col-span-12">
+            <Label class="font-semibold text-sm text-gray-900 mb-1">
+              {{ t('integrations.labels.maxRetries') }}
+            </Label>
+            <TextInput v-model="formData.maxRetries" :number="true" :min-number="1" :max-number="20" placeholder="3" class="w-full" />
+            <div class="mt-1 text-sm leading-6 text-gray-400">
+              <p class="text-red-500" v-if="fieldErrors['maxRetries']">{{ fieldErrors['maxRetries'] }}</p>
+              <p>{{ t('integrations.salesChannel.helpText.maxRetries') }}</p>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <template #sync>
+        <div class="space-y-4">
+          <div class="grid grid-cols-12 items-center" v-for="toggleField in ['useConfigurableName','syncContents','syncEanCodes','syncPrices','importOrders']" :key="toggleField">
+            <div class="md:col-span-4 col-span-12">
+              <Flex gap="2">
+                <FlexCell>
+                  <Label class="font-semibold text-sm text-gray-900 mb-1">
+                    {{ t(`integrations.labels.${toggleField}`) }}
+                  </Label>
+                </FlexCell>
+                <FlexCell>
+                  <Toggle v-model="formData[toggleField]" />
+                </FlexCell>
+              </Flex>
+            </div>
+            <div class="md:col-span-8 col-span-12 text-sm text-gray-400">
+              {{ t(`integrations.salesChannel.helpText.${toggleField}`) }}
+            </div>
+          </div>
+        </div>
+      </template>
+
+    </Accordion>
+
+    <div class="flex items-center justify-end gap-x-3 border-t border-gray-900/10 px-4 pt-4 sm:px-8">
+      <RouterLink :to="{ name: 'integrations.integrations.list' }">
+        <CancelButton>
+          {{ t('shared.button.back') }}
+        </CancelButton>
+      </RouterLink>
+
+      <ApolloMutation :mutation="updateEbaySalesChannelMutation" @done="handleSubmitAndContinueDone" @error="handleError">
+        <template #default="{ mutate, loading }">
+          <SecondaryButton ref="submitContinueButtonRef" :disabled="loading" @click="cleanupAndMutate(mutate)">
+            {{ t('shared.button.saveAndContinue') }}
+          </SecondaryButton>
+        </template>
+      </ApolloMutation>
+
+      <ApolloMutation :mutation="updateEbaySalesChannelMutation" @done="handleSubmitDone" @error="handleError">
+        <template #default="{ mutate, loading }">
+          <PrimaryButton ref="submitButtonRef" :disabled="loading" @click="cleanupAndMutate(mutate)">
+            {{ t('shared.button.save') }}
+          </PrimaryButton>
+        </template>
+      </ApolloMutation>
+    </div>
+  </div>
+
+  <div v-if="!formData.accessToken" class="p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 mt-4" role="alert">
+    <span class="font-medium flex items-center gap-1">
+      ⚠️ {{ t('integrations.show.ebayNotConnectedBanner.title') }}
+    </span>
+    {{ t('integrations.show.ebayNotConnectedBanner.content') }}
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/general/ebay-general-tab/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/general/ebay-general-tab/index.ts
@@ -1,0 +1,1 @@
+export { default as EbayGeneralInfoTab } from './EbayGeneralInfoTab.vue';

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -105,6 +105,12 @@ export interface AmazonChannelInfo extends SpecificChannelInfo {
   listingOwner: boolean;
 }
 
+export interface EbayChannelInfo extends SpecificChannelInfo {
+  region: string | null;
+  country: string | null;
+  listingOwner?: boolean;
+}
+
 
 /**
  * The complete integration create wizard form.
@@ -148,6 +154,14 @@ export function getAmazonDefaultFields(): AmazonChannelInfo {
   };
 }
 
+export function getEbayDefaultFields(): EbayChannelInfo {
+  return {
+    region: null,
+    country: null,
+    listingOwner: false,
+  };
+}
+
 export const getDefaultFields = (type: IntegrationTypes) => {
   switch (type) {
     case IntegrationTypes.Magento:
@@ -158,6 +172,8 @@ export const getDefaultFields = (type: IntegrationTypes) => {
       return getWoocommerceDefaultFields();
     case IntegrationTypes.Amazon:
       return getAmazonDefaultFields();
+    case IntegrationTypes.Ebay:
+      return getEbayDefaultFields();
     default:
       return {};
   }

--- a/src/core/integrations/routes.ts
+++ b/src/core/integrations/routes.ts
@@ -84,6 +84,12 @@ export const routes = [
     name: 'integrations.amazon.installed',
     meta: { title: 'integrations.amazon.installed.title' },
     component: () => import('./integrations/integrations-installed/amazon-installed/AmazonInstalledController.vue'),
+  },
+  {
+    path: '/integrations/ebay/installed',
+    name: 'integrations.ebay.installed',
+    meta: { title: 'integrations.ebay.installed.title' },
+    component: () => import('./integrations/integrations-installed/ebay-installed/EbayInstalledController.vue'),
   }
 
 ];

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2239,6 +2239,10 @@
         "title": "Amazon connection not completed",
         "content": "The app authorization did not complete or was aborted. Please retry to connect."
       },
+      "ebayNotConnectedBanner": {
+        "title": "Ebay connection not completed",
+        "content": "The app authorization did not complete or was aborted. Please retry to connect."
+      },
       "stores": {
         "title": "Store"
       },
@@ -2350,6 +2354,8 @@
           "shopifyExample": "Shopify integration to manage your products in seconds.",
           "amazonTitle": "Amazon",
           "amazonExample": "Amazon integration to manage your marketplace listings.",
+          "ebayTitle": "Ebay",
+          "ebayExample": "Ebay integration to manage your marketplace listings.",
           "woocommerceTitle": "Woocommerce",
           "woocommerceExample": "WooCommerce integration to manage your products.",
           "magentoInfoModal": {
@@ -2513,6 +2519,11 @@
         "title": "Amazon Connected"
       }
     },
+    "ebay": {
+      "installed": {
+        "title": "Ebay Connected"
+      }
+    },
     "salesChannel": {
       "shopify": {
         "installed": {
@@ -2541,6 +2552,15 @@
         },
         "labels": {
           "productsWithIssuesForSalesChannel": "Products With Amazon Issues For"
+        }
+      },
+      "ebay": {
+        "installed": {
+          "title": "Ebay Connected",
+          "loading": "Connecting your store",
+          "success": "Your Ebay store was successfully connected!",
+          "genericError": "Something went wrong while connecting your store.",
+          "missingParams": "Missing required query parameters. Please retry the installation."
         }
       },
       "toast": {

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -57,6 +57,15 @@ export const createAmazonSalesChannelMutation = gql`
   }
 `;
 
+export const createEbaySalesChannelMutation = gql`
+  mutation createEbaySalesChannel($data: EbaySalesChannelInput!) {
+    createEbaySalesChannel(data: $data) {
+      id
+      hostname
+    }
+  }
+`;
+
 export const updateWoocommerceSalesChannelMutation = gql`
   mutation updateWoocommerceSalesChannel($data: WoocommerceSalesChannelPartialInput!) {
     updateWoocommerceSalesChannel(data: $data) {
@@ -69,6 +78,15 @@ export const updateWoocommerceSalesChannelMutation = gql`
 export const updateAmazonSalesChannelMutation = gql`
   mutation updateAmazonSalesChannel($data: AmazonSalesChannelPartialInput!) {
     updateAmazonSalesChannel(data: $data) {
+      id
+      hostname
+    }
+  }
+`;
+
+export const updateEbaySalesChannelMutation = gql`
+  mutation updateEbaySalesChannel($data: EbaySalesChannelPartialInput!) {
+    updateEbaySalesChannel(data: $data) {
       id
       hostname
     }
@@ -481,6 +499,24 @@ export const getAmazonRedirectUrlMutation = gql`
   }
 `;
 
+export const getEbayRedirectUrlMutation = gql`
+  mutation GetEbayRedirectUrl($data: EbaySalesChannelPartialInput!) {
+    getEbayRedirectUrl(instance: $data) {
+      ... on EbayRedirectUrlType {
+        redirectUrl
+      }
+      ... on OperationInfo {
+        messages {
+          kind
+          message
+          field
+          code
+        }
+      }
+    }
+  }
+`;
+
 export const validateAmazonAuthMutation = gql`
   mutation ValidateAmazonAuth($data: AmazonValidateAuthInput!) {
     validateAmazonAuth(instance: $data) {
@@ -488,6 +524,24 @@ export const validateAmazonAuthMutation = gql`
         id
         region
         country
+      }
+      ... on OperationInfo {
+        messages {
+          kind
+          message
+          field
+          code
+        }
+      }
+    }
+  }
+`;
+
+export const validateEbayAuthMutation = gql`
+  mutation ValidateEbayAuth($data: EbayValidateAuthInput!) {
+    validateEbayAuth(instance: $data) {
+      ... on EbaySalesChannelType {
+        id
       }
       ... on OperationInfo {
         messages {

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -283,6 +283,114 @@ export const amazonChannelsQuerySelector = gql`
   }
 `;
 
+export const getEbayChannelQuery = gql`
+  query getEbayChannel($id: GlobalID!) {
+    ebayChannel(id: $id) {
+      id
+      hostname
+      active
+      verifySsl
+      requestsPerMinute
+      maxRetries
+      useConfigurableName
+      syncContents
+      syncEanCodes
+      syncPrices
+      importOrders
+      region
+      country
+      firstImportComplete
+      isImporting
+      integrationPtr {
+        id
+      }
+      saleschannelPtr {
+        id
+      }
+    }
+  }
+`;
+
+export const ebayChannelsQuery = gql`
+  query ebayChannelsQuery(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: EbaySalesChannelOrder
+    $filters: EbaySalesChannelFilter
+  ) {
+    ebayChannels(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filters
+    ) {
+      edges {
+        node {
+          id
+          hostname
+          active
+          region
+          country
+          createdAt
+          integrationPtr {
+            id
+          }
+          saleschannelPtr {
+            id
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const ebayChannelsQuerySelector = gql`
+  query EbayChannels(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: EbaySalesChannelOrder
+    $filters: EbaySalesChannelFilter
+  ) {
+    ebayChannels(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filters
+    ) {
+      edges {
+        node {
+          id
+          hostname
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 
 
 // Sales Channel Integration Pricelist Queries


### PR DESCRIPTION
## Summary
- add Ebay integration type
- support Ebay during integration creation wizard
- add Ebay installed controller and general tab
- include Ebay queries and mutations
- add translations and config for Ebay

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883b8bf2e94832ea990bfbe06e9d315