### PR TITLE
fix: enable scrolling for variations bulk edit

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -115,7 +115,7 @@ const startResize = (e: MouseEvent, key: string) => {
 </script>
 
 <template>
-  <perfect-scrollbar class="max-h-96 border border-gray-200 relative">
+  <perfect-scrollbar class="max-h-96 overflow-auto border border-gray-200 relative">
     <ApolloQuery
       :query="query"
       :variables="{ filter: { parent: { id: { exact: parentId } } }, first: 100 }"


### PR DESCRIPTION
## Summary
- allow VariationsBulkEdit table to scroll within limited height by adding overflow to the PerfectScrollbar container

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a76fa79cbc832eaee506927264b771