### PR TITLE
Add option to disable query field auto-completion

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -377,6 +377,7 @@ const selectFields = computed<Record<string, QueryFormField>>(() => {
         queryVariables: { filter: { property: { id: { exact: p.id } } }, first: 100 },
         multiple: p.type === PropertyTypes.MULTISELECT,
         removable: true,
+        autocompleteIfOneResult: false,
       }
     }
   })

--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -165,7 +165,12 @@ function processAndCleanData(rawData: any) {
 
   cleanedData.value = [...newData, ...preservedItems];
 
-  if (!props.field.optional && cleanedData.value.length === 1 && (selectedValue.value === undefined || selectedValue.value === null)) {
+  if (
+    props.field.autocompleteIfOneResult !== false &&
+    !props.field.optional &&
+    cleanedData.value.length === 1 &&
+    (selectedValue.value === undefined || selectedValue.value === null)
+  ) {
     if (props.field.multiple) {
       updateValue([cleanedData.value[0][props.field.valueBy]]);
     } else {

--- a/src/shared/components/organisms/general-form/formConfig.ts
+++ b/src/shared/components/organisms/general-form/formConfig.ts
@@ -166,6 +166,7 @@ export interface QueryFormField extends BaseFormField {
   filterable?: boolean;
   removable?: boolean;
   limit?: number;
+  autocompleteIfOneResult?: boolean;
   isLiveUpdate?: boolean;
   createOnFlyConfig?: CreateOnTheFly;
   setDefaultKey?: string;


### PR DESCRIPTION
## Summary
- support `autocompleteIfOneResult` config for query fields
- disable auto-completing property selects in VariationsBulkEdit

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adbba69958832ea6b459fd08fe5a91