### PR TITLE
Show product price list items

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/sales-price-lists/SalesPricelistList.vue
+++ b/src/core/products/products/product-show/containers/tabs/sales-price-lists/SalesPricelistList.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
 
-import {Product} from "../../../../configs";
-import {listingQuery, listingQueryKey, searchConfigConstructor, listingConfigConstructor} from "../../../../../../sales/price-lists/configs";
+import { Product } from "../../../../configs";
+import { listingQuery, listingQueryKey, searchConfigConstructor, listingConfigConstructor } from "./configs";
 import { GeneralListing } from "../../../../../../../shared/components/organisms/general-listing";
-import {useI18n} from "vue-i18n";
+import { Link } from "../../../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../../../shared/components/atoms/button";
+import { useI18n } from "vue-i18n";
 import TabContentTemplate from "../TabContentTemplate.vue";
 
 const { t } = useI18n();
 
 const props = defineProps<{ product: Product }>();
-
 
 const searchConfig = searchConfigConstructor(t);
 const listingConfig = listingConfigConstructor(t);
@@ -18,15 +19,24 @@ const listingConfig = listingConfigConstructor(t);
 
 <template>
   <TabContentTemplate>
-
     <template v-slot:content>
       <GeneralListing
-        :searchConfig="searchConfig"
+        :search-config="searchConfig"
         :config="listingConfig"
         :query="listingQuery"
         :query-key="listingQueryKey"
-        :fixed-filter-variables="{'salespricelistitem': {'product': {'id': {'exact': product.id}}}}"
-      />
+        :fixed-filter-variables="{ product: { id: { exact: product.id } } }"
+      >
+        <template #additionalButtons="{ item }">
+          <Link
+            :path="{ name: 'sales.priceLists.items.edit', params: { priceListId: item.node.salespricelist.id, id: item.node.id } }"
+          >
+            <Button class="text-indigo-600 hover:text-indigo-900">
+              {{ t('shared.button.edit') }}
+            </Button>
+          </Link>
+        </template>
+      </GeneralListing>
     </template>
   </TabContentTemplate>
 </template>

--- a/src/core/products/products/product-show/containers/tabs/sales-price-lists/configs.ts
+++ b/src/core/products/products/product-show/containers/tabs/sales-price-lists/configs.ts
@@ -1,0 +1,52 @@
+import { SearchConfig } from "../../../../../../../shared/components/organisms/general-search/searchConfig";
+import { ListingConfig } from "../../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { FieldType } from "../../../../../../../shared/utils/constants";
+import { salesPriceListItemsQuery } from "../../../../../../../shared/api/queries/salesPrices.js";
+import { deleteSalesPriceListItemMutation } from "../../../../../../../shared/api/mutations/salesPrices.js";
+
+export const searchConfigConstructor = (t: Function): SearchConfig => ({
+  search: false,
+  orderKey: 'sort',
+  filters: [],
+  orders: []
+});
+
+export const listingConfigConstructor = (t: Function): ListingConfig => ({
+  headers: [
+    t('sales.priceLists.show.title'),
+    t('shared.labels.price'),
+    t('shared.labels.discountPrice'),
+    t('sales.prices.labels.discountPercentage')
+  ],
+  fields: [
+    {
+      name: 'salespricelist',
+      type: FieldType.NestedText,
+      keys: ['name']
+    },
+    {
+      name: 'price',
+      type: FieldType.Text
+    },
+    {
+      name: 'discount',
+      type: FieldType.Text
+    },
+    {
+      name: 'salespricelist',
+      type: FieldType.NestedText,
+      keys: ['discountPcnt']
+    }
+  ],
+  identifierKey: 'id',
+  addActions: true,
+  addEdit: false,
+  addShow: false,
+  addDelete: true,
+  deleteMutation: deleteSalesPriceListItemMutation,
+  addPagination: true
+});
+
+export const listingQuery = salesPriceListItemsQuery;
+export const listingQueryKey = 'salesPriceListItems';
+


### PR DESCRIPTION
## Summary
- Display actual price list items a product belongs to
- Allow editing and deleting price list item entries from the product page

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e15608280832e9ca2b313c7dd2d0b

## Summary by Sourcery

Show associated sales price list items on the product details page and allow users to edit or delete entries, while refactoring search and listing configurations into a dedicated local module

New Features:
- Display sales price list items under the product’s Sales Pricelist tab
- Add an edit button for each price list item linking to its edit page
- Enable deletion of price list items directly from the listing

Enhancements:
- Extract search and listing configuration into a new local configs.ts file
- Use Link and Button components to render action controls in the listing