### PR TITLE
Refactor integration products view to use GeneralListing

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/products/Products.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/products/Products.vue
@@ -1,191 +1,79 @@
 <script setup lang="ts">
-import {ref, watch} from 'vue';
-import {useI18n} from 'vue-i18n';
-import {useRouter} from "vue-router";
-import {FilterManager} from "../../../../../../shared/components/molecules/filter-manager";
-import {Icon} from "../../../../../../shared/components/atoms/icon";
-import {Button} from "../../../../../../shared/components/atoms/button";
-import {Link} from "../../../../../../shared/components/atoms/link";
-import {ApolloAlertMutation} from "../../../../../../shared/components/molecules/apollo-alert-mutation";
-import {Pagination} from "../../../../../../shared/components/molecules/pagination";
-import {SearchConfig} from "../../../../../../shared/components/organisms/general-search/searchConfig";
-import { salesChannelViewAssignsQuery } from "../../../../../../shared/api/queries/salesChannels.js";
-import {
-  deleteSalesChannelViewAssignMutation,
-  resyncSalesChannelViewAssignMutation
-} from "../../../../../../shared/api/mutations/salesChannels.js";
-import { displayApolloError, shortenText } from "../../../../../../shared/utils";
-import {Toast} from "../../../../../../shared/modules/toast";
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { GeneralListing } from "../../../../../../shared/components/organisms/general-listing";
+import { Button } from "../../../../../../shared/components/atoms/button";
+import { Icon } from "../../../../../../shared/components/atoms/icon";
+import { Link } from "../../../../../../shared/components/atoms/link";
+import { productsSearchConfigConstructor, productsListingConfigConstructor, listingQuery, listingQueryKey } from "./configs";
+import { resyncSalesChannelViewAssignMutation } from "../../../../../../shared/api/mutations/salesChannels.js";
+import { displayApolloError } from "../../../../../../shared/utils";
+import { Toast } from "../../../../../../shared/modules/toast";
 import { LogsInfoModal } from "../../../../../products/products/product-show/containers/tabs/websites/containers/logs-info-modal";
-import {Badge} from "../../../../../../shared/components/atoms/badge";
-import {getProductTypeBadgeMap} from "../../../../../products/products/configs";
-
 
 const { t } = useI18n();
 const props = defineProps<{ salesChannelId: string }>();
+
 const infoId = ref<string | null>(null);
 const showInfoModal = ref(false);
 const infoIntegrationType = ref<string | undefined>(undefined);
-const router = useRouter();
 
-const searchConfig: SearchConfig = {
-  search: true,
-  orderKey: "sort",
-  filters: [],
-  orders: []
-};
+const searchConfig = productsSearchConfigConstructor(t, props.salesChannelId);
+const listingConfig = productsListingConfigConstructor(t);
 
 const onResyncError = (error) => {
   displayApolloError(error);
 };
 
 const onResyncSuccess = () => {
-  Toast.success(t('integrations.salesChannel.toast.resyncSuccess'))
+  Toast.success(t('integrations.salesChannel.toast.resyncSuccess'));
 };
 
 const setInfoId = (id: string | null, type: string | null) => {
   infoId.value = id;
   infoIntegrationType.value = type || undefined;
   showInfoModal.value = true;
-}
+};
 
-const modalColsed = () => {
+const modalClosed = () => {
   infoId.value = null;
   infoIntegrationType.value = undefined;
   showInfoModal.value = false;
-}
-
-const getStatusColor = (item) => {
-  if (item.remoteProduct?.hasErrors) {
-    return 'red';
-  }
-
-  if (item.remoteProductPercentage == 100) {
-    return 'green';
-  } else {
-    return 'yellow';
-  }
-}
-
-const getStatusText = (item) => {
-  if (item.remoteProduct?.hasErrors) {
-    return t('shared.labels.failed');
-  }
-
-  if (item.remoteProductPercentage == 100) {
-    return t('shared.labels.completed');
-  } else {
-    return t('shared.labels.processing');
-  }
-}
-
+};
 </script>
 
 <template>
   <div>
