### PR TITLE
feat: add blur loading for dashboard cards

### DIFF
--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-card/DashboardCard.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-card/DashboardCard.vue
@@ -111,7 +111,10 @@ onUnmounted(() => {
       class="flex-item-inner"
       :class="{ 'no-flip': isMobile || isCompleted }"
     >
-      <div class="card">
+      <div
+        class="card transition-all duration-300"
+        :class="{ 'blur-sm animate-pulse': props.loading }"
+      >
         <!-- For Desktop -->
         <template v-if="!isMobile">
           <!-- Card Front -->

--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-general/DashboardSectionGeneral.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-general/DashboardSectionGeneral.vue
@@ -16,15 +16,12 @@ import {
   dashboardPropertySelectValuesUsedInProductsMissingMainTranslations,
   dashboardPropertySelectValuesUsedInProductsMissingTranslations,
 } from "../../../../../../../shared/api/queries/dashboardCards.js"
-import { LocalLoader } from "../../../../../../../shared/components/atoms/local-loader";
 import apolloClient from "../../../../../../../../apollo-client";
 
 const { t } = useI18n();
 
 const showCompletedGeneralCards = ref(false);
 const hideGeneralSection = ref(true);
-const finshFetch = ref(false);
-const loading = ref(false);
 
 const generalCards = ref([
   {
@@ -119,8 +116,6 @@ const generalCards = ref([
 
 
 async function fetchGeneralCounts() {
-  loading.value = true
-
   const fetchPromises = generalCards.value.map(async (card) => {
     try {
       const { data } = await apolloClient.query({
@@ -146,21 +141,18 @@ async function fetchGeneralCounts() {
   });
 
   await Promise.all(fetchPromises);
-  loading.value = false;
-
 }
 
 
 onMounted(async () =>  {
   await fetchGeneralCounts();
-  finshFetch.value = true;
 });
 
 </script>
 
 <template>
   <div class="py-8 mb-4 mt-4">
-  <Card v-if="!loading">
+  <Card>
      <Flex vertical class="pb-6 gap-2">
       <FlexCell>
         <Flex between>
@@ -214,13 +206,6 @@ onMounted(async () =>  {
         {{ t('dashboard.cards.general.noIssuesMessage') }}
       </p>
     </Card>
-    <template v-else>
-      <Card v-if="!finshFetch">
-        <div class="flex justify-center items-center h-64">
-          <LocalLoader loading />
-        </div>
-     </Card>
-    </template>
   </div>
 
 </template>

--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-orders/DashboardSectionOrders.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-orders/DashboardSectionOrders.vue
@@ -7,14 +7,12 @@ import {Card} from "../../../../../../../shared/components/atoms/card";
 import {Icon} from "../../../../../../../shared/components/atoms/icon";
 import { useI18n } from 'vue-i18n';
 import { dashboardOngoingOrders, dashboardOngoingShipments } from "../../../../../../../shared/api/queries/dashboardCards.js"
-import { LocalLoader } from "../../../../../../../shared/components/atoms/local-loader";
 import apolloClient from "../../../../../../../../apollo-client";
 
 const { t } = useI18n();
 
 const showCompletedOrdersCards = ref(false);
 const hideOrdersSection = ref(true);
-const finshFetch = ref(false);
 
 const orderCards = ref([
   {
@@ -84,7 +82,6 @@ async function fetchOrderCounts() {
 
 onMounted(async () =>  {
   await fetchOrderCounts();
-  finshFetch.value = true;
 });
 
 </script>
@@ -141,12 +138,4 @@ onMounted(async () =>  {
         />
       </div>
     </Card>
-    <template v-else>
-      <Card v-if="!finshFetch">
-        <div class="flex justify-center items-center h-64">
-          <LocalLoader loading />
-        </div>
-     </Card>
-    </template>
-
 </template>

--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-products/DashboardSectionProducts.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-products/DashboardSectionProducts.vue
@@ -7,15 +7,12 @@ import {Card} from "../../../../../../../shared/components/atoms/card";
 import {Icon} from "../../../../../../../shared/components/atoms/icon";
 import { useI18n } from 'vue-i18n';
 import { productsDashboardCardsQuery } from "../../../../../../../shared/api/queries/dashboardCards.js"
-import { LocalLoader } from "../../../../../../../shared/components/atoms/local-loader";
 import apolloClient from "../../../../../../../../apollo-client";
 
 const { t } = useI18n();
 
 const showCompletedProductsCards = ref(false);
 const allCardsCompleted = ref(true);
-const finshFetch = ref(false);
-const loading = ref(false);
 
 const productErrors = ref([
   // High importance errors
@@ -41,7 +38,6 @@ const productErrors = ref([
 ]);
 
 async function fetchErrorCounts() {
-  loading.value = true
   for (const error of productErrors.value) {
     try {
       const { data } = await apolloClient.query({
@@ -68,18 +64,16 @@ async function fetchErrorCounts() {
     }
   }
 
-  loading.value = false;
 }
 
 onMounted(async () =>  {
   await fetchErrorCounts();
-  finshFetch.value = true;
 });
 
 </script>
 
 <template>
-  <Card v-if="!loading" class="py-8">
+  <Card class="py-8">
       <Flex vertical class="py-6 gap-2">
         <FlexCell>
           <Flex between>
@@ -133,12 +127,5 @@ onMounted(async () =>  {
         {{ t('dashboard.cards.products.noIssuesMessage') }}
       </p>
   </Card>
-    <template v-else>
-      <Card v-if="!finshFetch">
-        <div class="flex justify-center items-center h-64">
-          <LocalLoader loading />
-        </div>
-     </Card>
-    </template>
 
 </template>


### PR DESCRIPTION
## Summary
- add blur and pulse transition to `DashboardCard` while data loads
- remove loaders so dashboard sections render cards immediately
- support loading state for Amazon integration cards

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68952f165ecc832e8022e32ac7c378f7