### PR TITLE
style: refine bulk edit modals

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -12,6 +12,7 @@ import { DateInput } from "../../../../../../../../../shared/components/atoms/in
 import DateTimeInput from "../../../../../../../../../shared/components/atoms/input-date-time/DateTimeInput.vue";
 import { shortenText } from "../../../../../../../../../shared/utils";
 import { Modal } from "../../../../../../../../../shared/components/atoms/modal";
+import { Card } from "../../../../../../../../../shared/components/atoms/card";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
 import { FieldQuery } from "../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
 import type { QueryFormField } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
@@ -380,22 +381,28 @@ const startResize = (e: MouseEvent, key: string) => {
     </table>
   </div>
   <Modal v-model="showTextModal">
-    <div class="p-4 space-y-4">
+    <Card class="modal-content w-1/2">
+      <h3 class="text-xl font-semibold text-center mb-4">
+        {{ t('products.products.bulkEditModal.textTitle') }}
+      </h3>
       <TextInput class="w-full" v-model="modalValue" />
-      <div class="flex justify-end gap-2">
-        <Button class="btn btn-primary" @click="saveModal">Edit</Button>
-        <Button class="btn btn-outline-dark" @click="cancelModal">Cancel</Button>
+      <div class="flex justify-end gap-4 mt-4">
+        <Button class="btn btn-outline-dark" @click="cancelModal">{{ t('shared.button.cancel') }}</Button>
+        <Button class="btn btn-primary" @click="saveModal">{{ t('shared.button.edit') }}</Button>
       </div>
-    </div>
+    </Card>
   </Modal>
   <Modal v-model="showDescriptionModal">
-    <div class="p-4 space-y-4">
-      <TextEditor class="h-32" v-model="modalValue" />
-      <div class="flex justify-end gap-2">
-        <Button class="btn btn-primary" @click="saveModal">Edit</Button>
-        <Button class="btn btn-outline-dark" @click="cancelModal">Cancel</Button>
+    <Card class="modal-content w-2/3">
+      <h3 class="text-xl font-semibold text-center mb-4">
+        {{ t('products.products.bulkEditModal.descriptionTitle') }}
+      </h3>
+      <TextEditor class="h-64" v-model="modalValue" />
+      <div class="flex justify-end gap-4 mt-4">
+        <Button class="btn btn-outline-dark" @click="cancelModal">{{ t('shared.button.cancel') }}</Button>
+        <Button class="btn btn-primary" @click="saveModal">{{ t('shared.button.edit') }}</Button>
       </div>
-    </div>
+    </Card>
   </Modal>
 </template>
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1184,6 +1184,10 @@
       "duplicateModal": {
         "description": "Provide an SKU for the duplicated product or leave empty to auto generate."
       },
+      "bulkEditModal": {
+        "textTitle": "Edit value",
+        "descriptionTitle": "Edit description"
+      },
       "duplicateSuccessfully": "Product was successfully duplicated!"
     }
   },

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -856,6 +856,10 @@
       "show": {
         "title": "Product"
       },
+      "bulkEditModal": {
+        "textTitle": "Waarde bewerken",
+        "descriptionTitle": "Beschrijving bewerken"
+      },
       "duplicateSuccessfully": "Product succesvol gedupliceerd!"
     }
   },


### PR DESCRIPTION
## Summary
- redesign bulk edit text/description modals with Card wrapper and localized UI
- add English/Dutch translations for modal titles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7a293a29c832e9b9faa953afb1811

## Summary by Sourcery

Refine the bulk edit text and description modals by wrapping content in Card components, adding localized titles and translated button labels, and adjusting layout and input sizes

Enhancements:
- Wrap modal content in Card components and update layout classes for width, spacing, and heading
- Replace hardcoded labels with translation keys for modal titles and shared button text
- Increase the description editor height in the description modal

Documentation:
- Add English and Dutch translations for bulk edit modal titles in locale files