### PR TITLE
Improve Amazon browse node section and fix mutation

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
@@ -127,6 +127,14 @@ const goToLevel = (index: number | null) => {
   currentParentId.value = pathStack.value[index].remoteId;
 };
 
+const goBack = () => {
+  if (!pathStack.value.length) {
+    goToLevel(null);
+    return;
+  }
+  const target = pathStack.value.length - 2;
+  goToLevel(target >= 0 ? target : null);
+};
 const selectNode = (node: BrowseNode) => {
   pendingNode.value = node;
 };
@@ -139,14 +147,14 @@ const saveSelection = async () => {
       mutation: updateAmazonProductBrowseNodeMutation,
       variables: {
         id: productBrowseNodeId.value,
-        input: { recommendedBrowseNodeId: node.remoteId },
+        data: { recommendedBrowseNodeId: node.remoteId },
       },
     });
   } else {
     const { data } = await apolloClient.mutate({
       mutation: createAmazonProductBrowseNodeMutation,
       variables: {
-        input: {
+        data: {
           product: props.productId,
           salesChannel: props.salesChannelId,
           salesChannelView: props.salesChannelViewId,
@@ -178,27 +186,29 @@ const removeSelection = async () => {
 
     <div class="mb-4">
       <div v-if="displayedNode" class="mb-2">
-        <div class="text-sm">
-          {{ displayedNode.browsePathByName.join(' > ') }}
-        </div>
-        <div
-          v-if="displayedNode.productTypeDefinitions.length"
-          class="text-xs text-gray-500 mt-1"
-        >
-          {{ t('products.products.amazon.recommendedProductTypes') }}
-          <ul class="list-disc ml-4">
-            <li
-              v-for="type in displayedNode.productTypeDefinitions"
-              :key="type"
-            >
-              {{ type }}
-            </li>
-          </ul>
+        <div class="flex justify-between items-start">
+          <div class="text-sm">
+            {{ displayedNode.browsePathByName.join(' > ') }}
+          </div>
+          <div
+            v-if="displayedNode.productTypeDefinitions.length"
+            class="text-xs text-gray-500 ml-4"
+          >
+            <div>{{ t('products.products.amazon.recommendedProductTypes') }}</div>
+            <ul class="list-disc ml-4">
+              <li
+                v-for="type in displayedNode.productTypeDefinitions"
+                :key="type"
+              >
+                {{ type }}
+              </li>
+            </ul>
+          </div>
         </div>
         <div class="flex gap-2 mt-2">
           <Button
             v-if="pendingNode"
-            class="btn btn-xs btn-outline-primary"
+            class="btn btn-sm btn-primary"
             @click="saveSelection"
           >
             {{ t('shared.button.save') }}
@@ -218,7 +228,7 @@ const removeSelection = async () => {
     </div>
 
     <div class="border rounded p-2">
-      <div class="mb-2 text-sm font-semibold flex flex-wrap items-center gap-1">
+      <div class="mb-2 text-base font-semibold flex flex-wrap items-center gap-1 py-2">
         <span
           class="cursor-pointer hover:underline"
           @click="goToLevel(null)"
@@ -232,6 +242,13 @@ const removeSelection = async () => {
             >{{ crumb.name }}</span
           >
         </template>
+        <Button
+          v-if="pathStack.length"
+          class="btn btn-xs btn-outline-primary ml-auto"
+          @click="goBack"
+        >
+          {{ t('shared.button.back') }}
+        </Button>
       </div>
 
       <div v-if="loadingNodes">

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -4,6 +4,7 @@
       "login": "Anmelden",
       "register": "Registrieren",
       "recover": "Wiederherstellen",
+      "select": "Auswählen",
       "duplicate": "Duplizieren",
       "resync": "Resync",
       "validate": "Validate",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -351,6 +351,7 @@
       "downloadConfirmation": "Download Confirmation",
       "uploadNew": "Upload New",
       "create": "Create",
+      "select": "Select",
       "skip": "Skip",
       "generate": "Generate",
       "translate": "Translate",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -4,6 +4,7 @@
       "login": "Se connecter",
       "register": "S'inscrire",
       "recover": "Récupérer",
+      "select": "Sélectionner",
       "duplicate": "Dupliquer",
       "resync": "Resync",
       "validate": "Validate",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -173,6 +173,7 @@
       "download": "Downloaden",
       "uploadNew": "Uploaden",
       "create": "Aanmaken",
+      "select": "Selecteer",
       "skip": "Overslaan",
       "generate": "Genereren",
       "duplicate": "Dupliceren",

--- a/src/shared/api/mutations/amazonProducts.js
+++ b/src/shared/api/mutations/amazonProducts.js
@@ -28,8 +28,8 @@ export const resyncAmazonProductMutation = gql`
 `;
 
 export const createAmazonProductBrowseNodeMutation = gql`
-  mutation createAmazonProductBrowseNode($input: AmazonProductBrowseNodeInput!) {
-    createAmazonProductBrowseNode(input: $input) {
+  mutation createAmazonProductBrowseNode($data: AmazonProductBrowseNodeInput!) {
+    createAmazonProductBrowseNode(data: $data) {
       id
       recommendedBrowseNodeId
     }
@@ -39,9 +39,9 @@ export const createAmazonProductBrowseNodeMutation = gql`
 export const updateAmazonProductBrowseNodeMutation = gql`
   mutation updateAmazonProductBrowseNode(
     $id: GlobalID!
-    $input: AmazonProductBrowseNodePartialInput!
+    $data: AmazonProductBrowseNodePartialInput!
   ) {
-    updateAmazonProductBrowseNode(id: $id, input: $input) {
+    updateAmazonProductBrowseNode(id: $id, data: $data) {
       id
       recommendedBrowseNodeId
     }


### PR DESCRIPTION
## Summary
- add back button and move recommended types to the right in Amazon browse node selector
- adjust save button style and size
- fix Amazon browse node mutations to use `data` argument
- add missing translations for the Select button

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4d22156d8832ea451201031b36c9a