### PR TITLE
Amazon product import async

### DIFF
--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -416,7 +416,6 @@ export interface SalesChannelViewAssign {
   remoteUrl: string;
   remoteProductPercentage: number;
   integrationType: string;
-  formattedIssues?: { message?: string | null; severity?: string | null }[];
   product: SalesChannelViewAssignProduct;
   salesChannelView: SalesChannelView;
   remoteProduct: RemoteProduct;

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
@@ -8,20 +8,17 @@ import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { ApolloAlertMutation } from "../../../../../../../../../shared/components/molecules/apollo-alert-mutation";
 import { deleteSalesChannelViewAssignMutation } from "../../../../../../../../../shared/api/mutations/salesChannels.js";
 import { Product } from "../../../../../../configs";
-import type { SalesChannelViewAssign } from "../../../../../../configs";
 import { AssignProgressBar } from "../../../../../../../../../shared/components/molecules/assign-progress-bar";
 import { resyncSalesChannelViewAssignMutation } from "../../../../../../../../../shared/api/mutations/salesChannels.js";
 import { displayApolloError } from "../../../../../../../../../shared/utils";
 import { Toast} from "../../../../../../../../../shared/modules/toast";
 import { LogsInfoModal } from "../logs-info-modal";
-import { IssuesInfoModal } from "../issues-info-modal";
 
 const { t } = useI18n();
 const props = defineProps<{ product: Product }>();
 const infoId = ref<string | null>(null);
 const showInfoModal = ref(false);
 const infoIntegrationType = ref<string | undefined>(undefined);
-const issuesList = ref<SalesChannelViewAssign['formattedIssues'] | null>(null);
 const showIssuesModal = ref(false);
 const issuesAssignId = ref(null);
 
@@ -41,7 +38,6 @@ const setInfoId = (id: string | null, type: string | null) => {
 
 const setIssues = (issues, id) => {
   issuesAssignId.value = id;
-  issuesList.value = issues || [];
   showIssuesModal.value = true;
 }
 
@@ -123,6 +119,5 @@ const issuesModalClosed = () => {
         </table>
       </div>
       <LogsInfoModal v-model="showInfoModal" :id="infoId" :integration-type="infoIntegrationType" @modal-closed="modalColsed()" />
-      <IssuesInfoModal v-model="showIssuesModal" :id="issuesAssignId" @modal-closed="issuesModalClosed()" />
     </div>
 </template>

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
@@ -52,7 +52,6 @@ const modalColsed = () => {
 }
 
 const issuesModalClosed = () => {
-  issuesList.value = null;
   issuesAssignId.value = null;
   showIssuesModal.value = false;
 }
@@ -83,10 +82,6 @@ const issuesModalClosed = () => {
             </td>
             <td>
               <div class="flex gap-4 items-center justify-end">
-
-                <Button v-if="item.formattedIssues?.length" @click="setIssues(item.formattedIssues, item.id)">
-                  <Icon name="exclamation-triangle" size="lg" class="text-red-500" />
-                </Button>
 
                 <Button :disabled="!item.remoteProduct?.id" @click="setInfoId(item.remoteProduct?.id, item.integrationType)">
                   <Icon name="clipboard-list" size="lg" class="text-gray-500" />
@@ -128,6 +123,6 @@ const issuesModalClosed = () => {
         </table>
       </div>
       <LogsInfoModal v-model="showInfoModal" :id="infoId" :integration-type="infoIntegrationType" @modal-closed="modalColsed()" />
-      <IssuesInfoModal v-model="showIssuesModal" :issues="issuesList" :id="issuesAssignId" @modal-closed="issuesModalClosed()" />
+      <IssuesInfoModal v-model="showIssuesModal" :id="issuesAssignId" @modal-closed="issuesModalClosed()" />
     </div>
 </template>

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -272,11 +272,6 @@ export const refreshLatestAmazonIssuesMutation = gql`
   mutation refreshLatestAmazonIssues($data: SalesChannelViewAssignPartialInput!) {
     refreshAmazonLatestIssues(instance: $data) {
       id
-      formattedIssues {
-        message
-        severity
-        validationIssue
-      }
     }
   }
 `;

--- a/src/shared/api/subscriptions/products.js
+++ b/src/shared/api/subscriptions/products.js
@@ -66,11 +66,6 @@ export const productSubscription = gql`
           remoteUrl
           remoteProductPercentage
           integrationType
-          formattedIssues {
-            message
-            severity
-            validationIssue
-          }
           product {
             id
             name


### PR DESCRIPTION
## Summary by Sourcery

Remove the legacy issues list functionality from the sales channel assignment flow by stripping out all related state, UI components, GraphQL fields, and TypeScript types.

Enhancements:
- Remove IssuesInfoModal, its state refs, and button triggers from the WebsitesList component
- Eliminate formattedIssues fields from salesChannels GraphQL mutations and subscriptions
- Delete the formattedIssues property from the SalesChannelViewAssign TypeScript interface