### PR TITLE
Improve variation selector search and layout

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 
 import { ref, onMounted, watch } from 'vue';
+import debounce from 'lodash.debounce';
 import { Product } from "../../../../../../configs";
 import { useI18n } from "vue-i18n";
 import { ProductType, variationTypes } from "../../../../../../../../../shared/utils/constants";
@@ -15,6 +16,7 @@ const { t } = useI18n();
 const props = defineProps<{ product: Product, form: VariationForm, variationIds: string[] }>();
 const variations = ref([]);
 const loading = ref(false);
+const search = ref('');
 
 const cleanedData = (rawData) => {
   return rawData?.edges ? rawData.edges.map(edge => edge.node) : rawData;
@@ -39,18 +41,20 @@ const fetchData = async () => {
       typeFilter = variationTypes;
   }
 
+  const filter: any = {
+    NOT: { id: { inList: props.variationIds } },
+    type: { inList: typeFilter },
+  };
+
+  if (search.value) {
+    filter.search = search.value;
+  }
 
   const { data } = await apolloClient.query({
     query: productsQuery,
-    variables: {
-      filter: {
-        NOT: { id: { inList: props.variationIds } },
-        type: { inList: typeFilter },
-      },
-    },
+    variables: { filter },
     fetchPolicy: 'network-only',
   });
-
 
   if (data) {
     variations.value = cleanedData(data.products);
@@ -59,6 +63,11 @@ const fetchData = async () => {
   loading.value = false;
 
 };
+
+const handleInput = debounce((value: string) => {
+  search.value = value;
+  fetchData();
+}, 500);
 
 onMounted(fetchData);
 
@@ -74,7 +83,7 @@ watch(() => props.variationIds, fetchData, { deep: true });
     </svg>
   </Flex>
   <Flex v-else gap="2">
-    <FlexCell>
+    <FlexCell grow>
       <Selector v-if="variations.length > 0"
                 v-model="form.variation"
                 :options="variations"
@@ -84,7 +93,8 @@ watch(() => props.variationIds, fetchData, { deep: true });
                 :removable="false"
                 :placeholder="t('shared.placeholders.product')"
                 filterable
-                class="min-w-[200px] mr-2" />
+                class="mr-2 w-full"
+                @searched="handleInput" />
     </FlexCell>
     <FlexCell v-if="product.type !== ProductType.Configurable">
       <TextInput v-model="form.quantity" float :placeholder="t('shared.placeholders.quantity')" class="w-32" />


### PR DESCRIPTION
## Summary
- allow variation selector to expand fully and grow with container
- fetch variation options based on search term for SKU/name lookup

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68adb2b2c4f4832e9d6db248a4e8c780

## Summary by Sourcery

Enable dynamic search and responsive layout for the variation selector

New Features:
- Add debounced search input to fetch variations by SKU or name

Enhancements:
- Include search term in Apollo GraphQL filter for variation lookup
- Replace static filter variables with a dynamic filter object
- Update selector layout to fully expand by using FlexCell grow and full-width styling