### PR TITLE
Handle null boolean values in variation bulk edit

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -38,9 +38,9 @@ const { t } = useI18n()
 const language = ref<string | null>(null)
 
 const baseColumns = [
-  { key: 'name', label: t('shared.labels.name') },
-  { key: 'sku', label: t('shared.labels.sku') },
-  { key: 'active', label: t('shared.labels.active') },
+  { key: 'name', label: t('shared.labels.name'), requireType: undefined },
+  { key: 'sku', label: t('shared.labels.sku'), requireType: undefined },
+  { key: 'active', label: t('shared.labels.active'), requireType: undefined },
 ]
 
 const properties = ref<PropertyInfo[]>([])
@@ -613,7 +613,11 @@ const updateNumberValue = (
   prop[field] = value
 }
 
-const updateBooleanValue = (index: number, key: string, value: boolean) => {
+const updateBooleanValue = (
+  index: number,
+  key: string,
+  value: boolean | null
+) => {
   const prop = ensureProp(index, key)
   prop.valueBoolean = value
 }
@@ -812,7 +816,7 @@ const startResize = (e: MouseEvent, key: string) => {
               </div>
               <Toggle
                 v-else-if="getPropertyType(col.key) === PropertyTypes.BOOLEAN"
-                :model-value="item.propertyValues[col.key]?.valueBoolean || false"
+                :model-value="item.propertyValues[col.key]?.valueBoolean ?? null"
                 @update:modelValue="(value) => updateBooleanValue(index, col.key, value)"
               />
               <div


### PR DESCRIPTION
## Summary
- Show validation ring for unset boolean values by binding null to toggles in VariationsBulkEdit
- Allow null boolean updates and add optional requireType to base columns

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acd10cf2e0832e8fdf9f1a18227908

## Summary by Sourcery

Enable handling of null boolean values in the variation bulk edit toggles and add optional requireType to base columns.

Enhancements:
- Support null boolean values in bulk edit toggles by extending updateBooleanValue and binding null to the model value
- Add optional requireType field to base column definitions