### PR TITLE
Sort Amazon marketplaces by default per sales channel

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonMarketplaceTabs.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonMarketplaceTabs.vue
@@ -22,7 +22,10 @@ const groupedViews = computed(() => {
     if (!groups[scId]) groups[scId] = [];
     groups[scId].push(view);
   });
-  return Object.entries(groups).map(([salesChannelId, views]) => ({ salesChannelId, views }));
+  return Object.entries(groups).map(([salesChannelId, views]) => ({
+    salesChannelId,
+    views: views.sort((a, b) => Number(b.isDefault) - Number(a.isDefault)),
+  }));
 });
 </script>
 


### PR DESCRIPTION
## Summary
- Sort Amazon marketplace tabs so each sales channel shows its default marketplace first

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad94d79c74832ea746c2742c0aaefc

## Summary by Sourcery

Enhancements:
- Sort the views array by isDefault flag so default marketplaces appear at the top