### PR TITLE
Trim general search query length

### DIFF
--- a/src/shared/components/molecules/search-input/SearchInput.vue
+++ b/src/shared/components/molecules/search-input/SearchInput.vue
@@ -21,11 +21,15 @@ const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
 const input = ref<HTMLInputElement | null>(null);
-const inputValue = ref(props.modelValue || "");
+const emit = defineEmits(["update:modelValue"]);
+const inputValue = ref((props.modelValue || "").slice(0, 100));
 
 watch(() => props.modelValue, (newValue) => {
   if (newValue === null) {
     newValue = "";
+  }
+  if (newValue.length > 100) {
+    newValue = newValue.slice(0, 100);
   }
   inputValue.value = newValue;
   updateRoute(newValue);
@@ -48,6 +52,13 @@ const focus = () => {
 };
 
 defineExpose({ focus });
+
+const onInput = () => {
+  if (inputValue.value.length > 100) {
+    inputValue.value = inputValue.value.slice(0, 100);
+  }
+  emit("update:modelValue", inputValue.value);
+};
 </script>
 
 <template>
@@ -63,7 +74,7 @@ defineExpose({ focus });
         type="text"
         :placeholder="placeholder || t('shared.button.search')"
         :disabled="disabled"
-        @input="$emit('update:modelValue', inputValue)"
+        @input="onInput"
       />
     </div>
   </div>

--- a/src/shared/components/organisms/general-search/GeneralSearch.vue
+++ b/src/shared/components/organisms/general-search/GeneralSearch.vue
@@ -31,7 +31,7 @@ watch(
 
 watch(() => route.query[routeKey.value], (newQueryValue) => {
   if (newQueryValue && typeof newQueryValue === 'string') {
-    search.value = newQueryValue;
+    search.value = newQueryValue.slice(0, 100);
   }
 }, {immediate: true});
 


### PR DESCRIPTION
## Summary
- Limit general search inputs to 100 characters before emitting or updating the route
- Truncate route-based search queries to 100 characters to prevent overly long searches

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894e8404ab4832eb8b7c3a62372862c

## Summary by Sourcery

Enforce a maximum 100-character length for general search queries to prevent overly long inputs by truncating them in both the input component and the route-based search handler.

New Features:
- Limit search input component to 100 characters and emit trimmed values.
- Truncate route-based search query values to 100 characters before updating the search state.