### PR TITLE
feat: add amazon marketplace tabs with placeholders

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -1,14 +1,22 @@
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import TabContentTemplate from '../TabContentTemplate.vue';
 import { Product } from '../../../../configs';
-import { Accordion } from '../../../../../../../shared/components/atoms/accordion';
 import { Button } from '../../../../../../../shared/components/atoms/button';
 import { LocalLoader } from '../../../../../../../shared/components/atoms/local-loader';
 import { AssignProgressBar } from '../../../../../../../shared/components/molecules/assign-progress-bar';
+import AmazonMarketplaceTabs from './components/AmazonMarketplaceTabs.vue';
+import AmazonAsinSection from './components/AmazonAsinSection.vue';
+import AmazonGtinExemptionSection from './components/AmazonGtinExemptionSection.vue';
+import AmazonBrowseNodeSection from './components/AmazonBrowseNodeSection.vue';
+import AmazonUnmappedValuesSection from './components/AmazonUnmappedValuesSection.vue';
+import AmazonVariationThemeSection from './components/AmazonVariationThemeSection.vue';
 import { amazonChannelViewsQuery } from '../../../../../../../shared/api/queries/salesChannels.js';
-import { resyncAmazonProductMutation, refreshAmazonProductIssuesMutation } from '../../../../../../../shared/api/mutations/amazonProducts.js';
+import {
+  resyncAmazonProductMutation,
+  refreshAmazonProductIssuesMutation,
+} from '../../../../../../../shared/api/mutations/amazonProducts.js';
 import { Toast } from '../../../../../../../shared/modules/toast';
 import { displayApolloError } from '../../../../../../../shared/utils';
 import apolloClient from '../../../../../../../../apollo-client';
