### PR TITLE
feat: add usedInProducts filters

### DIFF
--- a/src/core/properties/properties/configs.ts
+++ b/src/core/properties/properties/configs.ts
@@ -199,6 +199,12 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
         strict: true,
       },
       {
+        type: FieldType.Boolean,
+        name: 'usedInProducts',
+        label: t('properties.properties.labels.usedInProducts'),
+        strict: true,
+      },
+      {
         type: FieldType.Choice,
         name: 'type',
         label: t('products.products.labels.type.title'),

--- a/src/core/properties/property-select-values/configs.ts
+++ b/src/core/properties/property-select-values/configs.ts
@@ -236,6 +236,12 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
             label: t('properties.values.labels.missingTranslations'),
             strict: true,
         },
+        {
+            type: FieldType.Boolean,
+            name: 'usedInProducts',
+            label: t('properties.values.labels.usedInProducts'),
+            strict: true,
+        },
     ],
     orders: []
 });

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2080,7 +2080,8 @@
         "internalName": "Internal Name",
         "valueValidator": "Value Validator",
         "missingMainTranslation": "Missing Main Translation",
-        "missingTranslations": "Missing Translations"
+        "missingTranslations": "Missing Translations",
+        "usedInProducts": "Used In Products"
       },
       "placeholders": {
         "internalName": "Enter internal name",
@@ -2125,7 +2126,8 @@
       "labels": {
         "value": "Value",
         "missingMainTranslation": "Missing Main Translation",
-        "missingTranslations": "Missing Translations"
+        "missingTranslations": "Missing Translations",
+        "usedInProducts": "Used In Products"
       },
       "placeholders": {
         "value": "Enter value"


### PR DESCRIPTION
## Summary
- allow filtering properties by whether they are used in products
- allow filtering property select values by usage in products
- add English translations for new filters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894f8ec0978832e8538adb8c85c96a2

## Summary by Sourcery

Introduce usedInProducts filters for properties and property select values and include their English translations

New Features:
- Add usedInProducts boolean filter to property search configuration
- Add usedInProducts boolean filter to property select value search configuration

Documentation:
- Add English translations for the usedInProducts filter labels