### PR TITLE
feat: add Amazon variation theme management

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -290,7 +290,12 @@ const formatDate = (dateString?: string | null) => {
               <AmazonGtinExemptionSection class="mb-4" />
               <AmazonBrowseNodeSection class="mb-4" />
               <AmazonUnmappedValuesSection class="mb-4" />
-              <AmazonVariationThemeSection v-if="isConfigurable" class="mb-4" />
+              <AmazonVariationThemeSection
+                v-if="isConfigurable && selectedView"
+                class="mb-4"
+                :product="product"
+                :view="selectedView"
+              />
             </div>
           </div>
         </div>

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
@@ -1,6 +1,153 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Selector } from '../../../../../../../../shared/components/atoms/selector';
+import { Button } from '../../../../../../../../shared/components/atoms/button';
+import { LocalLoader } from '../../../../../../../../shared/components/atoms/local-loader';
+import apolloClient from '../../../../../../../../../apollo-client';
+import { Toast } from '../../../../../../../../shared/modules/toast';
+import { displayApolloError } from '../../../../../../../../shared/utils';
+import { amazonProductTypesQuery } from '../../../../../../../../shared/api/queries/salesChannels.js';
+import { amazonVariationThemesQuery } from '../../../../../../../../shared/api/queries/amazonVariationThemes.js';
+import {
+  createAmazonVariationThemeMutation,
+  updateAmazonVariationThemeMutation,
+  deleteAmazonVariationThemeMutation,
+} from '../../../../../../../../shared/api/mutations/amazonVariationThemes.js';
+
+const props = defineProps<{ product: any; view: any | null }>();
+const { t } = useI18n();
+
+const loading = ref(false);
+const saving = ref(false);
+const themeOptions = ref<{ id: string; name: string }[]>([]);
+const selectedTheme = ref<string | null>(null);
+const originalTheme = ref<string | null>(null);
+const recordId = ref<string | null>(null);
+
+const productTypeRuleId = computed(() => {
+  const typeProp = props.product?.productpropertySet?.find((p: any) => p.property?.isProductType);
+  return typeProp?.valueSelect?.productpropertiesruleSet?.[0]?.id || null;
+});
+
+const fetchOptions = async () => {
+  if (!productTypeRuleId.value) {
+    themeOptions.value = [];
+    return;
+  }
+  const { data } = await apolloClient.query({
+    query: amazonProductTypesQuery,
+    variables: { filter: { localInstance: { id: { exact: productTypeRuleId.value } } } },
+    fetchPolicy: 'network-only',
+  });
+  const node = data?.amazonProductTypes?.edges?.[0]?.node;
+  const themes: string[] = node?.variationThemes || [];
+  themeOptions.value = themes.map((t: string) => ({ id: t, name: t }));
+};
+
+const fetchCurrent = async () => {
+  if (!props.view?.id) {
+    selectedTheme.value = null;
+    originalTheme.value = null;
+    recordId.value = null;
+    return;
+  }
+  const { data } = await apolloClient.query({
+    query: amazonVariationThemesQuery,
+    variables: {
+      filter: {
+        product: { id: { exact: props.product.id } },
+        view: { id: { exact: props.view.id } },
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+  const node = data?.amazonVariationThemes?.edges?.[0]?.node;
+  recordId.value = node?.id || null;
+  selectedTheme.value = node?.theme || null;
+  originalTheme.value = selectedTheme.value;
+};
+
+watch(
+  () => [props.view?.id, productTypeRuleId.value],
+  async () => {
+    loading.value = true;
+    try {
+      await fetchOptions();
+      await fetchCurrent();
+    } finally {
+      loading.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+const hasChanges = computed(() => selectedTheme.value !== originalTheme.value);
+
+const save = async () => {
+  if (!hasChanges.value) return;
+  saving.value = true;
+  try {
+    if (recordId.value) {
+      if (selectedTheme.value) {
+        await apolloClient.mutate({
+          mutation: updateAmazonVariationThemeMutation,
+          variables: { data: { id: recordId.value, theme: selectedTheme.value } },
+        });
+        originalTheme.value = selectedTheme.value;
+        Toast.success(t('shared.alerts.saveSuccess'));
+      } else {
+        await apolloClient.mutate({
+          mutation: deleteAmazonVariationThemeMutation,
+          variables: { id: recordId.value },
+        });
+        recordId.value = null;
+        originalTheme.value = null;
+        Toast.success(t('shared.alerts.deleteSuccess'));
+      }
+    } else if (selectedTheme.value && props.view) {
+      const res = await apolloClient.mutate({
+        mutation: createAmazonVariationThemeMutation,
+        variables: {
+          data: {
+            product: { id: props.product.id },
+            view: { id: props.view.id },
+            theme: selectedTheme.value,
+          },
+        },
+      });
+      recordId.value = res.data?.createAmazonVariationTheme?.id || null;
+      originalTheme.value = selectedTheme.value;
+      Toast.success(t('shared.alerts.saveSuccess'));
+    }
+  } catch (error) {
+    displayApolloError(error);
+  } finally {
+    saving.value = false;
+  }
+};
+</script>
 
 <template>
-  <div class="p-2 border rounded text-sm text-gray-500">Variations Theme section placeholder</div>
+  <div class="p-4 border rounded">
+    <LocalLoader :loading="loading" />
+    <div v-if="!loading" class="flex items-end gap-2">
+      <Selector
+        class="w-72"
+        :options="themeOptions"
+        v-model="selectedTheme"
+        label-by="name"
+        value-by="id"
+        :filterable="false"
+        :placeholder="t('shared.placeholders.select')"
+      />
+      <Button
+        class="btn btn-sm btn-outline-primary"
+        :disabled="!hasChanges || saving"
+        @click="save"
+      >
+        {{ t('shared.button.save') }}
+      </Button>
+    </div>
+  </div>
 </template>
-

--- a/src/shared/api/mutations/amazonVariationThemes.js
+++ b/src/shared/api/mutations/amazonVariationThemes.js
@@ -1,0 +1,31 @@
+import { gql } from 'graphql-tag';
+
+export const createAmazonVariationThemeMutation = gql`
+  mutation createAmazonVariationTheme($data: AmazonVariationThemeInput!) {
+    createAmazonVariationTheme(data: $data) {
+      id
+      theme
+      product { id }
+      view { id }
+    }
+  }
+`;
+
+export const updateAmazonVariationThemeMutation = gql`
+  mutation updateAmazonVariationTheme($data: AmazonVariationThemePartialInput!) {
+    updateAmazonVariationTheme(data: $data) {
+      id
+      theme
+      product { id }
+      view { id }
+    }
+  }
+`;
+
+export const deleteAmazonVariationThemeMutation = gql`
+  mutation deleteAmazonVariationTheme($id: GlobalID!) {
+    deleteAmazonVariationTheme(data: { id: $id }) {
+      id
+    }
+  }
+`;

--- a/src/shared/api/queries/amazonVariationThemes.js
+++ b/src/shared/api/queries/amazonVariationThemes.js
@@ -1,0 +1,20 @@
+import { gql } from 'graphql-tag';
+
+export const amazonVariationThemesQuery = gql`
+  query AmazonVariationThemes($filter: AmazonVariationThemeFilter) {
+    amazonVariationThemes(filters: $filter) {
+      edges {
+        node {
+          id
+          theme
+          product {
+            id
+          }
+          view {
+            id
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -859,6 +859,7 @@ export const amazonProductTypesQuery = gql`
               value
             }
           }
+          variationThemes
         }
         cursor
       }
@@ -902,9 +903,11 @@ export const getAmazonProductTypeQuery = gql`
         }
         remoteType
       }
+      variationThemes
     }
   }
-`;export const amazonImportProcessesQuery = gql`
+`;
+export const amazonImportProcessesQuery = gql`
   query AmazonImportProcesses(
     $first: Int,
     $last: Int,


### PR DESCRIPTION
## Summary
- implement Amazon variation theme section with save and delete capabilities
- expose Amazon variation theme GraphQL queries and mutations
- include variationThemes field on Amazon product type queries and wire component into Amazon tab

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a3b70ebabc832ebba6d66033182697

## Summary by Sourcery

Add management of Amazon variation themes in product detail view with UI and GraphQL integration

New Features:
- Add AmazonVariationThemeSection component for selecting, saving, and deleting variation themes
- Expose variationThemes field in Amazon product types GraphQL query
- Introduce GraphQL queries and mutations for create, update, and delete operations on Amazon variation themes

Enhancements:
- Integrate the variation theme section into the Amazon tab view based on product configuration