### PR TITLE
feat: add amazon product action buttons

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -107,7 +107,11 @@ const tabItems = computed(() => {
         <ProductEanCodesList :product="product" />
       </template>
       <template v-if="amazonProducts.length" v-slot:amazon>
-        <AmazonView :product="product" :amazon-products="amazonProducts" />
+        <AmazonView
+          :product="product"
+          :amazon-products="amazonProducts"
+          @refresh-amazon-products="fetchAmazonProducts"
+        />
       </template>
     </Tabs>
   </div>

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -87,7 +87,11 @@ const tabItems = computed(() => {
         <WebsitesView :product="product" />
       </template>
       <template v-if="amazonProducts.length" v-slot:amazon>
-        <AmazonView :product="product" :amazon-products="amazonProducts" />
+        <AmazonView
+          :product="product"
+          :amazon-products="amazonProducts"
+          @refresh-amazon-products="fetchAmazonProducts"
+        />
       </template>
     </Tabs>
   </div>

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -108,7 +108,11 @@ const tabItems = computed(() => {
         <ProductEanCodesList :product="product" />
       </template>
       <template v-if="amazonProducts.length" v-slot:amazon>
-        <AmazonView :product="product" :amazon-products="amazonProducts" />
+        <AmazonView
+          :product="product"
+          :amazon-products="amazonProducts"
+          @refresh-amazon-products="fetchAmazonProducts"
+        />
       </template>
     </Tabs>
   </div>

--- a/src/shared/api/mutations/amazonProducts.js
+++ b/src/shared/api/mutations/amazonProducts.js
@@ -1,0 +1,28 @@
+import { gql } from 'graphql-tag';
+
+export const refreshAmazonProductIssuesMutation = gql`
+  mutation refreshAmazonProductIssues(
+    $remoteProduct: AmazonProductPartialInput!
+    $view: AmazonSalesChannelViewPartialInput!
+  ) {
+    refreshAmazonLatestIssues(remoteProduct: $remoteProduct, view: $view) {
+      id
+    }
+  }
+`;
+
+export const resyncAmazonProductMutation = gql`
+  mutation resyncAmazonProduct(
+    $remoteProduct: AmazonProductPartialInput!
+    $view: AmazonSalesChannelViewPartialInput!
+    $forceValidationOnly: Boolean!
+  ) {
+    resyncAmazonProduct(
+      remoteProduct: $remoteProduct
+      view: $view
+      forceValidationOnly: $forceValidationOnly
+    ) {
+      id
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- add mutations for refreshing issues and resyncing Amazon products
- wire up Amazon tab buttons to trigger GraphQL actions with success/error handling
- notify parent product views to refresh Amazon product data after actions

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689286578134832e8c50e791a191d450

## Summary by Sourcery

Add action buttons to the Amazon tab to resync, validate, and fetch issues for Amazon products via GraphQL mutations with UI feedback and automatic data refresh.

New Features:
- Introduce GraphQL mutations for resyncing Amazon products and refreshing Amazon product issues
- Add ApolloMutation wrappers to the Amazon tab buttons to invoke resync, validate, and fetch issues actions

Enhancements:
- Display success toasts and error handling for mutation results
- Emit a refresh event after actions to reload Amazon product data in the parent views