### PR TITLE
feat: add slot for additional form content

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -209,28 +209,30 @@ const selectRecommendation = (id: string) => {
             </Button>
           </Link>
         </template>
-      </GeneralForm>
-      <div v-if="formConfig" class="mt-4 border border-gray-300 bg-gray-50 rounded p-4">
-        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-2">{{ t('integrations.show.propertySelectValues.recommendation.title') }}</Label>
-        <div v-if="loadingRecommendations" class="flex items-center gap-2">
-          <LocalLoader :loading="true" />
-          <span class="text-sm text-gray-500">{{ t('integrations.show.propertySelectValues.recommendation.searching') }}</span>
-        </div>
-        <div v-else>
-          <div v-if="recommendations.length" class="flex flex-wrap gap-2">
-            <button
-              v-for="item in recommendations"
-              :key="item.id"
-              type="button"
-              class="bg-purple-100 text-purple-800 px-2 py-1 rounded text-sm hover:bg-purple-200"
-              @click="selectRecommendation(item.id)"
-            >
-              {{ item.name }}
-            </button>
+        <template #additional-fields>
+          <div class="mt-4 border border-gray-300 bg-gray-50 rounded p-4">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-2">{{ t('integrations.show.propertySelectValues.recommendation.title') }}</Label>
+            <div v-if="loadingRecommendations" class="flex items-center gap-2">
+              <LocalLoader :loading="true" />
+              <span class="text-sm text-gray-500">{{ t('integrations.show.propertySelectValues.recommendation.searching') }}</span>
+            </div>
+            <div v-else>
+              <div v-if="recommendations.length" class="flex flex-wrap gap-2">
+                <button
+                  v-for="item in recommendations"
+                  :key="item.id"
+                  type="button"
+                  class="bg-purple-100 text-purple-800 px-2 py-1 rounded text-sm hover:bg-purple-200"
+                  @click="selectRecommendation(item.id)"
+                >
+                  {{ item.name }}
+                </button>
+              </div>
+              <p v-else class="text-sm text-gray-500">{{ t('integrations.show.propertySelectValues.recommendation.none') }}</p>
+            </div>
           </div>
-          <p v-else class="text-sm text-gray-500">{{ t('integrations.show.propertySelectValues.recommendation.none') }}</p>
-        </div>
-      </div>
+        </template>
+      </GeneralForm>
     </template>
   </GeneralTemplate>
 </template>

--- a/src/shared/components/organisms/general-form/GeneralForm.vue
+++ b/src/shared/components/organisms/general-form/GeneralForm.vue
@@ -51,11 +51,17 @@ watch(() => props.config, (newConfig) => {
           <template #additional-button>
             <slot name="additional-button" />
           </template>
+          <template #additional-fields>
+            <slot name="additional-fields" />
+          </template>
         </FormCreate>
 
         <FormEdit v-else-if="enhancedConfig.type === FormType.EDIT" :config="enhancedConfig" :fields-to-clear="fieldsToClear" @submit="emit('submit')"  @set-data="handleSetData" @form-updated="handleFormUpdate" >
             <template #additional-button>
               <slot name="additional-button" />
+            </template>
+            <template #additional-fields>
+              <slot name="additional-fields" />
             </template>
         </FormEdit>
       </div>

--- a/src/shared/components/organisms/general-form/containers/form-create/FormCreate.vue
+++ b/src/shared/components/organisms/general-form/containers/form-create/FormCreate.vue
@@ -81,6 +81,7 @@ watch(() => props.fieldsToClear, (fields) => {
       <FormLayout :config="config" :form="form" :errors="outsideErrors !== null && outsideErrors !== undefined ? outsideErrors : errors" />
     </div>
   </div>
+  <slot name="additional-fields" />
   <SubmitButtons v-if="!config.hideButtons" :form="form" :config="config" @submit="emit('submit')" @update-errors="handleUpdateErrors" >
     <template #additional-button>
       <slot name="additional-button" />

--- a/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
+++ b/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
@@ -113,6 +113,7 @@ watch(() => props.fieldsToClear, (fields) => {
         </template>
       </ApolloQuery>
   </div>
+  <slot name="additional-fields" />
   <SubmitButtons
     v-if="!config.hideButtons"
     :form="form"


### PR DESCRIPTION
## Summary
- add `additional-fields` slot to general form components for content below fields
- use new slot to display Amazon property recommendations within the form

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c850e0240832e84fd30877b3bb270

## Summary by Sourcery

Add a new additional-fields slot to GeneralForm components to allow injecting custom content below form fields and apply this slot to render Amazon property recommendations directly within the form.

New Features:
- Introduce an additional-fields slot in GeneralForm, FormCreate, and FormEdit to support extra content below the form fields.

Enhancements:
- Embed the Amazon property recommendations panel into the form using the new additional-fields slot.