### PR TITLE
refactor: use apollo client query in AmazonView

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useQuery } from '@vue/apollo-composable';
 import TabContentTemplate from '../TabContentTemplate.vue';
 import { Product } from '../../../../configs';
 import { Accordion } from '../../../../../../../shared/components/atoms/accordion';
 import { Button } from '../../../../../../../shared/components/atoms/button';
 import { LocalLoader } from '../../../../../../../shared/components/atoms/local-loader';
 import { amazonProductsQuery } from '../../../../../../../shared/api/queries/amazonProducts.js';
+import apolloClient from '../../../../../../../../apollo-client';
 
 const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
@@ -27,9 +27,21 @@ interface AmazonProduct {
   issues: { edges: { node: AmazonProductIssue }[] };
 }
 
-const { result, loading } = useQuery(amazonProductsQuery, {
-  localInstance: props.product.id,
-});
+const result = ref();
+const loading = ref(false);
+
+const fetchProducts = async () => {
+  loading.value = true;
+  const { data } = await apolloClient.query({
+    query: amazonProductsQuery,
+    variables: { localInstance: props.product.id },
+    fetchPolicy: 'network-only',
+  });
+  result.value = data;
+  loading.value = false;
+};
+
+onMounted(fetchProducts);
 
 const viewNameMap = computed<Record<string, string>>(() => {
   const map: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- replace `useQuery` with `apolloClient.query` in `AmazonView`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891571aeb50832e8efe8cd7cea93684

## Summary by Sourcery

Enhancements:
- Replace useQuery composable with manual apolloClient.query call and loading state management in AmazonView.vue