### PR TITLE
Show Amazon tab without remote product

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -24,7 +24,6 @@ const { t } = useI18n();
 const router = useRouter();
 
 const amazonProducts = ref<any[]>([]);
-const amazonProductsLoaded = ref(false);
 
 const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
@@ -33,7 +32,6 @@ const fetchAmazonProducts = async () => {
     fetchPolicy: 'network-only',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
-  amazonProductsLoaded.value = true;
 };
 
 onMounted(fetchAmazonProducts);
@@ -62,9 +60,7 @@ const tabItems = computed(() => {
     { name: 'eanCodes', label: t('products.products.tabs.eanCodes'), icon: 'qrcode' }
   );
 
-  if (!amazonProductsLoaded.value || amazonProducts.value.length > 0) {
-    items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
-  }
+  items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
 
   return items;
 });
@@ -108,7 +104,7 @@ const tabItems = computed(() => {
       <template v-slot:eanCodes>
         <ProductEanCodesList :product="product" />
       </template>
-      <template v-if="amazonProducts.length" v-slot:amazon>
+      <template v-slot:amazon>
         <AmazonView
           :product="product"
           :amazon-products="amazonProducts"

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -19,7 +19,6 @@ const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 
 const amazonProducts = ref<any[]>([]);
-const amazonProductsLoaded = ref(false);
 
 const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
@@ -28,7 +27,6 @@ const fetchAmazonProducts = async () => {
     fetchPolicy: 'network-only',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
-  amazonProductsLoaded.value = true;
 };
 
 onMounted(fetchAmazonProducts);
@@ -54,9 +52,7 @@ const tabItems = computed(() => {
     { name: 'websites', label: t('products.products.tabs.websites'), icon: 'globe' }
   );
 
-  if (!amazonProductsLoaded.value || amazonProducts.value.length > 0) {
-    items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
-  }
+  items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
 
   return items;
 });
@@ -88,7 +84,7 @@ const tabItems = computed(() => {
       <template v-slot:websites>
         <WebsitesView :product="product" />
       </template>
-      <template v-if="amazonProducts.length" v-slot:amazon>
+      <template v-slot:amazon>
         <AmazonView
           :product="product"
           :amazon-products="amazonProducts"

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -24,7 +24,6 @@ const { t } = useI18n();
 const router = useRouter();
 
 const amazonProducts = ref<any[]>([]);
-const amazonProductsLoaded = ref(false);
 
 const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
@@ -33,7 +32,6 @@ const fetchAmazonProducts = async () => {
     fetchPolicy: 'network-only',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
-  amazonProductsLoaded.value = true;
 };
 
 onMounted(fetchAmazonProducts);
@@ -67,9 +65,7 @@ const tabItems = computed(() => {
     { name: 'eanCodes', label: t('products.products.tabs.eanCodes'), icon: 'qrcode' },
   );
 
-  if (!amazonProductsLoaded.value || amazonProducts.value.length > 0) {
-    items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
-  }
+  items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
 
   return items;
 });
@@ -109,7 +105,7 @@ const tabItems = computed(() => {
       <template v-slot:eanCodes>
         <ProductEanCodesList :product="product" />
       </template>
-      <template v-if="amazonProducts.length" v-slot:amazon>
+      <template v-slot:amazon>
         <AmazonView
           :product="product"
           :amazon-products="amazonProducts"


### PR DESCRIPTION
## Summary
- Always display Amazon tab in product pages even without remote Amazon products
- Render Amazon product view regardless of existing remote products

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a630c8789c832eb8eadc25f414140d