### PR TITLE
feat: add scrollable variations bulk edit matrix

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -1,14 +1,141 @@
 <script setup lang="ts">
-import { Product } from "../../../../../../configs";
+import { reactive, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Product } from '../../../../../../configs'
+import { bundleVariationsQuery, configurableVariationsQuery } from '../../../../../../../../../shared/api/queries/products.js'
+import { ProductType } from '../../../../../../../../../shared/utils/constants'
 
-const props = defineProps<{ product: Product }>();
+const props = defineProps<{ product: Product }>()
 
-// TODO: implement bulk edit matrix functionalities (drag, copy/paste, modals, etc.)
+const { t } = useI18n()
+
+const mockProperties = [
+  { key: 'prop1', label: 'Property 1' },
+  { key: 'prop2', label: 'Property 2' },
+  { key: 'prop3', label: 'Property 3' },
+  { key: 'prop4', label: 'Property 4' },
+  { key: 'prop5', label: 'Property 5' },
+]
+
+const baseColumns = [
+  { key: 'name', label: t('shared.labels.name') },
+  { key: 'sku', label: t('shared.labels.sku') },
+  { key: 'active', label: t('shared.labels.active') },
+]
+
+const columns = [...baseColumns, ...mockProperties]
+
+const columnWidths = reactive<Record<string, number>>({})
+columns.forEach((col) => (columnWidths[col.key] = 150))
+
+const isAlias = computed(() => props.product.type === ProductType.Alias)
+const parentId = computed(() => (isAlias.value ? props.product.aliasParentProduct.id : props.product.id))
+const parentType = computed(() => (isAlias.value ? props.product.aliasParentProduct.type : props.product.type))
+const query = computed(() =>
+  parentType.value === ProductType.Bundle ? bundleVariationsQuery : configurableVariationsQuery
+)
+const queryKey = computed(() =>
+  parentType.value === ProductType.Bundle ? 'bundleVariations' : 'configurableVariations'
+)
+
+const startResize = (e: MouseEvent, key: string) => {
+  const startX = e.pageX
+  const startWidth = columnWidths[key]
+
+  const onMouseMove = (event: MouseEvent) => {
+    const delta = event.pageX - startX
+    columnWidths[key] = Math.max(50, startWidth + delta)
+  }
+
+  const onMouseUp = () => {
+    document.removeEventListener('mousemove', onMouseMove)
+    document.removeEventListener('mouseup', onMouseUp)
+  }
+
+  document.addEventListener('mousemove', onMouseMove)
+  document.addEventListener('mouseup', onMouseUp)
+}
 </script>
 
 <template>
-  <div>
-    <!-- Placeholder for bulk edit matrix -->
-    <p class="text-gray-500">Bulk edit interface under construction..</p>
+  <div class="overflow-auto max-h-96 border border-gray-200">
+    <ApolloQuery
+      :query="query"
+      :variables="{ filter: { parent: { id: { exact: parentId } } }, first: 100 }"
+    >
+      <template v-slot="{ result: { data } }">
+        <table v-if="data && data[queryKey]" class="min-w-max">
+          <thead class="bg-gray-100 sticky top-0">
+            <tr>
+              <th
+                v-for="col in columns"
+                :key="col.key"
+                class="text-left px-2 py-1 text-sm font-medium text-gray-700 relative"
+                :style="{ width: columnWidths[col.key] + 'px' }"
+              >
+                <div class="flex items-center h-full">
+                  <span>{{ col.label }}</span>
+                  <span
+                    class="resizer select-none"
+                    @mousedown="(e) => startResize(e, col.key)"
+                  />
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="edge in data[queryKey].edges"
+              :key="edge.node.id"
+              class="border-t"
+            >
+              <td
+                v-for="col in columns"
+                :key="col.key"
+                class="px-2 py-1"
+                :style="{ width: columnWidths[col.key] + 'px' }"
+              >
+                <template v-if="col.key === 'name'">
+                  <span class="block truncate" :title="edge.node.variation.name">
+                    {{ edge.node.variation.name }}
+                  </span>
+                </template>
+                <template v-else-if="col.key === 'sku'">
+                  <span class="block truncate" :title="edge.node.variation.sku">
+                    {{ edge.node.variation.sku }}
+                  </span>
+                </template>
+                <template v-else-if="col.key === 'active'">
+                  <Icon
+                    v-if="edge.node.variation.active"
+                    name="check-circle"
+                    class="text-green-500"
+                  />
+                  <Icon
+                    v-else
+                    name="times-circle"
+                    class="text-red-500"
+                  />
+                </template>
+                <template v-else>
+                  <input type="text" class="w-full border p-1" />
+                </template>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </template>
+    </ApolloQuery>
   </div>
 </template>
+
+<style scoped>
+.resizer {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+}
+</style>


### PR DESCRIPTION
## Summary
- build basic bulk edit matrix for product variations
- support scrolling with resizable columns and real variation data
- display active status with icons

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a74bc266a0832eb104b9bcaaa1979b

## Summary by Sourcery

Add a scrollable bulk edit matrix for product variations with dynamic columns, live GraphQL data fetching, and resizable column support

New Features:
- Implement bulk edit matrix component with horizontal scrolling and reactive column resizing
- Fetch and render real variation data via Apollo GraphQL queries for bundle and configurable products
- Display variation active status using icons and provide editable cells for custom properties