### PR TITLE
feat(amazon): add GTIN exemption toggle

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -287,7 +287,11 @@ const formatDate = (dateString?: string | null) => {
               <div class="border-t my-4"></div>
 
               <AmazonAsinSection class="mb-4" />
-              <AmazonGtinExemptionSection class="mb-4" />
+              <AmazonGtinExemptionSection
+                class="mb-4"
+                :product-id="props.product.id"
+                :view-id="selectedView?.id"
+              />
               <AmazonBrowseNodeSection class="mb-4" />
               <AmazonUnmappedValuesSection class="mb-4" />
               <AmazonVariationThemeSection v-if="isConfigurable" class="mb-4" />

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonGtinExemptionSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonGtinExemptionSection.vue
@@ -1,6 +1,106 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import apolloClient from '../../../../../../../../../apollo-client';
+import { Toggle } from '../../../../../../../../shared/components/atoms/toggle';
+import { Button } from '../../../../../../../../shared/components/atoms/button';
+import { Toast } from '../../../../../../../../shared/modules/toast';
+import { displayApolloError } from '../../../../../../../../shared/utils';
+import { amazonGtinExemptionsQuery } from '../../../../../../../../shared/api/queries/amazonGtinExemptions.js';
+import {
+  createAmazonGtinExemptionMutation,
+  updateAmazonGtinExemptionMutation,
+} from '../../../../../../../../shared/api/mutations/amazonGtinExemptions.js';
+
+const props = defineProps<{ productId?: string; viewId?: string }>();
+
+const { t } = useI18n();
+
+const loading = ref(false);
+const saving = ref(false);
+const exemptionId = ref<string | null>(null);
+const value = ref(false);
+const initialValue = ref(false);
+
+const fetchExemption = async () => {
+  if (!props.productId || !props.viewId) return;
+  loading.value = true;
+  try {
+    const { data } = await apolloClient.query({
+      query: amazonGtinExemptionsQuery,
+      variables: { productId: props.productId, viewId: props.viewId },
+      fetchPolicy: 'network-only',
+    });
+    const node = data.amazonGtinExemptions?.edges?.[0]?.node;
+    if (node) {
+      exemptionId.value = node.id;
+      value.value = node.value;
+      initialValue.value = node.value;
+    } else {
+      exemptionId.value = null;
+      value.value = false;
+      initialValue.value = false;
+    }
+  } catch (error) {
+    displayApolloError(error);
+  }
+  loading.value = false;
+};
+
+watch(
+  () => [props.productId, props.viewId],
+  () => {
+    fetchExemption();
+  },
+  { immediate: true },
+);
+
+const save = async () => {
+  if (!props.productId || !props.viewId) return;
+  saving.value = true;
+  try {
+    if (exemptionId.value) {
+      const { data } = await apolloClient.mutate({
+        mutation: updateAmazonGtinExemptionMutation,
+        variables: { data: { id: exemptionId.value, value: value.value } },
+      });
+      exemptionId.value = data.updateAmazonGtinExemption.id;
+      initialValue.value = data.updateAmazonGtinExemption.value;
+    } else {
+      const { data } = await apolloClient.mutate({
+        mutation: createAmazonGtinExemptionMutation,
+        variables: {
+          data: {
+            product: { id: props.productId },
+            view: { id: props.viewId },
+            value: value.value,
+          },
+        },
+      });
+      exemptionId.value = data.createAmazonGtinExemption.id;
+      initialValue.value = data.createAmazonGtinExemption.value;
+    }
+    Toast.success(t('shared.alert.toast.submitSuccessUpdate'));
+  } catch (error) {
+    displayApolloError(error);
+  }
+  saving.value = false;
+};
+</script>
 
 <template>
-  <div class="p-2 border rounded text-sm text-gray-500">GTIN Exemption section placeholder</div>
+  <div class="p-4 border rounded">
+    <div class="flex items-center justify-between">
+      <div>
+        <h4 class="font-semibold mb-1">{{ t('products.products.amazon.gtinExemption') }}</h4>
+        <p class="text-xs text-gray-500">{{ t('products.products.amazon.gtinExemptionDescription') }}</p>
+      </div>
+      <Toggle v-model="value" :disabled="loading" />
+    </div>
+    <div v-if="value !== initialValue" class="mt-2 text-right">
+      <Button class="btn btn-sm btn-outline-primary" :disabled="saving" @click="save">
+        {{ t('shared.labels.save') }}
+      </Button>
+    </div>
+  </div>
 </template>
-

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -89,6 +89,10 @@
       },
       "tabs": {
         "amazon": "Amazon"
+      },
+      "amazon": {
+        "gtinExemption": "GTIN Exemption",
+        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -965,7 +965,9 @@
         "validationIssues": "Validation Issues",
         "validationIssuesDescription": "Issues detected locally before sending the product to Amazon.",
         "otherIssues": "Remote Product Issues",
-        "otherIssuesDescription": "Issues already present in Amazon for this product."
+        "otherIssuesDescription": "Issues already present in Amazon for this product.",
+        "gtinExemption": "GTIN Exemption",
+        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
       },
       "inspector": {
         "errors": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -89,6 +89,10 @@
       },
       "tabs": {
         "amazon": "Amazon"
+      },
+      "amazon": {
+        "gtinExemption": "GTIN Exemption",
+        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -655,6 +655,10 @@
         "inventoryMovements": "",
         "amazon": "Amazon"
       },
+      "amazon": {
+        "gtinExemption": "GTIN Exemption",
+        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
+      },
       "inspector": {
         "labels": {
           "missingInfo": "Ontbrekende Informatie",

--- a/src/shared/api/mutations/amazonGtinExemptions.js
+++ b/src/shared/api/mutations/amazonGtinExemptions.js
@@ -1,0 +1,19 @@
+import { gql } from 'graphql-tag';
+
+export const createAmazonGtinExemptionMutation = gql`
+  mutation createAmazonGtinExemption($data: AmazonGtinExemptionInput!) {
+    createAmazonGtinExemption(data: $data) {
+      id
+      value
+    }
+  }
+`;
+
+export const updateAmazonGtinExemptionMutation = gql`
+  mutation updateAmazonGtinExemption($data: AmazonGtinExemptionPartialInput!) {
+    updateAmazonGtinExemption(data: $data) {
+      id
+      value
+    }
+  }
+`;

--- a/src/shared/api/queries/amazonGtinExemptions.js
+++ b/src/shared/api/queries/amazonGtinExemptions.js
@@ -1,0 +1,16 @@
+import { gql } from 'graphql-tag';
+
+export const amazonGtinExemptionsQuery = gql`
+  query AmazonGtinExemptions($productId: GlobalID!, $viewId: GlobalID!) {
+    amazonGtinExemptions(
+      filters: { product: { id: { exact: $productId } }, view: { id: { exact: $viewId } } }
+    ) {
+      edges {
+        node {
+          id
+          value
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- add GTIN exemption toggle section in Amazon product tab
- support querying and updating GTIN exemption via GraphQL
- localize GTIN exemption labels

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3b714d360832ebd093c803c5d8cba

## Summary by Sourcery

Introduce a GTIN exemption feature toggle in the Amazon product tab, backed by GraphQL operations and localized for all supported languages

New Features:
- Add GTIN exemption toggle section in the Amazon product tab with save-on-change behavior
- Implement GraphQL query and create/update mutations to fetch and update GTIN exemption status
- Localize GTIN exemption labels and descriptions across supported locales

Enhancements:
- Display toast notifications on successful updates and handle loading and error states
- Integrate the GTIN exemption component into the AmazonView with proper product and view identifiers