### PR TITLE
feat: enhance product listing with type, status and store filters

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/products/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/products/configs.ts
@@ -3,6 +3,13 @@ import { salesChannelViewAssignsQuery, salesChannelViewsQuery } from "../../../.
 import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { SearchConfig } from "../../../../../../shared/components/organisms/general-search/searchConfig";
 import { deleteSalesChannelViewAssignMutation } from "../../../../../../shared/api/mutations/salesChannels.js";
+import { getProductTypeBadgeMap } from "../../../../../products/products/configs";
+
+const getStatusBadgeMap = (t: Function) => ({
+  completed: { text: t('shared.labels.completed'), color: 'green' },
+  failed: { text: t('shared.labels.failed'), color: 'red' },
+  processing: { text: t('shared.labels.processing'), color: 'yellow' },
+});
 
 export const productsSearchConfigConstructor = (t: Function, salesChannelId: string): SearchConfig => ({
   search: true,
@@ -27,19 +34,20 @@ export const productsSearchConfigConstructor = (t: Function, salesChannelId: str
     },
     {
       type: FieldType.Query,
-      name: 'NOT',
+      name: 'notSalesChannelView',
+      isNot: true,
       label: t('integrations.show.products.labels.excludeStores'),
       labelBy: 'name',
       valueBy: 'id',
       query: salesChannelViewsQuery,
       dataKey: 'salesChannelViews',
       isEdge: true,
-      multiple: true,
+      multiple: false,
       filterable: true,
       removable: true,
       addLookup: true,
       lookupKeys: ['salesChannelView', 'id'],
-      lookupType: 'inList',
+      lookupType: 'exact',
       queryVariables: { filter: { salesChannel: { id: { exact: salesChannelId } } } },
     },
   ],
@@ -49,6 +57,9 @@ export const productsSearchConfigConstructor = (t: Function, salesChannelId: str
 export const productsListingConfigConstructor = (t: Function): ListingConfig => ({
   headers: [
     t('shared.labels.name'),
+    t('products.products.labels.type.title'),
+    t('shared.labels.active'),
+    t('shared.labels.status'),
     t('shared.labels.sku'),
     t('integrations.show.products.labels.store'),
   ],
@@ -60,6 +71,29 @@ export const productsListingConfigConstructor = (t: Function): ListingConfig => 
       clickable: true,
       clickUrl: { name: 'products.products.show' },
       clickIdentifiers: [{ id: ['id'] }],
+    },
+    {
+      name: 'product.type',
+      type: FieldType.Badge,
+      badgeMap: getProductTypeBadgeMap(t),
+    },
+    {
+      name: 'product.active',
+      type: FieldType.Boolean,
+    },
+    {
+      name: 'status',
+      type: FieldType.Badge,
+      badgeMap: getStatusBadgeMap(t),
+      accessor: (node) => {
+        if (node.remoteProduct?.hasErrors) {
+          return 'failed';
+        }
+        if (node.remoteProductPercentage === 100) {
+          return 'completed';
+        }
+        return 'processing';
+      },
     },
     {
       name: 'product',

--- a/src/shared/components/organisms/general-listing/containers/table-row/TableRow.vue
+++ b/src/shared/components/organisms/general-listing/containers/table-row/TableRow.vue
@@ -5,7 +5,7 @@ import { ApolloAlertMutation } from '../../../../molecules/apollo-alert-mutation
 import { Link } from '../../../../atoms/link';
 import { Checkbox } from '../../../../atoms/checkbox';
 import { useI18n } from 'vue-i18n';
-import { getFieldComponent } from '../../../general-show/showConfig';
+import { getFieldComponent, accessNestedProperty } from '../../../general-show/showConfig';
 import { FieldType } from '../../../../../utils/constants';
 
 const { t } = useI18n();
@@ -24,6 +24,23 @@ const slots = defineSlots<{
   additionalButtons?: (scope: { item: any }) => any;
 }>();
 
+const getModelValue = (field: any, item: any) => {
+  if (typeof field.accessor === 'function') {
+    return field.accessor(item.node);
+  }
+  if (field.name && field.name.includes('.')) {
+    return accessNestedProperty(item.node, field.name.split('.'));
+  }
+  return item.node[field.name];
+};
+
+const getImageValue = (field: any, item: any) => {
+  if (field.imageField && field.imageField.includes('.')) {
+    return accessNestedProperty(item.node, field.imageField.split('.'));
+  }
+  return item.node[field.imageField];
+};
+
 </script>
 
 <template>
@@ -41,13 +58,13 @@ const slots = defineSlots<{
         v-if="field.type === FieldType.Text && field.addImage && field.imageField"
         :is="getFieldComponent(field.type)"
         :field="getUpdatedField(field, item, index)"
-        :model-value="item.node[field.name]"
-        :image-value="item.node[field.imageField]" />
+        :model-value="getModelValue(field, item)"
+        :image-value="getImageValue(field, item)" />
       <component
         v-else
         :is="getFieldComponent(field.type)"
         :field="getUpdatedField(field, item, index)"
-        :model-value="item.node[field.name]" />
+        :model-value="getModelValue(field, item)" />
     </td>
     <td v-if="config.addActions">
       <div class="flex gap-4 items-center justify-end">

--- a/src/shared/components/organisms/general-search/searchConfig.ts
+++ b/src/shared/components/organisms/general-search/searchConfig.ts
@@ -15,6 +15,7 @@ export interface BaseFilter {
   addLookup?: boolean;
   lookupKeys?: string[];
   lookupType?: string | null;
+  isNot?: boolean;
 }
 
 export interface BooleanFilter extends BaseFilter {

--- a/src/shared/components/organisms/general-show/showConfig.ts
+++ b/src/shared/components/organisms/general-show/showConfig.ts
@@ -24,6 +24,7 @@ export interface ShowBaseField {
   customCss?: string; // Custom CSS for individual fields
   customCssClass?: string; // Custom CSS class for individual fields
   addImage?: boolean;
+  accessor?: (item: any) => any;
 }
 
 export interface TextField extends ShowBaseField {


### PR DESCRIPTION
## Summary
- show product type badge, active state and sync status alongside sku and store
- add exclude store filter using nested lookup
- support nested field values and custom accessors in general listings
- allow negative filters via `isNot` without exposing `NOT` in URLs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68950addca84832eb9c1e483f5f2cead

## Summary by Sourcery

Enhance product listing by adding store exclusion filters and displaying product type, active state, and sync status columns, and improve nested data handling and negative filters in general listings

New Features:
- Add store exclusion filter with nested lookup and isNot support
- Display product type badges, active state, and sync status badges in product listing

Enhancements:
- Support nested field values and custom accessor functions in table rows and grid cards
- Consolidate and simplify FilterManager lookup logic and enable negative filters without exposing NOT in URLs
- Introduce getStatusBadgeMap utility for status badge rendering
- Extend searchConfig with isNot flag and showConfig with accessor support