### PR TITLE
feat: improve Amazon browse node selection UI

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -92,7 +92,11 @@
       },
       "amazon": {
         "gtinExemption": "GTIN Exemption",
-        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
+        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace.",
+        "browseNode": "Browse node",
+        "noBrowseNodeSelected": "No browse node selected",
+        "browseNodeRoot": "Root",
+        "recommendedProductTypes": "Recommended product types"
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -971,7 +971,11 @@
         "asin": "ASIN",
         "asinPlaceholder": "Enter ASIN",
         "asinSaved": "ASIN saved",
-        "asinDeleted": "ASIN deleted"
+        "asinDeleted": "ASIN deleted",
+        "browseNode": "Browse node",
+        "noBrowseNodeSelected": "No browse node selected",
+        "browseNodeRoot": "Root",
+        "recommendedProductTypes": "Recommended product types"
       },
       "inspector": {
         "errors": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -92,7 +92,11 @@
       },
       "amazon": {
         "gtinExemption": "GTIN Exemption",
-        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
+        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace.",
+        "browseNode": "Browse node",
+        "noBrowseNodeSelected": "No browse node selected",
+        "browseNodeRoot": "Root",
+        "recommendedProductTypes": "Recommended product types"
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -665,7 +665,11 @@
         "asinSaved": "ASIN opgeslagen",
         "asinDeleted": "ASIN verwijderd",
         "gtinExemption": "GTIN Exemption",
-        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace."
+        "gtinExemptionDescription": "Enable if this product is exempt from GTIN requirements for this marketplace.",
+        "browseNode": "Browse node",
+        "noBrowseNodeSelected": "No browse node selected",
+        "browseNodeRoot": "Root",
+        "recommendedProductTypes": "Recommended product types"
       },
       "inspector": {
         "labels": {


### PR DESCRIPTION
## Summary
- add browse node translations for all locales
- revamp Amazon browse node picker with breadcrumb navigation and saveable selection

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4cb628cb4832eab24d78591586489

## Summary by Sourcery

Revamp the Amazon browse node selection UI by introducing breadcrumbs for navigation, a pending selection workflow with save/remove actions, and multi-locale translations

New Features:
- Add breadcrumb-based navigation for Amazon browse node picker
- Allow users to select and save pending browse node selection

Enhancements:
- Include translations for browse nodes in all supported locales
- Enhance node list interaction with clickable rows and selected-state styling