### PR TITLE
feat: handle bulk property changes

### DIFF
--- a/src/shared/api/mutations/properties.js
+++ b/src/shared/api/mutations/properties.js
@@ -228,6 +228,14 @@ export const bulkCreateProductPropertiesMutation = gql`
   }
 `;
 
+export const bulkUpdateProductPropertiesMutation = gql`
+  mutation bulkUpdateProductProperties($data: [BulkProductPropertyPartialInput!]!) {
+    bulkUpdateProductProperties(productProperties: $data) {
+      id
+    }
+  }
+`;
+
 export const updateProductPropertyMutation = gql`
   mutation updateProductProperty($data: ProductPropertyPartialInput!) {
     updateProductProperty(data: $data) {


### PR DESCRIPTION
## Summary
- track created, updated and deleted variation property values
- invoke bulk create/update/delete mutations when saving
- expose bulkUpdateProductProperties mutation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acad8fc9d8832e85e943e5b4c3f81f

## Summary by Sourcery

Enable bulk processing of product variation property edits by computing diffs and invoking batch GraphQL mutations

New Features:
- Support bulk create, update, and delete operations for variation property values
- Expose bulkUpdateProductProperties mutation in the API

Enhancements:
- Implement custom diff logic to track created, updated, and deleted property values
- Replace lodash isEqual with specialized change detection and deep watch on variations
- Update save action to execute appropriate bulk create/update/delete mutations and reset tracked state