### PR TITLE
feat: add undo redo keyboard shortcuts

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -185,6 +185,19 @@ const handleKeydown = (e: KeyboardEvent) => {
     target.isContentEditable
   )
     return
+  if (e.ctrlKey) {
+    const key = e.key.toLowerCase()
+    if (key === 'z') {
+      undo()
+      e.preventDefault()
+      return
+    }
+    if (key === 'x') {
+      redo()
+      e.preventDefault()
+      return
+    }
+  }
   const { row, col } = selectedCell.value
   if (row === null || col === null) return
 


### PR DESCRIPTION
## Summary
- add Ctrl+Z and Ctrl+X keyboard shortcuts for undo and redo in VariationsBulkEdit

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad7826b858832e925262d4daab9f84