### PR TITLE
Handle removal of variation property select values

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -37,7 +37,7 @@ const { t } = useI18n()
 
 const language = ref<string | null>(null)
 
-const baseColumns = [
+const baseColumns: { key: string; label: string; requireType?: string }[] = [
   { key: 'name', label: t('shared.labels.name') },
   { key: 'sku', label: t('shared.labels.sku') },
   { key: 'active', label: t('shared.labels.active') },
@@ -86,9 +86,21 @@ const copyValue = (from: number, to: number, key: string) => {
   const source = variations.value[from]
   const target = variations.value[to]
   if (!target.propertyValues) target.propertyValues = {}
-  target.propertyValues[key] = JSON.parse(
-    JSON.stringify(source.propertyValues[key] || {})
-  )
+  const src = source.propertyValues?.[key]
+  if (
+    !src ||
+    (src.valueSelect == null &&
+      (!src.valueMultiSelect || !src.valueMultiSelect.length) &&
+      src.valueInt === undefined &&
+      src.valueFloat === undefined &&
+      src.valueBoolean === undefined &&
+      !src.translation?.valueText &&
+      !src.translation?.valueDescription)
+  ) {
+    delete target.propertyValues[key]
+  } else {
+    target.propertyValues[key] = JSON.parse(JSON.stringify(src))
+  }
 }
 
 const startDragFill = (row: number, col: string) => {
@@ -594,13 +606,23 @@ const ensureProp = (index: number, key: string) => {
 }
 
 const updateSelectValue = (index: number, key: string, value: any) => {
+  const item = variations.value[index]
+  if (!value) {
+    if (item.propertyValues[key]) delete item.propertyValues[key]
+    return
+  }
   const prop = ensureProp(index, key)
-  prop.valueSelect = value ? { id: value } : null
+  prop.valueSelect = { id: value }
 }
 
 const updateMultiSelectValue = (index: number, key: string, value: any[]) => {
+  const item = variations.value[index]
+  if (!value || !value.length) {
+    if (item.propertyValues[key]) delete item.propertyValues[key]
+    return
+  }
   const prop = ensureProp(index, key)
-  prop.valueMultiSelect = value ? value.map((id) => ({ id })) : []
+  prop.valueMultiSelect = value.map((id) => ({ id }))
 }
 
 const updateNumberValue = (


### PR DESCRIPTION
## Summary
- Delete select or multiselect variation property when value cleared instead of updating with null
- Prevent copying empty property values by removing target property
- Annotate base columns with optional requireType to satisfy type checking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acd1be8ea4832eabfcd8b6cf458b5f