### PR TITLE
Add translated name and recommendations for Amazon property values

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
@@ -33,6 +33,7 @@ export const amazonPropertySelectValueEditFormConfigConstructor = (
     { type: FieldType.Text, name: 'marketplace', label: t('integrations.show.propertySelectValues.labels.marketplace'), disabled: true, help: t('integrations.show.propertySelectValues.help.marketplace') },
     { type: FieldType.Text, name: 'remoteValue', label: t('integrations.show.propertySelectValues.labels.remoteValue'), disabled: true, help: t('integrations.show.propertySelectValues.help.remoteValue') },
     { type: FieldType.Text, name: 'remoteName', label: t('shared.labels.name'), help: t('integrations.show.propertySelectValues.help.remoteName') },
+    { type: FieldType.Text, name: 'translatedRemoteName', label: t('integrations.show.propertySelectValues.labels.translatedRemoteName'), help: t('integrations.show.propertySelectValues.help.translatedRemoteName') },
   ]
 });
 

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, reactive, computed } from 'vue';
+import { onMounted, ref, reactive, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
 import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
@@ -19,6 +19,9 @@ import apolloClient from "../../../../../../../../../../apollo-client";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { LocalLoader } from "../../../../../../../../../shared/components/atoms/local-loader";
+import { checkPropertySelectValueForDuplicatesMutation } from "../../../../../../../../../shared/api/mutations/properties.js";
+import debounce from 'lodash.debounce';
 
 const { t } = useI18n();
 const route = useRoute();
@@ -54,18 +57,21 @@ const form = reactive({
   marketplace: '',
   remoteValue: '',
   remoteName: '',
+  translatedRemoteName: '',
   localInstance: { id: route.query.createPropertySelectValueId ? route.query.createPropertySelectValueId.toString() : null },
 });
-
-console.log(form)
 
 const updatableForm = computed(() => ({
   id: form.id,
   remoteName: form.remoteName,
+  translatedRemoteName: form.translatedRemoteName,
   localInstance: { id: form.localInstance.id },
 }));
 
 const localInstanceField = ref<QueryFormField | null>(null);
+
+const recommendations = ref<{ id: string; value: string }[]>([]);
+const loadingRecommendations = ref(false);
 
 const amazonPropertyEditPath = computed(() =>
   amazonPropertyId.value
@@ -100,11 +106,47 @@ const generateValuePath = computed(() =>
         query: {
           propertyId: localPropertyId.value,
           amazonSelectValueId: `${valueId.value}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`,
-          value: form.remoteName,
+          value: form.translatedRemoteName || form.remoteName,
         },
       }
     : null
 );
+
+const fetchRecommendations = async () => {
+  if (!localPropertyId.value) return;
+  const searchValue = form.translatedRemoteName || form.remoteName;
+  if (!searchValue) {
+    recommendations.value = [];
+    return;
+  }
+  try {
+    loadingRecommendations.value = true;
+    const { data } = await apolloClient.mutate({
+      mutation: checkPropertySelectValueForDuplicatesMutation,
+      variables: { property: { id: localPropertyId.value }, value: searchValue },
+    });
+    if (data && data.checkPropertySelectValueForDuplicates && data.checkPropertySelectValueForDuplicates.duplicateFound) {
+      recommendations.value = data.checkPropertySelectValueForDuplicates.duplicates.map((p: any) => ({
+        id: p.id,
+        value: p.value || p.id,
+      }));
+    } else {
+      recommendations.value = [];
+    }
+  } finally {
+    loadingRecommendations.value = false;
+  }
+};
+
+const debouncedFetchRecommendations = debounce(fetchRecommendations, 500);
+
+watch(() => [form.remoteName, form.translatedRemoteName], () => {
+  debouncedFetchRecommendations();
+});
+
+watch(localPropertyId, () => {
+  debouncedFetchRecommendations();
+});
 
 onMounted(async () => {
   const { data } = await apolloClient.query({
@@ -122,6 +164,7 @@ onMounted(async () => {
   form.marketplace = valueData?.marketplace?.name || '';
   form.remoteValue = valueData?.remoteValue || '';
   form.remoteName = valueData?.remoteName || '';
+  form.translatedRemoteName = valueData?.translatedRemoteName || '';
 
   if (valueData?.localInstance?.id) {
       form.localInstance.id = valueData?.localInstance?.id;
@@ -156,6 +199,8 @@ onMounted(async () => {
       }
     }
   }
+
+  await fetchRecommendations();
 
   if (!isWizard) return;
 
@@ -291,6 +336,19 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                     </FlexCell>
                   </Flex>
                 </div>
+                <div class="col-span-full">
+                  <Flex vertical>
+                    <FlexCell>
+                      <Label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('integrations.show.propertySelectValues.labels.translatedRemoteName') }}</Label>
+                    </FlexCell>
+                    <FlexCell>
+                      <TextInput v-model="form.translatedRemoteName" class="w-full" />
+                    </FlexCell>
+                    <FlexCell>
+                      <p class="mt-1 text-sm leading-6 text-gray-400">{{ t('integrations.show.propertySelectValues.help.translatedRemoteName') }}</p>
+                    </FlexCell>
+                  </Flex>
+                </div>
                 <div v-if="!propertyMapped" class="col-span-full p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400" role="alert">
                   <span class="font-medium flex items-center gap-1">
                     ⚠️ {{ t('integrations.show.propertySelectValues.notMappedBanner.title') }}
@@ -311,6 +369,27 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                       <p class="mt-1 text-sm leading-6 text-gray-400">{{ t('integrations.show.propertySelectValues.help.selectValue') }}</p>
                     </FlexCell>
                   </Flex>
+                  <div class="mt-4 border border-gray-300 bg-gray-50 rounded p-4">
+                    <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-2">{{ t('integrations.show.propertySelectValues.recommendation.title') }}</Label>
+                    <div v-if="loadingRecommendations" class="flex items-center gap-2">
+                      <LocalLoader :loading="true" />
+                      <span class="text-sm text-gray-500">{{ t('integrations.show.propertySelectValues.recommendation.searching') }}</span>
+                    </div>
+                    <div v-else>
+                      <div v-if="recommendations.length" class="flex flex-wrap gap-2">
+                        <button
+                          v-for="item in recommendations"
+                          :key="item.id"
+                          type="button"
+                          class="bg-purple-100 text-purple-800 px-2 py-1 rounded text-sm hover:bg-purple-200"
+                          @click="form.localInstance.id = item.id"
+                        >
+                          {{ item.value }}
+                        </button>
+                      </div>
+                      <p v-else class="text-sm text-gray-500">{{ t('integrations.show.propertySelectValues.recommendation.none') }}</p>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2343,7 +2343,8 @@
           "amazonProperty": "Amazon Property",
           "marketplace": "Marketplace",
           "localProperty": "Local Property",
-          "selectValue": "Select Value"
+          "selectValue": "Select Value",
+          "translatedRemoteName": "Translated Name"
         },
         "help": {
           "amazonProperty": "Amazon property to which this value belongs.",
@@ -2351,11 +2352,17 @@
           "localProperty": "Local property that this Amazon property maps to.",
           "remoteValue": "Value exactly as defined in Amazon.",
           "remoteName": "Name from Amazon. You can change it.",
-          "selectValue": "Choose the local value that matches this Amazon value."
+          "selectValue": "Choose the local value that matches this Amazon value.",
+          "translatedRemoteName": "Translated name for this value."
         },
         "notMappedBanner": {
           "title": "Amazon property not mapped",
           "content": "Map the Amazon property first before mapping values."
+        },
+        "recommendation": {
+          "title": "Recommendations",
+          "searching": "Searching for suggestions...",
+          "none": "No suggestion found"
         },
         "bulkAssign": "Assign Select Value",
         "bulkAssignTitle": "Assign to {count} value(s)",

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -815,6 +815,7 @@ export const getAmazonPropertySelectValueQuery = gql`
       }
       remoteValue
       remoteName
+      translatedRemoteName
       localInstance {
         id
         value


### PR DESCRIPTION
## Summary
- support translatedRemoteName for Amazon property select values
- add recommendation section with suggestions when property is mapped
- include new translations and query fields

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c78247128832eaa560b1a72cf0678

## Summary by Sourcery

Support translated remote names and show mapping recommendations in the Amazon property select value editor.

New Features:
- Expose translatedRemoteName field in the editor form, GraphQL query, and form config.
- Add a recommendation panel to fetch and list existing local values based on duplicate checking when entering names.

Enhancements:
- Debounce duplicate-check API calls and display a loading indicator during recommendation fetching.

Documentation:
- Add localization entries for translatedRemoteName labels and recommendation texts.