### PR TITLE
Fix undo/redo history handling in variation bulk edit

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, computed, ref, onMounted, watch, toRaw, onBeforeUnmount } from 'vue'
+import { reactive, computed, ref, onMounted, watch, toRaw, onBeforeUnmount, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Product } from '../../../../../../configs'
 import { bundleVariationsQuery, configurableVariationsQuery } from '../../../../../../../../../shared/api/queries/products.js'
@@ -558,7 +558,9 @@ const undo = () => {
   redoStack.value.push(JSON.parse(JSON.stringify(variations.value)))
   const prev = history.value.pop()
   variations.value = JSON.parse(JSON.stringify(prev))
-  skipHistory.value = false
+  nextTick(() => {
+    skipHistory.value = false
+  })
   Toast.info(t('products.products.alert.toast.undo'))
 }
 
@@ -568,7 +570,9 @@ const redo = () => {
   history.value.push(JSON.parse(JSON.stringify(variations.value)))
   const next = redoStack.value.pop()
   variations.value = JSON.parse(JSON.stringify(next))
-  skipHistory.value = false
+  nextTick(() => {
+    skipHistory.value = false
+  })
   Toast.info(t('products.products.alert.toast.redo'))
 }
 


### PR DESCRIPTION
## Summary
- ensure skipHistory resets after nextTick to preserve undo/redo stacks
- expose nextTick from Vue for proper history control

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ace0e62654832eaec2c88b4c58842b

## Summary by Sourcery

Ensure undo and redo operations reset the skipHistory flag after a nextTick to correctly maintain the history stacks by importing and using Vue's nextTick.

Bug Fixes:
- Wrap skipHistory reset in nextTick in both undo and redo handlers to prevent premature history skipping and maintain correct undo/redo stacks

Enhancements:
- Import nextTick from Vue to enable deferred history reset after state updates