### PR TITLE
Enable table scrolling in variations bulk edit

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -115,7 +115,7 @@ const startResize = (e: MouseEvent, key: string) => {
 </script>
 
 <template>
-  <div class="overflow-auto max-h-96 border border-gray-200">
+  <perfect-scrollbar class="max-h-96 border border-gray-200 relative">
     <ApolloQuery
       :query="query"
       :variables="{ filter: { parent: { id: { exact: parentId } } }, first: 100 }"
@@ -183,7 +183,7 @@ const startResize = (e: MouseEvent, key: string) => {
         </table>
       </template>
     </ApolloQuery>
-  </div>
+  </perfect-scrollbar>
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- use PerfectScrollbar to confine scrolling within the variations bulk edit table

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7525fb638832e96a2484cf7cfa77c