### PR TITLE
feat: add property mapping recommendations

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -126,10 +126,12 @@ const fetchRecommendations = async () => {
       variables: { property: { id: localPropertyId.value }, value: searchValue },
     });
     if (data && data.checkPropertySelectValueForDuplicates && data.checkPropertySelectValueForDuplicates.duplicateFound) {
-      recommendations.value = data.checkPropertySelectValueForDuplicates.duplicates.map((p: any) => ({
-        id: p.id,
-        value: p.value || p.id,
-      }));
+      recommendations.value = data.checkPropertySelectValueForDuplicates.duplicates
+        .filter((p: any) => p.id !== form.localInstance.id)
+        .map((p: any) => ({
+          id: p.id,
+          value: p.value || p.id,
+        }));
     } else {
       recommendations.value = [];
     }
@@ -147,6 +149,15 @@ watch(() => [form.remoteName, form.translatedRemoteName], () => {
 watch(localPropertyId, () => {
   debouncedFetchRecommendations();
 });
+
+watch(() => form.localInstance.id, () => {
+  recommendations.value = recommendations.value.filter(r => r.id !== form.localInstance.id);
+});
+
+const selectRecommendation = (id: string) => {
+  form.localInstance.id = id;
+  recommendations.value = recommendations.value.filter(r => r.id !== id);
+};
 
 onMounted(async () => {
   const { data } = await apolloClient.query({
@@ -382,7 +393,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                           :key="item.id"
                           type="button"
                           class="bg-purple-100 text-purple-800 px-2 py-1 rounded text-sm hover:bg-purple-200"
-                          @click="form.localInstance.id = item.id"
+                          @click="selectRecommendation(item.id)"
                         >
                           {{ item.value }}
                         </button>


### PR DESCRIPTION
## Summary
- provide local property recommendations when mapping Amazon properties
- filter out selected values from duplicate suggestions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c81031898832eb46ff1e13dc56368

## Summary by Sourcery

Add dynamic recommendation flows to Amazon property and select-value mapping forms by querying for duplicates, debouncing user input, filtering out selected items, and presenting suggestions in the form UI.

New Features:
- Show real-time recommendations for local properties when mapping Amazon properties
- Show real-time recommendations for local select values when mapping Amazon property values

Enhancements:
- Debounce input changes and query server-side duplicates for recommendation data
- Filter out already selected local property or value from suggestion lists
- Add UI section with loader and suggestion buttons to display recommendations in mapping forms