### PR TITLE
feat: add Amazon ASIN management section

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -286,7 +286,11 @@ const formatDate = (dateString?: string | null) => {
 
               <div class="border-t my-4"></div>
 
-              <AmazonAsinSection class="mb-4" />
+              <AmazonAsinSection
+                class="mb-4"
+                :product="product"
+                :view="selectedView"
+              />
               <AmazonGtinExemptionSection class="mb-4" />
               <AmazonBrowseNodeSection class="mb-4" />
               <AmazonUnmappedValuesSection class="mb-4" />

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonAsinSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonAsinSection.vue
@@ -1,6 +1,122 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useApolloClient } from '@vue/apollo-composable';
+import { amazonMerchantAsinsQuery } from '../../../../../../../../shared/api/queries/amazonMerchantAsins.js';
+import {
+  createAmazonMerchantAsinMutation,
+  updateAmazonMerchantAsinMutation,
+  deleteAmazonMerchantAsinMutation,
+} from '../../../../../../../../shared/api/mutations/amazonMerchantAsins.js';
+import { processGraphQLErrors } from '../../../../../../../../shared/utils';
+import { Toast } from '../../../../../../../../shared/modules/toast';
+import { PrimaryButton } from '../../../../../../../../shared/components/atoms/button-primary';
+import { FieldValue } from '../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-value';
+import { ValueFormField } from '../../../../../../../../shared/components/organisms/general-form/formConfig';
+import { FieldType } from '../../../../../../../../shared/utils/constants';
+import { Label } from '../../../../../../../../shared/components/atoms/label';
+
+const props = defineProps<{ product: any; view: any }>();
+const { t } = useI18n();
+const apolloClient = useApolloClient().client;
+
+const asin = ref('');
+const asinId = ref<string | null>(null);
+const lastSavedAsin = ref('');
+const errors = ref<Record<string, string>>({});
+
+const field = (): ValueFormField => ({
+  type: FieldType.Text,
+  name: 'asin',
+  label: t('products.products.amazon.asin'),
+  placeholder: t('products.products.amazon.asinPlaceholder'),
+});
+
+const fetchAsin = async () => {
+  if (!props.product?.id || !props.view?.id) return;
+  const { data } = await apolloClient.query({
+    query: amazonMerchantAsinsQuery,
+    variables: {
+      filter: {
+        product: { id: { exact: props.product.id } },
+        view: { id: { exact: props.view.id } },
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+  const node = data?.amazonMerchantAsins?.edges?.[0]?.node;
+  asinId.value = node?.id || null;
+  asin.value = node?.asin || '';
+  lastSavedAsin.value = asin.value;
+};
+
+watch(
+  () => [props.product?.id, props.view?.id],
+  () => {
+    asin.value = '';
+    asinId.value = null;
+    lastSavedAsin.value = '';
+    fetchAsin();
+  },
+  { immediate: true },
+);
+
+const handleSave = async () => {
+  errors.value = {};
+  const value = asin.value.trim();
+  try {
+    if (!value) {
+      if (asinId.value) {
+        await apolloClient.mutate({
+          mutation: deleteAmazonMerchantAsinMutation,
+          variables: { id: asinId.value },
+        });
+        Toast.success(t('products.products.amazon.asinDeleted'));
+        asinId.value = null;
+        lastSavedAsin.value = '';
+      }
+      return;
+    }
+
+    if (asinId.value) {
+      await apolloClient.mutate({
+        mutation: updateAmazonMerchantAsinMutation,
+        variables: { data: { id: asinId.value, asin: value } },
+      });
+    } else {
+      await apolloClient.mutate({
+        mutation: createAmazonMerchantAsinMutation,
+        variables: {
+          data: {
+            product: { id: props.product.id },
+            view: { id: props.view.id },
+            asin: value,
+          },
+        },
+      });
+    }
+    Toast.success(t('products.products.amazon.asinSaved'));
+    lastSavedAsin.value = value;
+    fetchAsin();
+  } catch (err) {
+    errors.value = processGraphQLErrors(err, t);
+  }
+};
+
+const isSaveDisabled = computed(() => asin.value === lastSavedAsin.value);
+</script>
 
 <template>
-  <div class="p-2 border rounded text-sm text-gray-500">ASIN section placeholder</div>
+  <div>
+    <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-2">
+      {{ t('products.products.amazon.asin') }}
+    </Label>
+    <FieldValue class="w-96" v-model="asin" :field="field()" />
+    <div v-if="errors.asin" class="text-danger text-small mt-1">
+      {{ errors.asin }}
+    </div>
+    <PrimaryButton class="mt-2" :disabled="isSaveDisabled" @click="handleSave">
+      {{ t('shared.button.save') }}
+    </PrimaryButton>
+  </div>
 </template>
-

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -965,7 +965,11 @@
         "validationIssues": "Validation Issues",
         "validationIssuesDescription": "Issues detected locally before sending the product to Amazon.",
         "otherIssues": "Remote Product Issues",
-        "otherIssuesDescription": "Issues already present in Amazon for this product."
+        "otherIssuesDescription": "Issues already present in Amazon for this product.",
+        "asin": "ASIN",
+        "asinPlaceholder": "Enter ASIN",
+        "asinSaved": "ASIN saved",
+        "asinDeleted": "ASIN deleted"
       },
       "inspector": {
         "errors": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -655,6 +655,16 @@
         "inventoryMovements": "",
         "amazon": "Amazon"
       },
+      "amazon": {
+        "validationIssues": "Validatieproblemen",
+        "validationIssuesDescription": "Problemen gedetecteerd voordat het product naar Amazon wordt gestuurd.",
+        "otherIssues": "Problemen met Amazon product",
+        "otherIssuesDescription": "Problemen die al aanwezig zijn in Amazon voor dit product.",
+        "asin": "ASIN",
+        "asinPlaceholder": "Voer ASIN in",
+        "asinSaved": "ASIN opgeslagen",
+        "asinDeleted": "ASIN verwijderd"
+      },
       "inspector": {
         "labels": {
           "missingInfo": "Ontbrekende Informatie",

--- a/src/shared/api/mutations/amazonMerchantAsins.js
+++ b/src/shared/api/mutations/amazonMerchantAsins.js
@@ -1,0 +1,27 @@
+import { gql } from 'graphql-tag';
+
+export const createAmazonMerchantAsinMutation = gql`
+  mutation createAmazonMerchantAsin($data: AmazonMerchantAsinInput!) {
+    createAmazonMerchantAsin(data: $data) {
+      id
+      asin
+    }
+  }
+`;
+
+export const updateAmazonMerchantAsinMutation = gql`
+  mutation updateAmazonMerchantAsin($data: AmazonMerchantAsinPartialInput!) {
+    updateAmazonMerchantAsin(data: $data) {
+      id
+      asin
+    }
+  }
+`;
+
+export const deleteAmazonMerchantAsinMutation = gql`
+  mutation deleteAmazonMerchantAsin($id: GlobalID!) {
+    deleteAmazonMerchantAsin(data: { id: $id }) {
+      id
+    }
+  }
+`;

--- a/src/shared/api/queries/amazonMerchantAsins.js
+++ b/src/shared/api/queries/amazonMerchantAsins.js
@@ -1,0 +1,38 @@
+import { gql } from 'graphql-tag';
+
+export const amazonMerchantAsinsQuery = gql`
+  query AmazonMerchantAsins(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: AmazonMerchantAsinOrder
+    $filter: AmazonMerchantAsinFilter
+  ) {
+    amazonMerchantAsins(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filter
+    ) {
+      edges {
+        node {
+          id
+          asin
+          product { id }
+          view { id }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- implement Amazon ASIN section with create, update, and delete
- add GraphQL queries and mutations for merchant ASINs
- localize ASIN labels and messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3b70886d4832ea41630968455d9f5