### PR TITLE
feat: make FieldQuery live update configurable

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -377,6 +377,7 @@ const selectFields = computed<Record<string, QueryFormField>>(() => {
         queryVariables: { filter: { property: { id: { exact: p.id } } }, first: 100 },
         multiple: p.type === PropertyTypes.MULTISELECT,
         removable: true,
+        isLiveUpdate: false,
       }
     }
   })

--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -25,7 +25,7 @@ const loading = ref(true);
 const rawDataRef: Ref<any> = ref([]);
 const cleanedData: Ref<any[]> = ref([]);
 const selectedValue = ref(props.modelValue);
-const isLiveUpdate = ref(true); // in order to be live updates this always have to be true
+const isLiveUpdate = ref(props.field.isLiveUpdate ?? true);
 
 
 const dropdownPosition = props.field.dropdownPosition || 'top';

--- a/src/shared/components/organisms/general-form/formConfig.ts
+++ b/src/shared/components/organisms/general-form/formConfig.ts
@@ -166,6 +166,7 @@ export interface QueryFormField extends BaseFormField {
   filterable?: boolean;
   removable?: boolean;
   limit?: number;
+  isLiveUpdate?: boolean;
   createOnFlyConfig?: CreateOnTheFly;
   setDefaultKey?: string;
   defaultExpectedValue?: any; // if we have a default key but we don't give the value the default will be true


### PR DESCRIPTION
## Summary
- allow FieldQuery to use `isLiveUpdate` from field props with true default
- expose `isLiveUpdate` option on `QueryFormField`
- disable live updates for variation select fields to avoid unintended saves

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68adb8d8edf4832e86abdd051936f64b

## Summary by Sourcery

Enable configurable live updates for field queries by adding an isLiveUpdate prop with a true default, expose this option on the QueryFormField interface, and disable live updates for variation select fields to prevent accidental saves.

New Features:
- Allow FieldQuery to use isLiveUpdate from field props with a default value of true
- Expose the isLiveUpdate option on the QueryFormField interface

Bug Fixes:
- Disable live updates for variation select fields to avoid unintended saves