### PR TITLE
Prioritize default marketplaces in Amazon property select value mapping

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
@@ -26,6 +26,7 @@ const fetchFirstUnmapped = async () => {
         salesChannel: { id: { exact: props.salesChannelId } },
         mappedLocally: false,
       },
+      order: { marketplace: { isDefault: 'DESC' } },
     },
     fetchPolicy: 'network-only',
   });

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -242,6 +242,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         salesChannel: { id: { exact: salesChannelId } },
         mappedLocally: false,
       },
+      order: { marketplace: { isDefault: 'DESC' } },
     },
     fetchPolicy: 'network-only',
   });


### PR DESCRIPTION
## Summary
- prioritize default marketplaces when fetching unmapped Amazon property select values for mapping

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c8228e130832e85312da8c2df1640