-      <FilterManager :searchConfig="searchConfig">
-        <template v-slot:variables="{ filterVariables, orderVariables, pagination }">
-          <ApolloQuery :query="salesChannelViewAssignsQuery"
-                       :variables="{filter: {salesChannel: {id: {exact: salesChannelId }}},
-                                order: orderVariables,
-                                first: pagination.first,
-                                last: pagination.last,
-                                before: pagination.before,
-                                after: pagination.after }">
-            <template v-slot="{ result: { data }, query }">
-              <div v-if="data" class="mt-5 p-0 border-0 overflow-hidden">
-                <div :class="data.salesChannelViewAssigns.edges.length > 0 ? 'table-responsive custom-table-scroll' : ''">
-                  <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
-                    <thead>
-                    <tr>
-                      <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                        {{ t('shared.labels.name') }}
-                      </th>
-                      <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                        {{ t('shared.labels.type') }}
-                      </th>
-                      <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                        {{ t('shared.labels.active') }}
-                      </th>
-                      <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                        {{ t('shared.labels.status') }}
-                      </th>
-                      <th scope="col" class="px-3 py-3.5 text-sm font-semibold text-gray-900 !text-end">
-                        {{ t('shared.labels.actions') }}
-                      </th>
-                    </tr>
-                    </thead>
-                    <tbody class="divide-y divide-gray-200 bg-white">
-                    <tr v-for="item in data.salesChannelViewAssigns.edges" :key="item.node.id">
-                      <td>
-                        <Link :title="item.node.product.name" :path="{name: 'products.products.show', params: { id: item.node.product.id}, query: {tab: 'websites'}}">
-                          {{ shortenText(item.node.product.name, 64) }}
-                        </Link>
-                      </td>
-                      <td>
-                        <Badge
-                          :text="getProductTypeBadgeMap(t)[item.node.product.type]?.text"
-                          :color="getProductTypeBadgeMap(t)[item.node.product.type]?.color"
-                        />
-                      </td>
-                      <td>
-                        <Icon v-if="item.node.product.active" name="check-circle" class="ml-2 text-green-500"/>
-                        <Icon v-else name="times-circle" class="ml-2 text-red-500"/>
-                      </td>
-                      <td>
-                        <Badge :color="getStatusColor(item.node)" :text="getStatusText(item.node)" />
-                      </td>
-                      <td>
-                        <div class="flex gap-4 items-center justify-end">
+    <GeneralListing
+      :search-config="searchConfig"
+      :config="listingConfig"
+      :query="listingQuery"
+      :query-key="listingQueryKey"
+      :fixed-filter-variables="{ salesChannel: { id: { exact: salesChannelId } } }"
+    >
+      <template #additionalButtons="{ item }">
+        <Button :disabled="!item.node.remoteProduct?.id" @click="setInfoId(item.node.remoteProduct?.id, item.node.integrationType)">
+          <Icon name="clipboard-list" size="lg" class="text-gray-500" />
+        </Button>
 
-                          <Button :disabled="!item.node.remoteProduct?.id" @click="setInfoId(item.node.remoteProduct?.id, item.node.integrationType)">
-                            <Icon name="clipboard-list" size="lg" class="text-gray-500" />
-                          </Button>
+        <ApolloMutation :mutation="resyncSalesChannelViewAssignMutation" :variables="{ data: { id: item.node.id } }" @done="onResyncSuccess" @error="onResyncError">
+          <template #default="{ mutate, loading }">
+            <Button :disabled="item.node.remoteProductPercentage !== 100 || loading" @click="mutate()">
+              <Icon name="clock-rotate-left" size="lg" class="text-gray-500" />
+            </Button>
+          </template>
+        </ApolloMutation>
 
