### PR TITLE
feat: improve Amazon product issues view

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 
 import {useI18n} from "vue-i18n";
-import {ref} from "vue";
+import {ref, computed, onMounted} from "vue";
 import {Tabs} from "../../../../../../../shared/components/molecules/tabs";
 import {Product} from "../../../../configs"
 import ProductEditView from "../../tabs/general/ProductEditView.vue";
@@ -12,32 +12,52 @@ import PropertiesView from "../../tabs/properties/PropertiesView.vue";
 import WebsitesView from "../../tabs/websites/WebsitesView.vue";
 import AliasProductsView from "../../tabs/alias-parents/AliasProductsView.vue";
 import AmazonView from "../../tabs/amazon/AmazonView.vue";
+import { amazonProductsQuery } from "../../../../../../../shared/api/queries/amazonProducts.js";
+import apolloClient from "../../../../../../../../apollo-client";
 
 const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 
-const tabItems = ref();
+const amazonProducts = ref<any[]>([]);
 
-tabItems.value = [
-  { name: 'general', label: t('shared.tabs.general'), icon: 'circle-info' },
-  { name: 'productContent', label: t('products.products.tabs.content'), icon: 'rectangle-list' },
-  { name: 'media', label: t('products.products.tabs.media'), icon: 'photo-film' },
-  { name: 'properties', label: t('products.products.tabs.properties'), icon: 'screwdriver-wrench' },
-];
-
-if (props.product.aliasProducts?.length > 0) {
-  tabItems.value.push({
-    name: 'aliasProducts',
-    label: t('products.products.tabs.aliasProducts'),
-    icon: 'clone'
+const fetchAmazonProducts = async () => {
+  const { data } = await apolloClient.query({
+    query: amazonProductsQuery,
+    variables: { localInstance: props.product.id },
+    fetchPolicy: 'network-only',
   });
-}
+  amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
+};
 
-tabItems.value.push(
-  { name: 'variations', label: t('products.products.tabs.variations'), icon: 'sitemap' },
-  { name: 'websites', label: t('products.products.tabs.websites'), icon: 'globe' },
-  { name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' },
-);
+onMounted(fetchAmazonProducts);
+
+const tabItems = computed(() => {
+  const items = [
+    { name: 'general', label: t('shared.tabs.general'), icon: 'circle-info' },
+    { name: 'productContent', label: t('products.products.tabs.content'), icon: 'rectangle-list' },
+    { name: 'media', label: t('products.products.tabs.media'), icon: 'photo-film' },
+    { name: 'properties', label: t('products.products.tabs.properties'), icon: 'screwdriver-wrench' },
+  ];
+
+  if (props.product.aliasProducts?.length > 0) {
+    items.push({
+      name: 'aliasProducts',
+      label: t('products.products.tabs.aliasProducts'),
+      icon: 'clone'
+    });
+  }
+
+  items.push(
+    { name: 'variations', label: t('products.products.tabs.variations'), icon: 'sitemap' },
+    { name: 'websites', label: t('products.products.tabs.websites'), icon: 'globe' }
+  );
+
+  if (amazonProducts.value.length > 0) {
+    items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
+  }
+
+  return items;
+});
 
 
 </script>
@@ -66,8 +86,8 @@ tabItems.value.push(
       <template v-slot:websites>
         <WebsitesView :product="product" />
       </template>
-      <template v-slot:amazon>
-        <AmazonView :product="product" />
+      <template v-if="amazonProducts.length" v-slot:amazon>
+        <AmazonView :product="product" :amazon-products="amazonProducts" />
       </template>
     </Tabs>
   </div>

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -2,7 +2,7 @@
 
 import {useI18n} from "vue-i18n";
 import {useRouter} from "vue-router";
-import {computed, ref} from "vue";
+import {computed, ref, onMounted} from "vue";
 import {Tabs} from "../../../../../../../shared/components/molecules/tabs";
 import {Product} from "../../../../configs"
 import ProductEditView from "../../tabs/general/ProductEditView.vue";
@@ -16,10 +16,25 @@ import WebsitesView from "../../tabs/websites/WebsitesView.vue";
 import ParentsView from "../../tabs/parents/ParentsView.vue";
 import AliasProductsView from "../../tabs/alias-parents/AliasProductsView.vue";
 import AmazonView from "../../tabs/amazon/AmazonView.vue";
+import { amazonProductsQuery } from "../../../../../../../shared/api/queries/amazonProducts.js";
+import apolloClient from "../../../../../../../../apollo-client";
 
 const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 const router = useRouter();
+
+const amazonProducts = ref<any[]>([]);
+
+const fetchAmazonProducts = async () => {
+  const { data } = await apolloClient.query({
+    query: amazonProductsQuery,
+    variables: { localInstance: props.product.id },
+    fetchPolicy: 'network-only',
+  });
+  amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
+};
+
+onMounted(fetchAmazonProducts);
 
 const tabItems = computed(() => {
   const items = [
@@ -43,14 +58,16 @@ const tabItems = computed(() => {
     });
   }
 
-
   items.push(
     { name: 'price', label: t('products.products.tabs.price'), icon: 'tag' },
     { name: 'websites', label: t('products.products.tabs.websites'), icon: 'globe' },
     { name: 'priceLists', label: t('products.products.tabs.priceLists'), icon: 'money-bill' },
     { name: 'eanCodes', label: t('products.products.tabs.eanCodes'), icon: 'qrcode' },
-    { name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' },
   );
+
+  if (amazonProducts.value.length > 0) {
+    items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
+  }
 
   return items;
 });
@@ -90,8 +107,8 @@ const tabItems = computed(() => {
       <template v-slot:eanCodes>
         <ProductEanCodesList :product="product" />
       </template>
-      <template v-slot:amazon>
-        <AmazonView :product="product" />
+      <template v-if="amazonProducts.length" v-slot:amazon>
+        <AmazonView :product="product" :amazon-products="amazonProducts" />
       </template>
     </Tabs>
   </div>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -934,13 +934,19 @@
         "inventory": "Inventory",
         "inventoryMovements": "Inventory Movements",
         "websites": "Channels",
-        "amazon": "Amazon",
-        "supplierProducts": "Supplier Products",
-        "saleOrders": "Sale Orders",
-        "purchasingOrders": "Purchase Orders",
-        "properties": "Properties",
-        "hsCodes": "HS Codes",
-        "eanCodes": "EAN Codes"
+      "amazon": "Amazon",
+      "supplierProducts": "Supplier Products",
+      "saleOrders": "Sale Orders",
+      "purchasingOrders": "Purchase Orders",
+      "properties": "Properties",
+      "hsCodes": "HS Codes",
+      "eanCodes": "EAN Codes"
+      },
+      "amazon": {
+        "validationIssues": "Validation Issues",
+        "validationIssuesDescription": "Issues detected locally before sending the product to Amazon.",
+        "otherIssues": "Other Issues",
+        "otherIssuesDescription": "Issues returned by Amazon after processing the product."
       },
       "inspector": {
         "errors": {

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -500,6 +500,7 @@ export const amazonChannelViewsQuery = gql`
       edges {
         node {
           id
+          remoteId
           name
           active
           isDefault

--- a/src/shared/components/atoms/accordion/Accordion.vue
+++ b/src/shared/components/atoms/accordion/Accordion.vue
@@ -52,6 +52,9 @@ const isActive = (index: number) => activeIndex.value === index;
             <FlexCell center grow>
               <span>{{ item.label }}</span>
             </FlexCell>
+            <FlexCell center @click.stop>
+              <slot :name="item.name + '-actions'"></slot>
+            </FlexCell>
             <FlexCell center>
               <svg
                 v-if="isActive(index)"


### PR DESCRIPTION
## Summary
- load Amazon channel views separately and split validation vs other issues with severity highlights
- show header action buttons in the issues accordion
- hide Amazon tab unless an Amazon product exists

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68927f82fbf0832e9cf91dd59825edc7

## Summary by Sourcery

Improve the Amazon issues view by fetching channel views independently, conditionally showing the Amazon tab, grouping and highlighting issues by type and severity, and surfacing header action buttons for quick operations.

New Features:
- Load Amazon channel views separately via a dedicated GraphQL query
- Hide the Amazon tab when no Amazon products are found
- Add “resync”, “validate”, and “fetch issues” buttons in each accordion header

Enhancements:
- Split product issues into validation and other sections with separate tables
- Color-code issue severities (ERROR in red, WARNING in yellow)
- Extend Accordion component to support custom header action slots
- Fetch and pass Amazon products to the Amazon view component
- Include remoteId field in the amazonChannelViewsQuery