### PR TITLE
feat: manage integration price lists

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -24,6 +24,7 @@ import { Products } from "./containers/products";
 import { Stores } from "./containers/stores";
 import { Languages } from "./containers/languages";
 import { Currencies } from "./containers/currencies";
+import { PriceLists } from "./containers/price-lists";
 import { Rules } from "./containers/rules";
 import { Properties } from "./containers/properties";
 import { PropertySelectValues } from "./containers/property-select-values";
@@ -52,6 +53,7 @@ const tabItems = ref([
   { name: 'stores', label: t('shared.tabs.stores'), icon: 'store' },
   { name: 'languages', label: t('shared.tabs.languages'), icon: 'language' },
   { name: 'currencies', label: t('settings.currencies.title'), icon: 'money-bill' },
+  { name: 'priceLists', label: t('sales.priceLists.title'), icon: 'money-bill' },
 ]);
 
 if (type.value === IntegrationTypes.Amazon) {
@@ -231,6 +233,11 @@ const pullData = async () => {
           <!-- Currencies Tab -->
           <template #currencies>
             <Currencies v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
+          </template>
+
+          <!-- Price Lists Tab -->
+          <template #priceLists>
+            <PriceLists v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
           </template>
 
           <!-- Imports Tab -->

--- a/src/core/integrations/integrations/integrations-show/containers/price-lists/PriceLists.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/price-lists/PriceLists.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import GeneralTemplate from "../../../../../../shared/templates/GeneralTemplate.vue";
+import { GeneralListing } from "../../../../../../shared/components/organisms/general-listing";
+import { Button } from "../../../../../../shared/components/atoms/button";
+import { Link } from "../../../../../../shared/components/atoms/link";
+import {
+  priceListsSearchConfigConstructor,
+  priceListsListingConfigConstructor,
+  listingQuery,
+  listingQueryKey,
+} from './configs';
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const emit = defineEmits(['pull-data']);
+const { t } = useI18n();
+
+const searchConfig = priceListsSearchConfigConstructor(t);
+const listingConfig = priceListsListingConfigConstructor(t, props.id);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:buttons>
+      <div class="flex gap-2 flex-wrap justify-end">
+        <Link :path="{ name: 'integrations.priceLists.create', params: { integrationId: id }, query: { salesChannelId: salesChannelId } }">
+          <Button type="button" class="btn btn-primary">
+            {{ t('sales.priceLists.create.title') }}
+          </Button>
+        </Link>
+        <Button type="button" class="btn btn-primary" @click="$emit('pull-data')">
+          {{ t('integrations.labels.pullData') }}
+        </Button>
+      </div>
+    </template>
+
+    <template v-slot:content>
+      <GeneralListing
+        :search-config="searchConfig"
+        :config="listingConfig"
+        :query="listingQuery"
+        :query-key="listingQueryKey"
+        :fixed-filter-variables="{ 'salesChannel': { 'id': { exact: salesChannelId } } }"
+      />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/price-lists/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/price-lists/configs.ts
@@ -1,0 +1,67 @@
+import { FieldType } from "../../../../../../shared/utils/constants";
+import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { SearchConfig } from "../../../../../../shared/components/organisms/general-search/searchConfig";
+import { FormConfig, FormType } from "../../../../../../shared/components/organisms/general-form/formConfig";
+import { salesPriceListsQuery } from "../../../../../../shared/api/queries/salesPrices.js";
+import { salesChannelIntegrationPricelistsQuery } from "../../../../../../shared/api/queries/salesChannels.js";
+import {
+  createSalesChannelIntegrationPricelistMutation,
+  deleteSalesChannelIntegrationPricelistMutation,
+} from "../../../../../../shared/api/mutations/salesChannels.js";
+
+export const priceListCreateFormConfigConstructor = (
+  t: Function,
+  type: string,
+  salesChannelId: string,
+  integrationId: string,
+): FormConfig => ({
+  cols: 1,
+  type: FormType.CREATE,
+  mutation: createSalesChannelIntegrationPricelistMutation,
+  mutationKey: 'createSalesChannelIntegrationPricelist',
+  submitUrl: { name: 'integrations.integrations.show', params: { type: type, id: integrationId }, query: { tab: 'priceLists' } },
+  fields: [
+    {
+      type: FieldType.Hidden,
+      name: 'salesChannel',
+      value: { id: salesChannelId },
+    },
+    {
+      type: FieldType.Query,
+      name: 'priceList',
+      label: t('sales.priceLists.title'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: salesPriceListsQuery,
+      dataKey: 'salesPriceLists',
+      isEdge: true,
+      multiple: false,
+      filterable: true,
+    },
+  ],
+});
+
+export const priceListsSearchConfigConstructor = (t: Function): SearchConfig => ({
+  search: true,
+  orderKey: 'sort',
+  filters: [],
+  orders: [],
+});
+
+export const priceListsListingConfigConstructor = (t: Function, specificIntegrationId: string): ListingConfig => ({
+  headers: [t('shared.labels.name')],
+  fields: [
+    { name: 'priceList', type: FieldType.NestedText, keys: ['name'] },
+  ],
+  identifierKey: 'id',
+  urlQueryParams: { integrationId: specificIntegrationId },
+  addActions: true,
+  addEdit: false,
+  addShow: false,
+  addDelete: true,
+  deleteMutation: deleteSalesChannelIntegrationPricelistMutation,
+  addPagination: true,
+});
+
+export const listingQueryKey = 'salesChannelIntegrationPricelists';
+export const listingQuery = salesChannelIntegrationPricelistsQuery;

--- a/src/core/integrations/integrations/integrations-show/containers/price-lists/containers/IntegrationsPriceListCreateController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/price-lists/containers/IntegrationsPriceListCreateController.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
+import { Breadcrumbs } from "../../../../../../../shared/components/molecules/breadcrumbs";
+import { GeneralForm } from "../../../../../../../shared/components/organisms/general-form";
+import { priceListCreateFormConfigConstructor } from '../configs';
+
+const route = useRoute();
+const { t } = useI18n();
+
+const type = ref(String(route.params.type));
+const integrationId = route.params.integrationId ? route.params.integrationId.toString() : '';
+const salesChannelId = route.query.salesChannelId ? route.query.salesChannelId.toString() : '';
+
+const formConfig = priceListCreateFormConfigConstructor(t, type.value, salesChannelId, integrationId);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-slot:breadcrumbs>
+      <Breadcrumbs
+        :links="[
+          { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
+          { path: { name: 'integrations.integrations.show', params: { id: integrationId, type: type }, query: { tab: 'priceLists' } }, name: t('integrations.show.title') },
+          { name: t('sales.priceLists.create.title') }
+        ]"
+      />
+    </template>
+    <template v-slot:content>
+      <GeneralForm :config="formConfig" />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/price-lists/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/price-lists/index.ts
@@ -1,0 +1,1 @@
+export { default as PriceLists } from './PriceLists.vue';

--- a/src/core/integrations/routes.ts
+++ b/src/core/integrations/routes.ts
@@ -37,6 +37,12 @@ export const routes = [
     component: () => import('./integrations/integrations-show/containers/currencies/containers/IntegrationsCurrencyEditController.vue'),
   },
   {
+    path: '/integrations/:type/price-list/:integrationId/create',
+    name: 'integrations.priceLists.create',
+    meta: { title: 'sales.priceLists.create.title' },
+    component: () => import('./integrations/integrations-show/containers/price-lists/containers/IntegrationsPriceListCreateController.vue'),
+  },
+  {
     path: '/integrations/:type/product-type/:id',
     name: 'integrations.amazonProductTypes.edit',
     meta: { title: 'integrations.show.productRules.title' },

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -148,9 +148,10 @@ export const createSalesChannelIntegrationPricelistMutation = gql`
   mutation createSalesChannelIntegrationPricelist($data: SalesChannelIntegrationPricelistInput!) {
     createSalesChannelIntegrationPricelist(data: $data) {
       id
-      name
-      active
-      multiTenantCompany {
+      salesChannel {
+        id
+      }
+      priceList {
         id
         name
       }
@@ -162,9 +163,10 @@ export const createSalesChannelIntegrationPricelistsMutation = gql`
   mutation createSalesChannelIntegrationPricelists($data: [SalesChannelIntegrationPricelistInput!]!) {
     createSalesChannelIntegrationPricelists(data: $data) {
       id
-      name
-      active
-      multiTenantCompany {
+      salesChannel {
+        id
+      }
+      priceList {
         id
         name
       }
@@ -176,9 +178,10 @@ export const updateSalesChannelIntegrationPricelistMutation = gql`
   mutation updateSalesChannelIntegrationPricelist($data: SalesChannelIntegrationPricelistPartialInput!) {
     updateSalesChannelIntegrationPricelist(data: $data) {
       id
-      name
-      active
-      multiTenantCompany {
+      salesChannel {
+        id
+      }
+      priceList {
         id
         name
       }

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -292,9 +292,10 @@ export const salesChannelIntegrationPricelistsQuery = gql`
       edges {
         node {
           id
-          name
-          active
-          multiTenantCompany {
+          salesChannel {
+            id
+          }
+          priceList {
             id
             name
           }
@@ -316,9 +317,10 @@ export const getSalesChannelIntegrationPricelistQuery = gql`
   query getSalesChannelIntegrationPricelist($id: GlobalID!) {
     salesChannelIntegrationPricelist(id: $id) {
       id
-      name
-      active
-      multiTenantCompany {
+      salesChannel {
+        id
+      }
+      priceList {
         id
         name
       }


### PR DESCRIPTION
## Summary
- add price list tab to integrations
- support creating and deleting sales channel price list links
- expose sales channel price list queries and mutations

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a49fc22e4832e8b87df94bd20cf14

## Summary by Sourcery

Introduce price list management for integrations by adding a dedicated tab, GraphQL support, and UI components for listing and creating integration price lists

New Features:
- Add a Price Lists tab in the integrations view with listing and pull-data capabilities
- Add UI components and routes for creating and deleting sales channel integration price lists
- Expose GraphQL queries and mutations for sales channel integration price lists

Enhancements:
- Update GraphQL payloads to replace multiTenantCompany with salesChannel and priceList fields