### PR TITLE
feat: add toast for amazon issue refresh and validation

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -92,8 +92,14 @@ const onResyncSuccess = () => {
   fetchViews();
 };
 
+const onValidateSuccess = () => {
+  Toast.success(t('integrations.salesChannel.toast.validateSuccess'));
+  emit('refreshAmazonProducts');
+  fetchViews();
+};
+
 const onFetchIssuesSuccess = () => {
-  Toast.success(t('shared.toast.submitSuccessUpdate'));
+  Toast.success(t('integrations.salesChannel.toast.fetchIssuesSuccess'));
   emit('refreshAmazonProducts');
   fetchViews();
 };
@@ -128,7 +134,7 @@ const onError = (error) => {
               <ApolloMutation
                 :mutation="resyncAmazonProductMutation"
                 :variables="{ remoteProduct: { id: item.remoteProductId }, view: { id: item.id }, forceValidationOnly: true }"
-                @done="onResyncSuccess"
+                @done="onValidateSuccess"
                 @error="onError"
               >
                 <template #default="{ mutate, loading }">

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2584,7 +2584,9 @@
         "notAssignedToSalesChannelView": "Not Assigned To Store"
       },
       "toast": {
-        "resyncSuccess": "The product resync process has begun. Please come later to see the results."
+        "resyncSuccess": "The product resync process has begun. Please come later to see the results.",
+        "fetchIssuesSuccess": "Product issues were refreshed from the remote server.",
+        "validateSuccess": "The product validation process has begun. Please come later to see the results."
       },
       "helpText": {
         "useConfigurableName": "If enabled, the system will always use the configurable (parent) product's name for variations.",


### PR DESCRIPTION
## Summary
- show dedicated toast messages when validating or refreshing Amazon product issues
- add English locale entries for validation and refreshed issues toasts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689620e04b68832e9f7ef364967332fd