@@ -37,6 +45,7 @@ interface AmazonProduct {
 
 const views = ref<any[]>([]);
 const loading = ref(false);
+const selectedViewId = ref<string | null>(null);
 
 const fetchViews = async () => {
   loading.value = true;
@@ -50,53 +59,50 @@ const fetchViews = async () => {
 
 onMounted(fetchViews);
 
-interface AccordionItem {
-  id: string;
-  name: string;
-  label: string;
-  validationIssues: AmazonProductIssue[];
-  otherIssues: AmazonProductIssue[];
-  remoteProductId: string | null;
-  lastSyncAt?: string | null;
-  syncingCurrentPercentage?: number | null;
-}
-
-const accordionItems = computed<AccordionItem[]>(() => {
-  return views.value
-    .filter((view: any) =>
-      props.amazonProducts.some((product: AmazonProduct) =>
-        product.createdMarketplaces.includes(view.remoteId),
-      ),
-    )
-    .map((view: any) => {
-      const allIssues: AmazonProductIssue[] = [];
-      let remoteProductId: string | null = null;
-      let lastSyncAt: string | null = null;
-      let syncingCurrentPercentage: number | null = null;
-      props.amazonProducts.forEach((product: AmazonProduct) => {
-        if (product.createdMarketplaces.includes(view.remoteId)) {
-          remoteProductId = product.id;
-          lastSyncAt = product.lastSyncAt ?? null;
-          syncingCurrentPercentage = product.syncingCurrentPercentage ?? null;
-        }
-        const issuesForView =
-          product.issues?.filter((issue) => issue.view?.remoteId === view.remoteId) || [];
-        allIssues.push(...issuesForView);
-      });
-
-      return {
-        id: view.id,
-        name: view.remoteId,
-        label: view.name || view.remoteId,
-        validationIssues: allIssues.filter((i) => i.isValidationIssue),
-        otherIssues: allIssues.filter((i) => !i.isValidationIssue),
-        remoteProductId,
-        lastSyncAt,
-        syncingCurrentPercentage,
-      };
-    });
+watch(views, (newViews) => {
+  if (!selectedViewId.value && newViews.length) {
+    selectedViewId.value = newViews[0].id;
+  }
 });
 
+const selectedView = computed(() =>
+  views.value.find((v: any) => v.id === selectedViewId.value),
+);
+
+const selectedProduct = computed(() => {
+  if (!selectedView.value) return null;
+  return (
+    props.amazonProducts.find((product: AmazonProduct) =>
+      product.createdMarketplaces.includes(selectedView.value.remoteId),
+    ) || null
+  );
+});
+
+const remoteProductId = computed(() => selectedProduct.value?.id || null);
+const lastSyncAt = computed(() => selectedProduct.value?.lastSyncAt || null);
+const syncingCurrentPercentage = computed(
+  () => selectedProduct.value?.syncingCurrentPercentage || null,
+);
+
+const validationIssues = computed(() => {
+  if (!selectedProduct.value || !selectedView.value) return [] as AmazonProductIssue[];
+  return (
+    selectedProduct.value.issues?.filter(
+      (issue) =>
+        issue.view?.remoteId === selectedView.value.remoteId && issue.isValidationIssue,
+    ) || []
+  );
+});
+
+const otherIssues = computed(() => {
+  if (!selectedProduct.value || !selectedView.value) return [] as AmazonProductIssue[];
+  return (
+    selectedProduct.value.issues?.filter(
+      (issue) =>
+        issue.view?.remoteId === selectedView.value.remoteId && !issue.isValidationIssue,
+    ) || []
+  );
+});
 
 const onResyncSuccess = () => {
   Toast.success(t('integrations.salesChannel.toast.resyncSuccess'));
@@ -132,66 +138,74 @@ const formatDate = (dateString?: string | null) => {
     hour12: false,
   }).format(date);
 };
-
-
 </script>
 
 <template>
   <TabContentTemplate>
     <template #content>
       <LocalLoader :loading="loading" />
-      <div v-if="!loading && accordionItems.length">
-        <Accordion :items="accordionItems">
-          <template v-for="item in accordionItems" #[item.name+'-actions'] :key="item.name+'-actions'">
-            <div class="flex gap-2">
-              <ApolloMutation
-                :mutation="resyncAmazonProductMutation"
-                :variables="{ remoteProduct: { id: item.remoteProductId }, view: { id: item.id }, forceValidationOnly: false }"
-                @done="onResyncSuccess"
-                @error="onError"
-              >
-                <template #default="{ mutate, loading }">
-                  <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
-                    {{ t('shared.button.resync') }}
-                  </Button>
-                </template>
-              </ApolloMutation>
-              <ApolloMutation
-                :mutation="resyncAmazonProductMutation"
-                :variables="{ remoteProduct: { id: item.remoteProductId }, view: { id: item.id }, forceValidationOnly: true }"
-                @done="onValidateSuccess"
-                @error="onError"
-              >
-                <template #default="{ mutate, loading }">
-                  <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
-                    {{ t('shared.button.validate') }}
-                  </Button>
-                </template>
-              </ApolloMutation>
-              <ApolloMutation
-                :mutation="refreshAmazonProductIssuesMutation"
-                :variables="{ remoteProduct: { id: item.remoteProductId }, view: { id: item.id } }"
-                @done="onFetchIssuesSuccess"
-                @error="onError"
-              >
-                <template #default="{ mutate, loading }">
-                  <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
-                    {{ t('shared.button.fetchIssues') }}
-                  </Button>
-                </template>
-              </ApolloMutation>
-            </div>
-          </template>
-          <template v-for="item in accordionItems" #[item.name] :key="item.name">
-            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
-              <div class="text-sm text-gray-500 mb-2 sm:mb-0">
-                {{ t('shared.labels.lastSyncAt') }}: {{ formatDate(item.lastSyncAt) }}
+      <div v-if="!loading && views.length" class="flex">
+        <AmazonMarketplaceTabs
+          class="w-64"
+          v-model="selectedViewId"
+          :views="views"
+          :amazon-products="amazonProducts"
+        />
+        <div class="flex-1 pl-4">
+          <div v-if="selectedView">
+            <div v-if="selectedProduct" class="mb-4">
+              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
+                <div class="text-sm text-gray-500 mb-2 sm:mb-0">
+                  {{ t('shared.labels.lastSyncAt') }}: {{ formatDate(lastSyncAt) }}
+                </div>
+                <div class="w-full sm:w-48">
+                  <AssignProgressBar :progress="syncingCurrentPercentage ?? 0" />
+                </div>
               </div>
-              <div class="w-full sm:w-48">
-                <AssignProgressBar :progress="item.syncingCurrentPercentage ?? 0" />
+              <div class="flex gap-2">
+                <ApolloMutation
+                  :mutation="resyncAmazonProductMutation"
+                  :variables="{ remoteProduct: { id: remoteProductId }, view: { id: selectedView.id }, forceValidationOnly: false }"
+                  @done="onResyncSuccess"
+                  @error="onError"
+                >
+                  <template #default="{ mutate, loading }">
+                    <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
+                      {{ t('shared.button.resync') }}
+                    </Button>
+                  </template>
+                </ApolloMutation>
+                <ApolloMutation
+                  :mutation="resyncAmazonProductMutation"
+                  :variables="{ remoteProduct: { id: remoteProductId }, view: { id: selectedView.id }, forceValidationOnly: true }"
+                  @done="onValidateSuccess"
+                  @error="onError"
+                >
+                  <template #default="{ mutate, loading }">
+                    <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
+                      {{ t('shared.button.validate') }}
+                    </Button>
+                  </template>
+                </ApolloMutation>
+                <ApolloMutation
+                  v-if="remoteProductId"
+                  :mutation="refreshAmazonProductIssuesMutation"
+                  :variables="{ remoteProduct: { id: remoteProductId }, view: { id: selectedView.id } }"
+                  @done="onFetchIssuesSuccess"
+                  @error="onError"
+                >
+                  <template #default="{ mutate, loading }">
+                    <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
+                      {{ t('shared.button.fetchIssues') }}
+                    </Button>
+                  </template>
+                </ApolloMutation>
               </div>
             </div>
-            <div v-if="item.validationIssues.length" class="mb-4">
+
+            <div class="border-t my-4"></div>
+
+            <div v-if="validationIssues.length" class="mb-4">
               <h4 class="font-semibold mb-2">{{ t('products.products.amazon.validationIssues') }}</h4>
               <p class="text-xs text-gray-500 mb-2">{{ t('products.products.amazon.validationIssuesDescription') }}</p>
               <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
@@ -203,15 +217,21 @@ const formatDate = (dateString?: string | null) => {
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-200 bg-white">
-                  <tr v-for="issue in item.validationIssues" :key="issue.id">
+                  <tr v-for="issue in validationIssues" :key="issue.id">
                     <td class="break-words max-w-xs">{{ issue.message }}</td>
-                    <td class="capitalize" :class="{ 'text-red-600': issue.severity === 'ERROR', 'text-yellow-600': issue.severity === 'WARNING' }">{{ issue.severity }}</td>
+                    <td
+                      class="capitalize"
+                      :class="{ 'text-red-600': issue.severity === 'ERROR', 'text-yellow-600': issue.severity === 'WARNING' }"
+                    >
+                      {{ issue.severity }}
+                    </td>
                     <td>{{ formatDate(issue.createdAt) }}</td>
                   </tr>
                 </tbody>
               </table>
             </div>
-            <div v-if="item.otherIssues.length" class="mb-4">
+
+            <div v-if="otherIssues.length" class="mb-4">
               <h4 class="font-semibold mb-2">{{ t('products.products.amazon.otherIssues') }}</h4>
               <p class="text-xs text-gray-500 mb-2">{{ t('products.products.amazon.otherIssuesDescription') }}</p>
               <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
@@ -223,19 +243,38 @@ const formatDate = (dateString?: string | null) => {
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-200 bg-white">
-                  <tr v-for="issue in item.otherIssues" :key="issue.id">
+                  <tr v-for="issue in otherIssues" :key="issue.id">
                     <td class="break-words max-w-xs">{{ issue.message }}</td>
-                    <td class="capitalize" :class="{ 'text-red-600': issue.severity === 'ERROR', 'text-yellow-600': issue.severity === 'WARNING' }">{{ issue.severity }}</td>
+                    <td
+                      class="capitalize"
+                      :class="{ 'text-red-600': issue.severity === 'ERROR', 'text-yellow-600': issue.severity === 'WARNING' }"
+                    >
+                      {{ issue.severity }}
+                    </td>
                     <td>{{ formatDate(issue.createdAt) }}</td>
                   </tr>
                 </tbody>
               </table>
             </div>
-            <div v-if="!item.validationIssues.length && !item.otherIssues.length" class="text-sm text-gray-500">{{ t('shared.labels.noIssues') }}</div>
-          </template>
-        </Accordion>
+
+            <div v-if="!validationIssues.length && !otherIssues.length" class="text-sm text-gray-500">
+              {{ t('shared.labels.noIssues') }}
+            </div>
+
+            <div class="border-t my-4"></div>
+
+            <AmazonAsinSection class="mb-4" />
+            <AmazonGtinExemptionSection class="mb-4" />
+            <AmazonBrowseNodeSection class="mb-4" />
+            <AmazonUnmappedValuesSection class="mb-4" />
+            <AmazonVariationThemeSection class="mb-4" />
+          </div>
+        </div>
       </div>
-      <div v-else-if="!loading" class="text-sm text-gray-500">{{ t('shared.labels.noIssues') }}</div>
+      <div v-else-if="!loading" class="text-sm text-gray-500">
+        {{ t('shared.labels.noIssues') }}
+      </div>
     </template>
   </TabContentTemplate>
 </template>
+

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonAsinSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonAsinSection.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="p-2 border rounded text-sm text-gray-500">ASIN section placeholder</div>
+</template>
+

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="p-2 border rounded text-sm text-gray-500">Browse Node section placeholder</div>
+</template>
+

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonGtinExemptionSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonGtinExemptionSection.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="p-2 border rounded text-sm text-gray-500">GTIN Exemption section placeholder</div>
+</template>
+

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonMarketplaceTabs.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonMarketplaceTabs.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Icon } from '../../../../../../../../shared/components/atoms/icon';
+import { Link } from '../../../../../../../../shared/components/atoms/link';
+import { IntegrationTypes } from '../../../../../../../integrations/integrations/integrations';
+
+const props = defineProps<{ views: any[]; amazonProducts: any[]; modelValue: string | null }>();
+const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>();
+
+const select = (val: string) => emit('update:modelValue', val);
+
+const hasMarketplace = (view: any) =>
+  props.amazonProducts.some((p: any) => p.createdMarketplaces.includes(view.remoteId));
+
+const groupedViews = computed(() => {
+  const groups: Record<string, any[]> = {};
+  props.views.forEach((view: any) => {
+    const scId = view.salesChannel?.id || 'unknown';
+    if (!groups[scId]) groups[scId] = [];
+    groups[scId].push(view);
+  });
+  return Object.entries(groups).map(([salesChannelId, views]) => ({ salesChannelId, views }));
+});
+</script>
+
+<template>
+  <div class="border-r border-gray-200">
+    <div class="max-h-[500px] overflow-y-auto">
+      <div v-for="group in groupedViews" :key="group.salesChannelId" class="mb-2">
+        <div
+          v-for="view in group.views"
+          :key="view.id"
+          class="cursor-pointer flex items-center gap-2 p-2 border-b last:border-b-0"
+          :class="{ 'bg-primary text-white': modelValue === view.id }"
+          @click="select(view.id)"
+        >
+          <Icon
+            :name="hasMarketplace(view) ? 'check' : 'xmark'"
+            class="w-4 h-4"
+            :class="hasMarketplace(view) ? 'text-green-500' : 'text-red-500'"
+          />
+          <div class="flex flex-col">
+            <span>{{ view.name || view.remoteId }}</span>
+            <Link
+              class="text-xs"
+              :path="{
+                name: 'integrations.integrations.show',
+                params: { type: IntegrationTypes.Amazon, id: view.salesChannel.id },
+              }"
+            >
+              ({{ view.salesChannel.id }})
+            </Link>
+          </div>
+        </div>
+        <div class="h-px bg-gray-200 mt-2"></div>
+      </div>
+    </div>
+  </div>
+</template>
+

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="p-2 border rounded text-sm text-gray-500">Unmapped Values section placeholder</div>
+</template>
+

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="p-2 border rounded text-sm text-gray-500">Variations Theme section placeholder</div>
+</template>
+


### PR DESCRIPTION
## Summary
- show all Amazon marketplaces as vertical tabs with status icons and links
- include placeholders for ASIN, GTIN exemption, browse node, unmapped values, and variation theme sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(terminated: no output)*

------
https://chatgpt.com/codex/tasks/task_e_689f955bc610832eb0ac6398b0bebc81

## Summary by Sourcery

Add vertical tab navigation for Amazon marketplaces with placeholder sections and refactor view logic

New Features:
- Introduce AmazonMarketplaceTabs component to display marketplaces as vertical tabs with status icons and links
- Add placeholder sections for ASIN, GTIN exemption, browse node, unmapped values, and variation theme

Enhancements:
- Refactor AmazonView.vue to replace accordion layout with tabbed interface and simplify computed logic for selected view and issue listings