### PR TITLE
Always include Amazon tab in product pages

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -24,6 +24,7 @@ const { t } = useI18n();
 const router = useRouter();
 
 const amazonProducts = ref<any[]>([]);
+const amazonProductsLoaded = ref(false);
 
 const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
@@ -32,6 +33,7 @@ const fetchAmazonProducts = async () => {
     fetchPolicy: 'network-only',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
+  amazonProductsLoaded.value = true;
 };
 
 onMounted(fetchAmazonProducts);
@@ -60,7 +62,7 @@ const tabItems = computed(() => {
     { name: 'eanCodes', label: t('products.products.tabs.eanCodes'), icon: 'qrcode' }
   );
 
-  if (amazonProducts.value.length > 0) {
+  if (!amazonProductsLoaded.value || amazonProducts.value.length > 0) {
     items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
   }
 

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -19,6 +19,7 @@ const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 
 const amazonProducts = ref<any[]>([]);
+const amazonProductsLoaded = ref(false);
 
 const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
@@ -27,6 +28,7 @@ const fetchAmazonProducts = async () => {
     fetchPolicy: 'network-only',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
+  amazonProductsLoaded.value = true;
 };
 
 onMounted(fetchAmazonProducts);
@@ -52,7 +54,7 @@ const tabItems = computed(() => {
     { name: 'websites', label: t('products.products.tabs.websites'), icon: 'globe' }
   );
 
-  if (amazonProducts.value.length > 0) {
+  if (!amazonProductsLoaded.value || amazonProducts.value.length > 0) {
     items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
   }
 

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -24,6 +24,7 @@ const { t } = useI18n();
 const router = useRouter();
 
 const amazonProducts = ref<any[]>([]);
+const amazonProductsLoaded = ref(false);
 
 const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
@@ -32,6 +33,7 @@ const fetchAmazonProducts = async () => {
     fetchPolicy: 'network-only',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
+  amazonProductsLoaded.value = true;
 };
 
 onMounted(fetchAmazonProducts);
@@ -65,7 +67,7 @@ const tabItems = computed(() => {
     { name: 'eanCodes', label: t('products.products.tabs.eanCodes'), icon: 'qrcode' },
   );
 
-  if (amazonProducts.value.length > 0) {
+  if (!amazonProductsLoaded.value || amazonProducts.value.length > 0) {
     items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
   }
 


### PR DESCRIPTION
## Summary
- always add Amazon tab to product pages and remove it after loading if no products are returned

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a59f9e0c10832e8819b40d98197f3a