### PR TITLE
Ensure default Amazon marketplace tab is selected

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -62,7 +62,8 @@ onMounted(fetchViews);
 
 watch(views, (newViews) => {
   if (!selectedViewId.value && newViews.length) {
-    selectedViewId.value = newViews[0].id;
+    const defaultView = newViews.find((v: any) => v.isDefault) || newViews[0];
+    selectedViewId.value = defaultView.id;
   }
 });
 


### PR DESCRIPTION
## Summary
- default Amazon marketplace view is now preselected when opening the tab

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68addd54ddf4832e8f515f234628acf0

## Summary by Sourcery

Enhancements:
- Select the marketplace view with isDefault flag (or fall back to the first view) instead of always choosing the first view