### PR TITLE
feat: add Amazon unmapped values section

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -289,7 +289,11 @@ const formatDate = (dateString?: string | null) => {
               <AmazonAsinSection class="mb-4" />
               <AmazonGtinExemptionSection class="mb-4" />
               <AmazonBrowseNodeSection class="mb-4" />
-              <AmazonUnmappedValuesSection class="mb-4" />
+              <AmazonUnmappedValuesSection
+                v-if="remoteProductId"
+                class="mb-4"
+                :remote-product-id="remoteProductId"
+              />
               <AmazonVariationThemeSection v-if="isConfigurable" class="mb-4" />
             </div>
           </div>

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
@@ -1,6 +1,78 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import apolloClient from '../../../../../../../../../apollo-client';
+import { amazonProductPropertiesQuery } from '../../../../../../../../../shared/api/queries/amazonProductProperties.js';
+
+interface SelectValue {
+  id: string;
+  remoteValue?: string | null;
+  remoteName?: string | null;
+  localInstance?: { id: string } | null;
+}
+
+const props = defineProps<{ remoteProductId: string | null }>();
+
+const { t } = useI18n();
+
+const properties = ref<any[]>([]);
+const loading = ref(false);
+
+const fetchProperties = async () => {
+  if (!props.remoteProductId) {
+    properties.value = [];
+    return;
+  }
+  loading.value = true;
+  const { data } = await apolloClient.query({
+    query: amazonProductPropertiesQuery,
+    variables: { remoteProductId: props.remoteProductId },
+    fetchPolicy: 'network-only',
+  });
+  properties.value = data?.amazonProductProperties?.edges?.map((e: any) => e.node) || [];
+  loading.value = false;
+};
+
+watch(
+  () => props.remoteProductId,
+  () => {
+    fetchProperties();
+  },
+  { immediate: true },
+);
+
+const unmappedValues = computed(() => {
+  const result: SelectValue[] = [];
+  for (const prop of properties.value) {
+    if (prop.remoteSelectValue && !prop.remoteSelectValue.localInstance) {
+      result.push(prop.remoteSelectValue);
+    }
+    if (Array.isArray(prop.remoteSelectValues)) {
+      for (const val of prop.remoteSelectValues as SelectValue[]) {
+        if (!val.localInstance) {
+          result.push(val);
+        }
+      }
+    }
+  }
+  return result;
+});
+</script>
 
 <template>
-  <div class="p-2 border rounded text-sm text-gray-500">Unmapped Values section placeholder</div>
+  <div v-if="unmappedValues.length" class="p-2 border rounded text-sm">
+    <div class="mb-2 font-medium">{{ t('dashboard.cards.amazon.unmappedSelectValues.title') }}</div>
+    <p class="mb-2 text-gray-500">{{ t('dashboard.cards.amazon.unmappedSelectValues.description') }}</p>
+    <ul class="list-disc pl-4">
+      <li v-for="value in unmappedValues" :key="value.id">
+        <RouterLink
+          class="text-primary hover:underline"
+          :to="{ name: 'integrations.amazonPropertySelectValues.edit', params: { type: 'amazon', id: value.id } }"
+        >
+          {{ value.remoteName || value.remoteValue || value.id }}
+        </RouterLink>
+      </li>
+    </ul>
+  </div>
 </template>
 

--- a/src/shared/api/queries/amazonProductProperties.js
+++ b/src/shared/api/queries/amazonProductProperties.js
@@ -1,0 +1,35 @@
+import { gql } from 'graphql-tag';
+
+export const amazonProductPropertiesQuery = gql`
+  query AmazonProductProperties($remoteProductId: GlobalID!) {
+    amazonProductProperties(
+      filters: { remoteProduct: { id: { exact: $remoteProductId } } }
+    ) {
+      edges {
+        node {
+          id
+          localInstance {
+            id
+          }
+          remoteSelectValue {
+            id
+            remoteValue
+            remoteName
+            localInstance {
+              id
+            }
+          }
+          remoteSelectValues {
+            id
+            remoteValue
+            remoteName
+            localInstance {
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+


### PR DESCRIPTION
## Summary
- add GraphQL query for Amazon product properties
- show Amazon unmapped select values with links to mapping
- pass remote product id to new section

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3b722058c832e9ba4b06e6a913f9c

## Summary by Sourcery

Add Amazon Unmapped Values section to the product view that queries for product properties, identifies unmapped select values, and presents them with links to mapping pages

New Features:
- Implement AmazonUnmappedValuesSection to fetch and display unmapped Amazon select values with links to their mapping pages
- Add amazonProductPropertiesQuery GraphQL query to retrieve Amazon product properties for identifying unmapped values
- Integrate the new Unmapped Values section into AmazonView and conditionally render it using the remoteProductId prop