-                          <ApolloMutation :mutation="resyncSalesChannelViewAssignMutation" :variables="{ data: {id: item.node.id} }" @done="onResyncSuccess" @error="onResyncError">
-                            <template v-slot="{ mutate, loading, error }">
-                              <Button :disabled="item.node.remoteProductPercentage !== 100 || loading" @click="mutate()">
-                                <Icon name="clock-rotate-left" size="lg" class="text-gray-500" />
-                              </Button>
-                            </template>
-                          </ApolloMutation>
-
-                          <Link :path="item.node.remoteUrl" external>
-                            <Icon class="text-gray-500" size="xl" name="eye"/>
-                          </Link>
-                          <ApolloAlertMutation
-                              :mutation="deleteSalesChannelViewAssignMutation"
-                              :mutation-variables="{id: item.node.id}"
-                              :refetch-queries="() => [{
-                               query: salesChannelViewAssignsQuery,
-                               variables: {
-                                 filter: { salesChannel: { id: { exact: salesChannelId } } },
-                                 order: orderVariables,
-                                 first: pagination.first,
-                                 last: pagination.last,
-                                 before: pagination.before,
-                                 after: pagination.after
-                               }}]">
-                            <template v-slot="{ loading, confirmAndMutate }">
-                              <Button :disabled="loading" class="btn btn-sm btn-outline-danger" @click="confirmAndMutate">
-                                {{ t('shared.button.delete') }}
-                              </Button>
-                            </template>
-                          </ApolloAlertMutation>
-                        </div>
-                      </td>
-                    </tr>
-                    </tbody>
-                  </table>
-                </div>
-                <div class="py-2 px-2">
-                  <Pagination :page-info="data.salesChannelViewAssigns.pageInfo"/>
-                </div>
-              </div>
-            </template>
-          </ApolloQuery>
-        </template>
-      </FilterManager>
-    <LogsInfoModal v-model="showInfoModal" :id="infoId" :integration-type="infoIntegrationType" @modal-closed="modalColsed()" />
+        <Link :path="item.node.remoteUrl" external>
+          <Icon class="text-gray-500" size="xl" name="eye" />
+        </Link>
+      </template>
+    </GeneralListing>
+    <LogsInfoModal
+      v-model="showInfoModal"
+      :id="infoId"
+      :integration-type="infoIntegrationType"
+      @modal-closed="modalClosed()"
+    />
   </div>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/products/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/products/configs.ts
@@ -1,0 +1,85 @@
+import { FieldType } from "../../../../../../shared/utils/constants";
+import { salesChannelViewAssignsQuery, salesChannelViewsQuery } from "../../../../../../shared/api/queries/salesChannels.js";
+import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { SearchConfig } from "../../../../../../shared/components/organisms/general-search/searchConfig";
+import { deleteSalesChannelViewAssignMutation } from "../../../../../../shared/api/mutations/salesChannels.js";
+
+export const productsSearchConfigConstructor = (t: Function, salesChannelId: string): SearchConfig => ({
+  search: true,
+  orderKey: "sort",
+  filters: [
+    {
+      type: FieldType.Query,
+      name: 'salesChannelView',
+      label: t('integrations.show.products.labels.store'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: salesChannelViewsQuery,
+      dataKey: 'salesChannelViews',
+      isEdge: true,
+      multiple: true,
+      filterable: true,
+      removable: true,
+      addLookup: true,
+      lookupKeys: ['id'],
+      lookupType: 'inList',
+      queryVariables: { filter: { salesChannel: { id: { exact: salesChannelId } } } },
+    },
+    {
+      type: FieldType.Query,
+      name: 'NOT',
+      label: t('integrations.show.products.labels.excludeStores'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: salesChannelViewsQuery,
+      dataKey: 'salesChannelViews',
+      isEdge: true,
+      multiple: true,
+      filterable: true,
+      removable: true,
+      addLookup: true,
+      lookupKeys: ['salesChannelView', 'id'],
+      lookupType: 'inList',
+      queryVariables: { filter: { salesChannel: { id: { exact: salesChannelId } } } },
+    },
+  ],
+  orders: [],
+});
+
+export const productsListingConfigConstructor = (t: Function): ListingConfig => ({
+  headers: [
+    t('shared.labels.name'),
+    t('shared.labels.sku'),
+    t('integrations.show.products.labels.store'),
+  ],
+  fields: [
+    {
+      name: 'product',
+      type: FieldType.NestedText,
+      keys: ['name'],
+      clickable: true,
+      clickUrl: { name: 'products.products.show' },
+      clickIdentifiers: [{ id: ['id'] }],
+    },
+    {
+      name: 'product',
+      type: FieldType.NestedText,
+      keys: ['sku'],
+    },
+    {
+      name: 'salesChannelView',
+      type: FieldType.NestedText,
+      keys: ['name'],
+    },
+  ],
+  identifierKey: 'id',
+  addActions: true,
+  addEdit: false,
+  addShow: false,
+  addDelete: true,
+  deleteMutation: deleteSalesChannelViewAssignMutation,
+  addPagination: true,
+});
+
+export const listingQuery = salesChannelViewAssignsQuery;
+export const listingQueryKey = 'salesChannelViewAssigns';

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2264,6 +2264,12 @@
           "remoteCode": "Remote Currency Code"
         }
       },
