### PR TITLE
refactor: update integration price list UI

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -237,7 +237,7 @@ const pullData = async () => {
 
           <!-- Price Lists Tab -->
           <template #priceLists>
-            <PriceLists v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" @pull-data="pullData()" />
+            <PriceLists v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" />
           </template>
 
           <!-- Imports Tab -->

--- a/src/core/integrations/integrations/integrations-show/containers/price-lists/PriceLists.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/price-lists/PriceLists.vue
@@ -12,7 +12,6 @@ import {
 } from './configs';
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
-const emit = defineEmits(['pull-data']);
 const { t } = useI18n();
 
 const searchConfig = priceListsSearchConfigConstructor(t);
@@ -28,9 +27,6 @@ const listingConfig = priceListsListingConfigConstructor(t, props.id);
             {{ t('sales.priceLists.create.title') }}
           </Button>
         </Link>
-        <Button type="button" class="btn btn-primary" @click="$emit('pull-data')">
-          {{ t('integrations.labels.pullData') }}
-        </Button>
       </div>
     </template>
 

--- a/src/core/integrations/integrations/integrations-show/containers/price-lists/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/price-lists/configs.ts
@@ -20,6 +20,12 @@ export const priceListCreateFormConfigConstructor = (
   mutation: createSalesChannelIntegrationPricelistMutation,
   mutationKey: 'createSalesChannelIntegrationPricelist',
   submitUrl: { name: 'integrations.integrations.show', params: { type: type, id: integrationId }, query: { tab: 'priceLists' } },
+  helpSections: [
+    {
+      header: t('integrations.show.priceLists.helpSection.rules.header'),
+      content: t('integrations.show.priceLists.helpSection.rules.content'),
+    },
+  ],
   fields: [
     {
       type: FieldType.Hidden,

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1583,7 +1583,7 @@
         }
       },
       "create": {
-        "title": "Create Price List"
+        "title": "Add Price List"
       },
       "show": {
         "title": "Price List"
@@ -2282,6 +2282,14 @@
       "currencies": {
         "labels": {
           "remoteCode": "Remote Currency Code"
+        }
+      },
+      "priceLists": {
+        "helpSection": {
+          "rules": {
+            "header": "How price lists work",
+            "content": "Think of price lists like calendars for your prices. When you add price lists to a sales channel, we first look for a list whose dates include today. If we can't find one, we use the list without dates—the default. If there is no default, we use the base price in that currency. Each sales channel can only have one default list and its dated lists cannot overlap. Different channels can still have lists with the same dates."
+          }
         }
       },
       "products": {


### PR DESCRIPTION
## Summary
- remove unused Pull Data button from integration price lists tab
- rename Create Price List button to Add Price List
- add detailed help section explaining how price list dates, defaults, and overlaps determine pricing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b0783103c832e830a2c7429ef584e