### PR TITLE
Fix history and save state in variations bulk edit

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -52,6 +52,7 @@ const clipboard = ref<{ col: string; value: any } | null>(null)
 const history = ref<any[]>([])
 const redoStack = ref<any[]>([])
 const skipHistory = ref(false)
+const lastSnapshot = ref(JSON.stringify(variations.value))
 const canUndo = computed(() => history.value.length > 0)
 const canRedo = computed(() => redoStack.value.length > 0)
 
@@ -539,12 +540,13 @@ const computeChanges = () => {
 
 watch(
   variations,
-  (newVal, oldVal) => {
+  (newVal) => {
     if (!skipHistory.value) {
-      history.value.push(JSON.parse(JSON.stringify(oldVal)))
+      history.value.push(JSON.parse(lastSnapshot.value))
       if (history.value.length > 20) history.value.shift()
       redoStack.value = []
     }
+    lastSnapshot.value = JSON.stringify(toRaw(newVal))
     computeChanges()
   },
   { deep: true }
@@ -571,6 +573,7 @@ const redo = () => {
 const clearHistory = () => {
   history.value = []
   redoStack.value = []
+  lastSnapshot.value = JSON.stringify(variations.value)
 }
 
 const hasChanges = computed(


### PR DESCRIPTION
## Summary
- Track previous variation snapshots to fix undo/redo history
- Reset history snapshot after clearing changes so save button disables correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acd80cd7a0832e80b43c80e5ce8e09

## Summary by Sourcery

Fix undo/redo history tracking and save state in the variations bulk edit by introducing a dedicated snapshot ref and resetting it on history clear

Bug Fixes:
- Use a lastSnapshot ref to capture and replay the correct previous variation state for history operations
- Reset lastSnapshot when clearing history to properly disable the save button