+      "products": {
+        "labels": {
+          "store": "Store",
+          "excludeStores": "Exclude Stores"
+        }
+      },
       "productRules": {
         "title": "Amazon Rules",
         "labels": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1842,5 +1842,15 @@
         "title": "Hoe moet deze eigenschap zich gedragen op het product-type?"
       }
     }
+  },
+  "integrations": {
+    "show": {
+      "products": {
+        "labels": {
+          "store": "Winkel",
+          "excludeStores": "Winkels uitsluiten"
+        }
+      }
+    }
   }
 }

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -339,6 +339,7 @@ export const salesChannelViewAssignsQuery = gql`
           product {
             id
             name
+            sku
             active
             type
           }

--- a/src/shared/components/organisms/general-listing/GeneralListing.vue
+++ b/src/shared/components/organisms/general-listing/GeneralListing.vue
@@ -36,6 +36,7 @@ const props = withDefaults(
 );
 const slots = defineSlots<{
   bulkActions?: (scope: { selectedEntities: string[]; viewType: string; query: any }) => any;
+  additionalButtons?: (scope: { item: any }) => any;
 }>();
 
 
@@ -325,7 +326,12 @@ defineExpose({
                        filter: fixedFilterVariables !== null ? { ...filterVariables, ...fixedFilterVariables } : filterVariables,
                        order: fixedOrderVariables !== null ? { ...orderVariables, ...fixedOrderVariables } : orderVariables,
                        pagination: pagination,
-                    }" />
+                    }"
+                  >
+                    <template #additionalButtons="{ item: tableItem }">
+                      <slot name="additionalButtons" :item="tableItem" />
+                    </template>
+                  </TableRow>
                   </tbody>
                 </table>
               </div>
@@ -350,7 +356,12 @@ defineExpose({
                        filter: fixedFilterVariables !== null ? { ...filterVariables, ...fixedFilterVariables } : filterVariables,
                        order: fixedOrderVariables !== null ? { ...orderVariables, ...fixedOrderVariables } : orderVariables,
                        pagination: pagination,
-                    }" />
+                    }"
+                >
+                  <template #additionalButtons="{ item: gridItem }">
+                    <slot name="additionalButtons" :item="gridItem" />
+                  </template>
+                </GridCard>
               </div>
             </div>
 

--- a/src/shared/components/organisms/general-listing/containers/grid-card/GridCard.vue
+++ b/src/shared/components/organisms/general-listing/containers/grid-card/GridCard.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import {defineProps, computed} from 'vue';
+import {defineProps, defineSlots, computed} from 'vue';
 import {Button} from '../../../../atoms/button';
 import {ApolloAlertMutation} from '../../../../molecules/apollo-alert-mutation';
 import {Link} from '../../../../atoms/link';
@@ -19,6 +19,10 @@ const props = defineProps<{
   selectedEntities: string[];
   selectCheckbox: (id: string, value: boolean) => void;
   queryObject: any;
+}>();
+
+const slots = defineSlots<{
+  additionalButtons?: (scope: { item: any }) => any;
 }>();
 
 // Compute the image field from the item's fields (internal to this component)
@@ -115,6 +119,7 @@ const getUpdatedField = (field: any, item: any, index: number) => {
       </table>
       <!-- Actions -->
       <div v-if="config.addActions" class="flex gap-4 justify-end mt-2">
+        <slot name="additionalButtons" :item="item" />
         <Link v-if="config.addEdit"
               :path="{ name: config.editUrlName,
                        params: config.identifierKey !== undefined ? { ...config.identifierVariables, id: item.node[config.identifierKey] } : undefined,
@@ -143,6 +148,6 @@ const getUpdatedField = (field: any, item: any, index: number) => {
           </template>
         </ApolloAlertMutation>
       </div>
-    </div>
+      </div>
   </div>
 </template>

--- a/src/shared/components/organisms/general-listing/containers/table-row/TableRow.vue
+++ b/src/shared/components/organisms/general-listing/containers/table-row/TableRow.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { defineProps } from 'vue';
+import { defineProps, defineSlots } from 'vue';
 import { Button } from '../../../../atoms/button';
 import { ApolloAlertMutation } from '../../../../molecules/apollo-alert-mutation';
 import { Link } from '../../../../atoms/link';
@@ -20,6 +20,10 @@ const props = defineProps<{
   selectCheckbox: (id: string, value: boolean) => void;
 }>();
 
+const slots = defineSlots<{
+  additionalButtons?: (scope: { item: any }) => any;
+}>();
+
 </script>
 
 <template>
@@ -32,7 +36,7 @@ const props = defineProps<{
         :modelValue="selectedEntities.includes(item.node[config.identifierKey || 'id'])"
         @update:model-value="value => selectCheckbox(item.node[config.identifierKey || 'id'], value)" />
     </td>
-    <td v-for="(field, index) in config.fields" :key="field.name" class="whitespace-nowrap px-3 py-4 text-sm">
+    <td v-for="(field, index) in config.fields" :key="field.name + '-' + index" class="whitespace-nowrap px-3 py-4 text-sm">
       <component
         v-if="field.type === FieldType.Text && field.addImage && field.imageField"
         :is="getFieldComponent(field.type)"
@@ -47,6 +51,7 @@ const props = defineProps<{
     </td>
     <td v-if="config.addActions">
       <div class="flex gap-4 items-center justify-end">
+        <slot name="additionalButtons" :item="item" />
         <Link
           v-if="config.addEdit"
           :path="{ name: config.editUrlName,


### PR DESCRIPTION
## Summary
- refactor integration product table to GeneralListing with slots for extra actions
- add configurable listing/search including store and SKU filters
- expose additionalButtons slot in GeneralListing and TableRow
- include SKU in salesChannelViewAssigns query and add translations for new labels
- allow custom buttons in grid view via additionalButtons slot propagation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894e9d33894832e8f7d361c8728b489

## Summary by Sourcery

Refactor the integration products listing to leverage the GeneralListing component with ergonomic search, filtering, and slot-based action extensions, and update the underlying GraphQL query to include SKU.

New Features:
- Introduce configurable search filters for store and SKU in the integration products view
- Switch the integration products table to use the GeneralListing component with an additionalButtons slot for custom actions
- Extend the salesChannelViewAssigns query to include product SKU

Enhancements:
- Expose an additionalButtons slot in GeneralListing, TableRow, and GridCard to support custom buttons
- Extract search and listing configurations into dedicated constructors for better maintainability