### PR TITLE
feat: hide amazon tab without integration

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -18,10 +18,12 @@ import AliasProductsView from "../../tabs/alias-parents/AliasProductsView.vue";
 import AmazonView from "../../tabs/amazon/AmazonView.vue";
 import { amazonProductsQuery } from "../../../../../../../shared/api/queries/amazonProducts.js";
 import apolloClient from "../../../../../../../../apollo-client";
+import { injectAuth } from "../../../../../../../shared/modules/auth";
 
 const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 const router = useRouter();
+const auth = injectAuth();
 
 const amazonProducts = ref<any[]>([]);
 
@@ -34,7 +36,9 @@ const fetchAmazonProducts = async () => {
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
 };
 
-onMounted(fetchAmazonProducts);
+if (auth.user.company?.hasAmazonIntegration) {
+  onMounted(fetchAmazonProducts);
+}
 
 const tabItems = computed(() => {
   const items = [
@@ -60,7 +64,9 @@ const tabItems = computed(() => {
     { name: 'eanCodes', label: t('products.products.tabs.eanCodes'), icon: 'qrcode' }
   );
 
-  items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
+  if (auth.user.company?.hasAmazonIntegration) {
+    items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
+  }
 
   return items;
 });
@@ -104,7 +110,7 @@ const tabItems = computed(() => {
       <template v-slot:eanCodes>
         <ProductEanCodesList :product="product" />
       </template>
-      <template v-slot:amazon>
+      <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView
           :product="product"
           :amazon-products="amazonProducts"

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -14,9 +14,11 @@ import AliasProductsView from "../../tabs/alias-parents/AliasProductsView.vue";
 import AmazonView from "../../tabs/amazon/AmazonView.vue";
 import { amazonProductsQuery } from "../../../../../../../shared/api/queries/amazonProducts.js";
 import apolloClient from "../../../../../../../../apollo-client";
+import { injectAuth } from "../../../../../../../shared/modules/auth";
 
 const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
+const auth = injectAuth();
 
 const amazonProducts = ref<any[]>([]);
 
@@ -29,7 +31,9 @@ const fetchAmazonProducts = async () => {
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
 };
 
-onMounted(fetchAmazonProducts);
+if (auth.user.company?.hasAmazonIntegration) {
+  onMounted(fetchAmazonProducts);
+}
 
 const tabItems = computed(() => {
   const items = [
@@ -52,7 +56,9 @@ const tabItems = computed(() => {
     { name: 'websites', label: t('products.products.tabs.websites'), icon: 'globe' }
   );
 
-  items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
+  if (auth.user.company?.hasAmazonIntegration) {
+    items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
+  }
 
   return items;
 });
@@ -84,7 +90,7 @@ const tabItems = computed(() => {
       <template v-slot:websites>
         <WebsitesView :product="product" />
       </template>
-      <template v-slot:amazon>
+      <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView
           :product="product"
           :amazon-products="amazonProducts"

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -18,10 +18,12 @@ import AliasProductsView from "../../tabs/alias-parents/AliasProductsView.vue";
 import AmazonView from "../../tabs/amazon/AmazonView.vue";
 import { amazonProductsQuery } from "../../../../../../../shared/api/queries/amazonProducts.js";
 import apolloClient from "../../../../../../../../apollo-client";
+import { injectAuth } from "../../../../../../../shared/modules/auth";
 
 const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 const router = useRouter();
+const auth = injectAuth();
 
 const amazonProducts = ref<any[]>([]);
 
@@ -34,7 +36,9 @@ const fetchAmazonProducts = async () => {
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
 };
 
-onMounted(fetchAmazonProducts);
+if (auth.user.company?.hasAmazonIntegration) {
+  onMounted(fetchAmazonProducts);
+}
 
 const tabItems = computed(() => {
   const items = [
@@ -65,7 +69,9 @@ const tabItems = computed(() => {
     { name: 'eanCodes', label: t('products.products.tabs.eanCodes'), icon: 'qrcode' },
   );
 
-  items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
+  if (auth.user.company?.hasAmazonIntegration) {
+    items.push({ name: 'amazon', label: t('products.products.tabs.amazon'), icon: 'store' });
+  }
 
   return items;
 });
@@ -105,7 +111,7 @@ const tabItems = computed(() => {
       <template v-slot:eanCodes>
         <ProductEanCodesList :product="product" />
       </template>
-      <template v-slot:amazon>
+      <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView
           :product="product"
           :amazon-products="amazonProducts"


### PR DESCRIPTION
## Summary
- hide Amazon product tab when company lacks Amazon integration

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a63b150b90832e9f8dace5d57f422d

## Summary by Sourcery

Inject auth into product-show components and guard Amazon tab rendering and data fetching behind the company’s hasAmazonIntegration flag

Enhancements:
- Add auth injection and conditional onMounted Amazon data fetch in ProductBundle, ProductConfigurable, and ProductVariation components
- Hide Amazon tab and its view in product-show containers when the company lacks Amazon integration