### PR TITLE
feat: add detailed property update toasts

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -183,7 +183,7 @@ const handleKeydown = (e: KeyboardEvent) => {
         col,
         value: JSON.parse(JSON.stringify(value ?? null)),
       }
-      Toast.success('Copied')
+      Toast.success(t('products.products.alert.toast.copied'))
     }
     e.preventDefault()
   } else if (e.ctrlKey && e.key.toLowerCase() === 'v') {
@@ -201,10 +201,10 @@ const handleKeydown = (e: KeyboardEvent) => {
               JSON.stringify(clipboard.value.value)
             )
           }
-          Toast.success('Pasted')
+          Toast.success(t('products.products.alert.toast.pasted'))
         }
       } else {
-        Toast.error('Cannot paste to different column')
+        Toast.error(t('products.products.alert.toast.pasteDifferentColumn'))
       }
     }
     e.preventDefault()
@@ -559,6 +559,7 @@ const undo = () => {
   const prev = history.value.pop()
   variations.value = JSON.parse(JSON.stringify(prev))
   skipHistory.value = false
+  Toast.info(t('products.products.alert.toast.undo'))
 }
 
 const redo = () => {
@@ -568,6 +569,7 @@ const redo = () => {
   const next = redoStack.value.pop()
   variations.value = JSON.parse(JSON.stringify(next))
   skipHistory.value = false
+  Toast.info(t('products.products.alert.toast.redo'))
 }
 
 const clearHistory = () => {
@@ -581,17 +583,20 @@ const hasChanges = computed(
 )
 
 const save = async () => {
-  if (toCreate.value.length)
+  const createdCount = toCreate.value.length
+  const updatedCount = toUpdate.value.length
+  const deletedCount = toDelete.value.length
+  if (createdCount)
     await apolloClient.mutate({
       mutation: bulkCreateProductPropertiesMutation,
       variables: { data: toCreate.value },
     })
-  if (toUpdate.value.length)
+  if (updatedCount)
     await apolloClient.mutate({
       mutation: bulkUpdateProductPropertiesMutation,
       variables: { data: toUpdate.value },
     })
-  if (toDelete.value.length)
+  if (deletedCount)
     await apolloClient.mutate({
       mutation: deleteProductPropertiesMutation,
       variables: { ids: toDelete.value },
@@ -599,6 +604,24 @@ const save = async () => {
   originalVariations.value = JSON.parse(JSON.stringify(variations.value))
   computeChanges()
   clearHistory()
+  if (createdCount)
+    Toast.success(
+      t('products.products.alert.toast.createdProductProperties', {
+        count: createdCount,
+      })
+    )
+  if (updatedCount)
+    Toast.success(
+      t('products.products.alert.toast.updatedProductProperties', {
+        count: updatedCount,
+      })
+    )
+  if (deletedCount)
+    Toast.success(
+      t('products.products.alert.toast.deletedProductProperties', {
+        count: deletedCount,
+      })
+    )
 }
 
 defineExpose({ save, hasChanges })

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -935,11 +935,19 @@
         "sameProductType": "Same product type only"
       },
       "alert": {
-        "toast": {
-          "bulkDeleteSuccess": "Products deleted successfully.",
-          "bulkDeleteError": "Failed to delete products. Please try again."
-        }
-      },
+      "toast": {
+        "bulkDeleteSuccess": "Products deleted successfully.",
+        "bulkDeleteError": "Failed to delete products. Please try again.",
+        "copied": "Copied",
+        "pasted": "Pasted",
+        "pasteDifferentColumn": "Cannot paste to different column",
+        "undo": "Undid last change",
+        "redo": "Redid last change",
+        "createdProductProperties": "Created {count} product properties.",
+        "updatedProductProperties": "Updated {count} product properties.",
+        "deletedProductProperties": "Deleted {count} product properties."
+      }
+    },
       "tabs": {
         "content": "Content",
         "aliasProducts": "Alias Products",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -636,6 +636,18 @@
         "dragAndDrop": "Versleep de items, of klik op ➕ om items toe te voegen",
         "noVariationsLeft": "Er zijn geen producten meer om toe te voegen"
       },
+      "alert": {
+        "toast": {
+          "copied": "Gekopieerd",
+          "pasted": "Geplakt",
+          "pasteDifferentColumn": "Kan niet plakken naar een andere kolom",
+          "undo": "Laatste wijziging ongedaan gemaakt",
+          "redo": "Laatste wijziging opnieuw toegepast",
+          "createdProductProperties": "{count} producteigenschappen aangemaakt.",
+          "updatedProductProperties": "{count} producteigenschappen bijgewerkt.",
+          "deletedProductProperties": "{count} producteigenschappen verwijderd."
+        }
+      },
       "tabs": {
         "content": "Inhoud",
         "variations": "Variaties",


### PR DESCRIPTION
## Summary
- add info toasts for undo and redo actions
- report counts of created, updated, deleted product properties after save
- localize variation bulk edit toast messages

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68acdb3c221c832eb3421f613606f214

## Summary by Sourcery

Add localized toast notifications for copy, paste, undo/redo, and detailed property change counts in the variations bulk edit workflow

New Features:
- Localize copy, paste, and error toasts in the variations bulk edit tab
- Show info toasts for undo and redo actions
- Display localized success toasts with counts of created, updated, and deleted product properties after saving changes