### PR TITLE
Add filters for sales channel view assignments

### DIFF
--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -14,7 +14,7 @@ import { createVatRateMutation } from "../../../shared/api/mutations/vatRates.js
 import { baseFormConfigConstructor as baseVatRateConfigConstructor } from '../../settings/vat-rates/configs'
 import { Badge, Icon } from "../../../shared/components/organisms/general-show/showConfig";
 import { propertySelectValuesQuerySelector } from "../../../shared/api/queries/properties.js";
-import { amazonChannelsQuerySelector } from "../../../shared/api/queries/salesChannels.js";
+import { amazonChannelsQuerySelector, salesChannelViewsQuery } from "../../../shared/api/queries/salesChannels.js";
 import { deleteProductsMutation } from "../../../shared/api/mutations/products.js";
 
 export const vatRateOnTheFlyConfig = (t: Function):CreateOnTheFly => ({
@@ -225,6 +225,32 @@ export const searchConfigConstructor = (t: Function, hasAmazon: boolean = false)
       labelBy: "fullValueName",
       valueBy: "id",
       dataKey: "propertySelectValues",
+      filterable: true,
+      multiple: false,
+      isEdge: true,
+      addLookup: false,
+    },
+    {
+      type: FieldType.Query,
+      name: 'assignedToSalesChannelViewId',
+      query: salesChannelViewsQuery,
+      label: t('integrations.salesChannel.labels.assignedToSalesChannelView'),
+      labelBy: 'name',
+      valueBy: 'id',
+      dataKey: 'salesChannelViews',
+      filterable: true,
+      multiple: false,
+      isEdge: true,
+      addLookup: false,
+    },
+    {
+      type: FieldType.Query,
+      name: 'notAssignedToSalesChannelViewId',
+      query: salesChannelViewsQuery,
+      label: t('integrations.salesChannel.labels.notAssignedToSalesChannelView'),
+      labelBy: 'name',
+      valueBy: 'id',
+      dataKey: 'salesChannelViews',
       filterable: true,
       multiple: false,
       isEdge: true,

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2555,6 +2555,10 @@
           "productsWithIssuesForSalesChannel": "Products With Amazon Issues For"
         }
       },
+      "labels": {
+        "assignedToSalesChannelView": "Assigned To Store",
+        "notAssignedToSalesChannelView": "Not Assigned To Store"
+      },
       "toast": {
         "resyncSuccess": "The product resync process has begun. Please come later to see the results."
       },

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1843,4 +1843,13 @@
       }
     }
   }
+,
+  "integrations": {
+    "salesChannel": {
+      "labels": {
+        "assignedToSalesChannelView": "Toegewezen aan winkel",
+        "notAssignedToSalesChannelView": "Niet toegewezen aan winkel"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- allow filtering products by assigned or unassigned sales channel view
- translate labels for new filters in English and Dutch

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894fbd61cac832ebd528d515dcd35a4

## Summary by Sourcery

Introduce two query-based filters for products to select those assigned or not assigned to specific sales channel views and update locale files with the corresponding labels.

New Features:
- Add filters to search products by assigned or not assigned sales channel view

Documentation:
- Add English and Dutch translation labels for the new sales channel view filters