### PR TITLE
feat(amazon): add ASIN section description

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonAsinSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonAsinSection.vue
@@ -107,10 +107,13 @@ const isSaveDisabled = computed(() => asin.value === lastSavedAsin.value);
 
 <template>
   <div>
-    <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-2">
+    <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
       {{ t('products.products.amazon.asin') }}
     </Label>
-    <div v-if="errors.asin" class="text-danger text-small mt-1">
+    <p class="text-xs text-gray-500 mb-2">
+      {{ t('products.products.amazon.asinDescription') }}
+    </p>
+    <div v-if="errors.asin" class="text-danger text-small mb-2">
       {{ errors.asin }}
     </div>
     <Flex middle gap="2">

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -91,6 +91,11 @@
         "amazon": "Amazon"
       },
       "amazon": {
+        "asin": "ASIN",
+        "asinDescription": "Provide the Amazon Standard Identification Number for this product.",
+        "asinPlaceholder": "Enter ASIN",
+        "asinSaved": "ASIN saved",
+        "asinDeleted": "ASIN deleted",
         "gtinExemption": "GTIN Exemption",
         "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
       }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -969,6 +969,7 @@
         "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace.",
         "otherIssuesDescription": "Issues already present in Amazon for this product.",
         "asin": "ASIN",
+        "asinDescription": "Provide the Amazon Standard Identification Number for this product.",
         "asinPlaceholder": "Enter ASIN",
         "asinSaved": "ASIN saved",
         "asinDeleted": "ASIN deleted"

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -91,6 +91,11 @@
         "amazon": "Amazon"
       },
       "amazon": {
+        "asin": "ASIN",
+        "asinDescription": "Provide the Amazon Standard Identification Number for this product.",
+        "asinPlaceholder": "Enter ASIN",
+        "asinSaved": "ASIN saved",
+        "asinDeleted": "ASIN deleted",
         "gtinExemption": "GTIN Exemption",
         "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
       }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -661,6 +661,7 @@
         "otherIssues": "Problemen met Amazon product",
         "otherIssuesDescription": "Problemen die al aanwezig zijn in Amazon voor dit product.",
         "asin": "ASIN",
+        "asinDescription": "Voer het Amazon Standard Identification Number (ASIN) voor dit product in.",
         "asinPlaceholder": "Voer ASIN in",
         "asinSaved": "ASIN opgeslagen",
         "asinDeleted": "ASIN verwijderd",


### PR DESCRIPTION
## Summary
- add description under ASIN section in Amazon tab
- add translation strings for ASIN description across locales

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4cc17178c832e96fe1525d90419d1