### PR TITLE
Improve AmazonUnmappedValuesSection links and styling

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 import TabContentTemplate from '../TabContentTemplate.vue';
 import { Product } from '../../../../configs';
 import { Button } from '../../../../../../../shared/components/atoms/button';
@@ -26,6 +27,7 @@ import { ProductType } from '../../../../../../../shared/utils/constants';
 const props = defineProps<{ product: Product; amazonProducts: AmazonProduct[] }>();
 const emit = defineEmits(['refreshAmazonProducts']);
 const { t } = useI18n();
+const route = useRoute();
 
 interface AmazonProductIssue {
   id: string;
@@ -294,12 +296,12 @@ const formatDate = (dateString?: string | null) => {
               <AmazonGtinExemptionSection class="mb-4" />
               <AmazonBrowseNodeSection class="mb-4" />
               <AmazonUnmappedValuesSection
-                v-if="remoteProductId"
+                v-if="remoteProductId && selectedView"
                 class="mb-4"
                 :remote-product-id="remoteProductId"
+                :id="String(route.query.integrationId || '')"
+                :sales-channel-id="selectedView.salesChannel.id"
               />
-              <AmazonVariationThemeSection v-if="isConfigurable" class="mb-4" />
-              <AmazonUnmappedValuesSection class="mb-4" />
               <AmazonVariationThemeSection
                 v-if="isConfigurable && selectedView"
                 class="mb-4"

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
@@ -10,12 +10,11 @@ interface SelectValue {
   remoteValue?: string | null;
   remoteName?: string | null;
   localInstance?: { id: string } | null;
+  salesChannel?: { id: string; ptrId: string } | null;
 }
 
 const props = defineProps<{
   remoteProductId: string | null;
-  id: string;
-  salesChannelId: string;
 }>();
 
 const { t } = useI18n();
@@ -85,11 +84,10 @@ const unmappedValues = computed(() => {
           class="text-primary hover:underline"
           :path="{
             name: 'integrations.amazonPropertySelectValues.edit',
-            params: {
-              type: 'amazon',
-              id: value.id,
-              integrationId: props.id,
-              salesChannelId: props.salesChannelId,
+            params: { type: 'amazon', id: value.id },
+            query: {
+              integrationId: value.salesChannel?.ptrId,
+              salesChannelId: value.salesChannel?.id,
             },
           }"
         >

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import apolloClient from '../../../../../../../../../apollo-client';
 import { amazonProductPropertiesQuery } from '../../../../../../../../shared/api/queries/amazonProductProperties.js';
+import { Link } from '../../../../../../../../shared/components/atoms/link';
 
 interface SelectValue {
   id: string;
@@ -11,26 +12,28 @@ interface SelectValue {
   localInstance?: { id: string } | null;
 }
 
-const props = defineProps<{ remoteProductId: string | null }>();
+const props = defineProps<{
+  remoteProductId: string | null;
+  id: string;
+  salesChannelId: string;
+}>();
 
 const { t } = useI18n();
 
 const properties = ref<any[]>([]);
-const loading = ref(false);
 
 const fetchProperties = async () => {
   if (!props.remoteProductId) {
     properties.value = [];
     return;
   }
-  loading.value = true;
   const { data } = await apolloClient.query({
     query: amazonProductPropertiesQuery,
     variables: { remoteProductId: props.remoteProductId },
     fetchPolicy: 'network-only',
   });
-  properties.value = data?.amazonProductProperties?.edges?.map((e: any) => e.node) || [];
-  loading.value = false;
+  properties.value =
+    data?.amazonProductProperties?.edges?.map((e: any) => e.node) || [];
 };
 
 watch(
@@ -42,35 +45,56 @@ watch(
 );
 
 const unmappedValues = computed(() => {
-  const result: SelectValue[] = [];
+  const map = new Map<string, SelectValue>();
   for (const prop of properties.value) {
+    const values: SelectValue[] = [];
     if (prop.remoteSelectValue && !prop.remoteSelectValue.localInstance) {
-      result.push(prop.remoteSelectValue);
+      values.push(prop.remoteSelectValue);
     }
     if (Array.isArray(prop.remoteSelectValues)) {
       for (const val of prop.remoteSelectValues as SelectValue[]) {
         if (!val.localInstance) {
-          result.push(val);
+          values.push(val);
         }
       }
     }
+    for (const val of values) {
+      if (!map.has(val.id)) {
+        map.set(val.id, val);
+      }
+    }
   }
-  return result;
+  return Array.from(map.values());
 });
 </script>
 
 <template>
-  <div v-if="unmappedValues.length" class="p-2 border rounded text-sm">
-    <div class="mb-2 font-medium">{{ t('dashboard.cards.amazon.unmappedSelectValues.title') }}</div>
-    <p class="mb-2 text-gray-500">{{ t('dashboard.cards.amazon.unmappedSelectValues.description') }}</p>
-    <ul class="list-disc pl-4">
+  <div
+    v-if="unmappedValues.length"
+    class="p-4 border rounded bg-gray-50 text-sm space-y-2"
+  >
+    <div class="font-medium">
+      {{ t('dashboard.cards.amazon.unmappedSelectValues.title') }}
+    </div>
+    <p class="text-gray-500">
+      {{ t('dashboard.cards.amazon.unmappedSelectValues.description') }}
+    </p>
+    <ul class="list-disc pl-5 space-y-1">
       <li v-for="value in unmappedValues" :key="value.id">
-        <RouterLink
+        <Link
           class="text-primary hover:underline"
-          :to="{ name: 'integrations.amazonPropertySelectValues.edit', params: { type: 'amazon', id: value.id } }"
+          :path="{
+            name: 'integrations.amazonPropertySelectValues.edit',
+            params: {
+              type: 'amazon',
+              id: value.id,
+              integrationId: props.id,
+              salesChannelId: props.salesChannelId,
+            },
+          }"
         >
           {{ value.remoteName || value.remoteValue || value.id }}
-        </RouterLink>
+        </Link>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- style Amazon unmapped values card and switch to shared `Link`
- de-duplicate unmapped select values and include integration/sales-channel ids in links
- remove unused loading state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4971cd600832eb564c2557b83ad4d