### PR TITLE
Bulk Update Variations Feature and more

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -62,7 +62,8 @@ onMounted(fetchViews);
 
 watch(views, (newViews) => {
   if (!selectedViewId.value && newViews.length) {
-    selectedViewId.value = newViews[0].id;
+    const defaultView = newViews.find((v: any) => v.isDefault) || newViews[0];
+    selectedViewId.value = defaultView.id;
   }
 });
 

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonMarketplaceTabs.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonMarketplaceTabs.vue
@@ -22,7 +22,10 @@ const groupedViews = computed(() => {
     if (!groups[scId]) groups[scId] = [];
     groups[scId].push(view);
   });
-  return Object.entries(groups).map(([salesChannelId, views]) => ({ salesChannelId, views }));
+  return Object.entries(groups).map(([salesChannelId, views]) => ({
+    salesChannelId,
+    views: views.sort((a, b) => Number(b.isDefault) - Number(a.isDefault)),
+  }));
 });
 </script>
 

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonStatusSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonStatusSection.vue
@@ -56,6 +56,7 @@ const formatDate = (dateString?: string | null) => {
           @done="() => emit('resync-success')"
           @error="(e) => emit('error', e)"
         >
+
           <template #default="{ mutate, loading }">
             <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
               {{ t('shared.button.resync') }}

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
@@ -158,7 +158,7 @@ const showAlert = computed(
           v-model="selectedTheme"
           label-by="name"
           value-by="id"
-          :filterable="false"
+          :filterable="true"
           :placeholder="t('shared.placeholders.select')"
         />
       </FlexCell>

--- a/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
@@ -1,20 +1,25 @@
 <script setup lang="ts">
-
-import {ref} from 'vue';
-import {Product} from "../../../../configs";
-import {useI18n} from "vue-i18n";
+import { ref } from 'vue';
+import { Product } from "../../../../configs";
 import TabContentTemplate from "../TabContentTemplate.vue";
 import { SearchConfig } from "../../../../../../../shared/components/organisms/general-search/searchConfig";
-import {  bundleVariationsQuery, configurableVariationsQuery } from "../../../../../../../shared/api/queries/products.js";
+import { bundleVariationsQuery, configurableVariationsQuery } from "../../../../../../../shared/api/queries/products.js";
 import { ProductType } from "../../../../../../../shared/utils/constants";
+import { Icon } from "../../../../../../../shared/components/atoms/icon";
 import VariationsList from "./containers/variations-list/VariationsList.vue";
 import VariationCreate from "./containers/variation-create/VariationCreate.vue";
+import VariationsBulkEdit from "./containers/variations-bulk-edit/VariationsBulkEdit.vue";
 
-const { t } = useI18n();
 
 const props = defineProps<{ product: Product }>();
 const ids = ref([]);
 const refetchNeeded = ref(false);
+const mode = ref<'list' | 'edit'>('list');
+
+const tabs: { key: 'list' | 'edit'; label: string; icon: string }[] = [
+  { key: 'list', label: 'List', icon: 'list' },
+  { key: 'edit', label: 'Edit', icon: 'pen-to-square' },
+];
 
 const searchConfig: SearchConfig = {
   search: true,
@@ -73,18 +78,40 @@ const getQueryKey = () => {
 
 <template>
   <TabContentTemplate>
-
     <template v-slot:content>
-      <VariationsList :product="product"
-                      :query-key="getQueryKey()"
-                      :list-query="getQuery()"
-                      :search-config="searchConfig"
-                      :refetch-needed="refetchNeeded"
-                      @refetched="handleRefeched"
-                      @update-ids="getIds" />
+      <div class="flex">
+        <div class="w-24 border-r border-gray-200 pr-4 space-y-2">
+          <div
+            v-for="tab in tabs"
+            :key="tab.key"
+            class="cursor-pointer flex items-center gap-2 p-2 rounded-md"
+            :class="{ 'bg-primary text-white': mode === tab.key }"
+            @click="mode = tab.key"
+          >
+            <Icon :name="tab.icon" class="w-4 h-4" />
+            <span>{{ tab.label }}</span>
+          </div>
+        </div>
 
-      <div v-if="product.type !== ProductType.Alias" class="mt-2">
-        <VariationCreate :product="product" :variation-ids="ids" @variation-added="handleVariationAdded" />
+        <div class="flex-1 min-w-0 pl-4">
+          <template v-if="mode === 'list'">
+            <VariationsList
+              :product="product"
+              :query-key="getQueryKey()"
+              :list-query="getQuery()"
+              :search-config="searchConfig"
+              :refetch-needed="refetchNeeded"
+              @refetched="handleRefeched"
+              @update-ids="getIds"
+            />
+            <div v-if="product.type !== ProductType.Alias" class="mt-2">
+              <VariationCreate :product="product" :variation-ids="ids" @variation-added="handleVariationAdded" />
+            </div>
+          </template>
+          <template v-else>
+            <VariationsBulkEdit :product="product" />
+          </template>
+        </div>
       </div>
     </template>
   </TabContentTemplate>

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 
 import { ref, onMounted, watch } from 'vue';
+import debounce from 'lodash.debounce';
 import { Product } from "../../../../../../configs";
 import { useI18n } from "vue-i18n";
 import { ProductType, variationTypes } from "../../../../../../../../../shared/utils/constants";
@@ -15,6 +16,7 @@ const { t } = useI18n();
 const props = defineProps<{ product: Product, form: VariationForm, variationIds: string[] }>();
 const variations = ref([]);
 const loading = ref(false);
+const search = ref('');
 
 const cleanedData = (rawData) => {
   return rawData?.edges ? rawData.edges.map(edge => edge.node) : rawData;
@@ -39,18 +41,20 @@ const fetchData = async () => {
       typeFilter = variationTypes;
   }
 
+  const filter: any = {
+    NOT: { id: { inList: props.variationIds } },
+    type: { inList: typeFilter },
+  };
+
+  if (search.value) {
+    filter.search = search.value;
+  }
 
   const { data } = await apolloClient.query({
     query: productsQuery,
-    variables: {
-      filter: {
-        NOT: { id: { inList: props.variationIds } },
-        type: { inList: typeFilter },
-      },
-    },
+    variables: { filter },
     fetchPolicy: 'network-only',
   });
-
 
   if (data) {
     variations.value = cleanedData(data.products);
@@ -59,6 +63,11 @@ const fetchData = async () => {
   loading.value = false;
 
 };
+
+const handleInput = debounce((value: string) => {
+  search.value = value;
+  fetchData();
+}, 500);
 
 onMounted(fetchData);
 
@@ -74,7 +83,7 @@ watch(() => props.variationIds, fetchData, { deep: true });
     </svg>
   </Flex>
   <Flex v-else gap="2">
-    <FlexCell>
+    <FlexCell grow>
       <Selector v-if="variations.length > 0"
                 v-model="form.variation"
                 :options="variations"
@@ -84,7 +93,8 @@ watch(() => props.variationIds, fetchData, { deep: true });
                 :removable="false"
                 :placeholder="t('shared.placeholders.product')"
                 filterable
-                class="min-w-[200px] mr-2" />
+                class="mr-2 w-full"
+                @searched="handleInput" />
     </FlexCell>
     <FlexCell v-if="product.type !== ProductType.Configurable">
       <TextInput v-model="form.quantity" float :placeholder="t('shared.placeholders.quantity')" class="w-32" />

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
@@ -84,8 +84,7 @@ watch(() => props.variationIds, fetchData, { deep: true });
   </Flex>
   <Flex v-else gap="2">
     <FlexCell grow>
-      <Selector v-if="variations.length > 0"
-                v-model="form.variation"
+      <Selector v-model="form.variation"
                 :options="variations"
                 label-by="name"
                 value-by="id"
@@ -93,7 +92,7 @@ watch(() => props.variationIds, fetchData, { deep: true });
                 :removable="false"
                 :placeholder="t('shared.placeholders.product')"
                 filterable
-                class="mr-2 w-full"
+                class="min-w-96"
                 @searched="handleInput" />
     </FlexCell>
     <FlexCell v-if="product.type !== ProductType.Configurable">

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -377,6 +377,7 @@ const selectFields = computed<Record<string, QueryFormField>>(() => {
         queryVariables: { filter: { property: { id: { exact: p.id } } }, first: 100 },
         multiple: p.type === PropertyTypes.MULTISELECT,
         removable: true,
+        isLiveUpdate: false,
       }
     }
   })

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -377,6 +377,7 @@ const selectFields = computed<Record<string, QueryFormField>>(() => {
         queryVariables: { filter: { property: { id: { exact: p.id } } }, first: 100 },
         multiple: p.type === PropertyTypes.MULTISELECT,
         removable: true,
+        autocompleteIfOneResult: false,
       }
     }
   })

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -377,7 +377,6 @@ const selectFields = computed<Record<string, QueryFormField>>(() => {
         queryVariables: { filter: { property: { id: { exact: p.id } } }, first: 100 },
         multiple: p.type === PropertyTypes.MULTISELECT,
         removable: true,
-        isLiveUpdate: false,
       }
     }
   })

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -40,8 +40,8 @@ const { t } = useI18n()
 const language = ref<string | null>(null)
 
 const baseColumns: { key: string; label: string; requireType?: string }[] = [
-  { key: 'name', label: t('shared.labels.name') },
   { key: 'sku', label: t('shared.labels.sku') },
+  { key: 'name', label: t('shared.labels.name') },
   { key: 'active', label: t('shared.labels.active') },
 ]
 
@@ -941,7 +941,7 @@ const startResize = (e: MouseEvent, key: string) => {
               :key="col.key"
               class="px-2 py-1 text-sm font-medium text-gray-700 relative border-r border-gray-200"
               :class="[col.key === 'active' ? 'text-center' : 'text-left', col.key === 'sku' ? 'sticky z-10 bg-gray-100' : '']"
-              :style="[{ width: columnWidths[col.key] + 'px' }, col.key === 'sku' ? { left: columnWidths['name'] + 'px' } : {}]"
+              :style="[{ width: columnWidths[col.key] + 'px' }, col.key === 'sku' ? { left: 0 } : {}]"
             >
               <div class="flex items-center h-full">
                 <Icon
@@ -975,7 +975,7 @@ const startResize = (e: MouseEvent, key: string) => {
               ]"
               :style="[
                 { width: columnWidths[col.key] + 'px' },
-                col.key === 'sku' ? { left: columnWidths['name'] + 'px' } : {}
+                col.key === 'sku' ? { left: 0 } : {}
               ]"
               :data-row="index"
               :data-col="col.key"

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -25,6 +25,7 @@ import { translationLanguagesQuery } from '../../../../../../../../../shared/api
 import { bulkCreateProductPropertiesMutation, bulkUpdateProductPropertiesMutation, deleteProductPropertiesMutation } from '../../../../../../../../../shared/api/mutations/properties.js'
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import { format } from 'date-fns'
+import {selectValueOnTheFlyConfig} from "../../../../../../../../properties/property-select-values/configs";
 
 interface PropertyInfo {
   id: string
@@ -378,6 +379,7 @@ const selectFields = computed<Record<string, QueryFormField>>(() => {
         multiple: p.type === PropertyTypes.MULTISELECT,
         removable: true,
         autocompleteIfOneResult: false,
+        createOnFlyConfig: selectValueOnTheFlyConfig(t, p.id)
       }
     }
   })

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -185,6 +185,19 @@ const handleKeydown = (e: KeyboardEvent) => {
     target.isContentEditable
   )
     return
+  if (e.ctrlKey) {
+    const key = e.key.toLowerCase()
+    if (key === 'z') {
+      undo()
+      e.preventDefault()
+      return
+    }
+    if (key === 'x') {
+      redo()
+      e.preventDefault()
+      return
+    }
+  }
   const { row, col } = selectedCell.value
   if (row === null || col === null) return
 

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -949,7 +949,7 @@ const startResize = (e: MouseEvent, key: string) => {
                   name="circle-dot"
                   :class="[getIconColor(col.requireType), 'mr-1']"
                 />
-                <span class="block truncate" :title="col.label">{{ col.label }}</span>
+                <span class="block truncate" :title="col.label"><strong>{{ col.label }}</strong></span>
                 <span
                   class="resizer select-none"
                   @mousedown="(e) => startResize(e, col.key)"
@@ -1045,39 +1045,45 @@ const startResize = (e: MouseEvent, key: string) => {
                   class="relative cursor-pointer"
                   @dblclick="openTextModal(index, col.key)"
                 >
-                  <div class="border border-gray-300 p-1 h-8 overflow-hidden">
-                    {{
-                      shortenText(
-                        item.propertyValues[col.key]?.translation?.valueText || '',
-                        32
-                      )
-                    }}
+                  <div class="border border-gray-300 p-1 h-8 flex items-center justify-between">
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap pr-6">
+                      {{
+                        shortenText(
+                          item.propertyValues[col.key]?.translation?.valueText || '',
+                          16
+                        )
+                      }}
+                    </div>
+                    <Icon
+                      name="maximize"
+                      class="text-gray-400 cursor-pointer flex-shrink-0"
+                      @click.stop="openTextModal(index, col.key)"
+                    />
                   </div>
-                  <Icon
-                    name="maximize"
-                    class="absolute top-1 right-1 text-gray-400 cursor-pointer"
-                    @click.stop="openTextModal(index, col.key)"
-                  />
                 </div>
+
                 <div
                   v-else-if="getPropertyType(col.key) === PropertyTypes.DESCRIPTION"
                   class="relative cursor-pointer"
                   @dblclick="openDescriptionModal(index, col.key)"
                 >
-                  <div class="border border-gray-300 p-1 h-16 overflow-hidden">
-                    {{
-                      shortenText(
-                        item.propertyValues[col.key]?.translation?.valueDescription || '',
-                        32
-                      )
-                    }}
+                  <div class="border border-gray-300 p-1 h-16 flex justify-between">
+                    <div class="overflow-hidden break-words">
+                      {{
+                        shortenText(
+                          item.propertyValues[col.key]?.translation?.valueDescription || '',
+                          32
+                        )
+                      }}
+                    </div>
+                    <Icon
+                      name="maximize"
+                      class="text-gray-400 cursor-pointer flex-shrink-0 ml-1"
+                      @click.stop="openDescriptionModal(index, col.key)"
+                    />
                   </div>
-                  <Icon
-                    name="maximize"
-                    class="absolute top-1 right-1 text-gray-400 cursor-pointer"
-                    @click.stop="openDescriptionModal(index, col.key)"
-                  />
                 </div>
+
                 <Toggle
                   v-else-if="getPropertyType(col.key) === PropertyTypes.BOOLEAN"
                   :model-value="item.propertyValues[col.key]?.valueBoolean ?? null"

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -1,0 +1,1087 @@
+<script setup lang="ts">
+import { reactive, computed, ref, onMounted, watch, toRaw, onBeforeUnmount, nextTick } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { Product } from '../../../../../../configs'
+import { bundleVariationsQuery, configurableVariationsQuery } from '../../../../../../../../../shared/api/queries/products.js'
+import { ProductType, PropertyTypes, FieldType, ConfigTypes } from '../../../../../../../../../shared/utils/constants'
+import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
+import { TextInput } from "../../../../../../../../../shared/components/atoms/input-text";
+import { TextEditor } from "../../../../../../../../../shared/components/atoms/input-text-editor";
+import { Toggle } from "../../../../../../../../../shared/components/atoms/toggle";
+import { DateInput } from "../../../../../../../../../shared/components/atoms/input-date";
+import DateTimeInput from "../../../../../../../../../shared/components/atoms/input-date-time/DateTimeInput.vue";
+import { shortenText } from "../../../../../../../../../shared/utils";
+import { Modal } from "../../../../../../../../../shared/components/atoms/modal";
+import { Card } from "../../../../../../../../../shared/components/atoms/card";
+import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { LocalLoader } from "../../../../../../../../../shared/components/atoms/local-loader";
+import { FieldQuery } from "../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
+import { Selector } from "../../../../../../../../../shared/components/atoms/selector";
+import type { QueryFormField } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
+import { Pagination } from "../../../../../../../../../shared/components/molecules/pagination";
+import apolloClient from '../../../../../../../../../../apollo-client'
+import { propertiesQuery, productPropertiesQuery, productPropertiesRulesQuery, productPropertyTextTranslationsQuery, propertySelectValuesQuerySimpleSelector } from '../../../../../../../../../shared/api/queries/properties.js'
+import { translationLanguagesQuery } from '../../../../../../../../../shared/api/queries/languages.js'
+import { bulkCreateProductPropertiesMutation, bulkUpdateProductPropertiesMutation, deleteProductPropertiesMutation } from '../../../../../../../../../shared/api/mutations/properties.js'
+import { Toast } from "../../../../../../../../../shared/modules/toast";
+
+interface PropertyInfo {
+  id: string
+  name: string
+  type: string
+  requireType: string
+}
+
+const props = defineProps<{ product: Product }>()
+
+const { t } = useI18n()
+
+const language = ref<string | null>(null)
+
+const baseColumns: { key: string; label: string; requireType?: string }[] = [
+  { key: 'name', label: t('shared.labels.name') },
+  { key: 'sku', label: t('shared.labels.sku') },
+  { key: 'active', label: t('shared.labels.active') },
+]
+
+const properties = ref<PropertyInfo[]>([])
+const variations = ref<any[]>([])
+const originalVariations = ref<any[]>([])
+const loading = ref(true)
+const selectedCell = ref<{ row: number | null; col: string | null }>({ row: null, col: null })
+const clipboard = ref<{ col: string; value: any } | null>(null)
+const history = ref<any[]>([])
+const redoStack = ref<any[]>([])
+const skipHistory = ref(false)
+const lastSnapshot = ref(JSON.stringify(variations.value))
+const canUndo = computed(() => history.value.length > 0)
+const canRedo = computed(() => redoStack.value.length > 0)
+
+const pageInfo = ref<any | null>(null)
+const limit = ref(20)
+const perPageOptions = [
+  { name: '10', value: 10 },
+  { name: '20', value: 20 },
+  { name: '50', value: 50 },
+  { name: '100', value: 100 },
+]
+const fetchPaginationData = ref<Record<string, any>>({})
+fetchPaginationData.value['first'] = limit.value
+
+const columns = computed(() => [
+  ...baseColumns,
+  ...properties.value.map((p) => ({ key: p.id, label: p.name, requireType: p.requireType })),
+])
+
+const getIconColor = (requireType: string) => {
+  if (
+    [
+      ConfigTypes.REQUIRED,
+      ConfigTypes.REQUIRED_IN_CONFIGURATOR,
+      ConfigTypes.OPTIONAL_IN_CONFIGURATOR,
+    ].includes(requireType as ConfigTypes)
+  ) {
+    return 'text-red-500'
+  }
+  if (requireType === ConfigTypes.OPTIONAL) {
+    return 'text-orange-400'
+  }
+  return 'text-gray-400'
+}
+
+const selectCell = (rowIndex: number, colKey: string) => {
+  selectedCell.value = { row: rowIndex, col: colKey }
+}
+
+const dragState = reactive({
+  active: false,
+  startRow: null as number | null,
+  endRow: null as number | null,
+  col: '' as string,
+})
+
+const copyValue = (from: number, to: number, key: string) => {
+  const source = variations.value[from]
+  const target = variations.value[to]
+  if (!target.propertyValues) target.propertyValues = {}
+  const src = source.propertyValues?.[key]
+  if (
+    !src ||
+    (src.valueSelect == null &&
+      (!src.valueMultiSelect || !src.valueMultiSelect.length) &&
+      src.valueInt === undefined &&
+      src.valueFloat === undefined &&
+      src.valueBoolean === undefined &&
+      !src.translation?.valueText &&
+      !src.translation?.valueDescription)
+  ) {
+    delete target.propertyValues[key]
+  } else {
+    target.propertyValues[key] = JSON.parse(JSON.stringify(src))
+  }
+}
+
+const startDragFill = (row: number, col: string) => {
+  if (['name', 'sku', 'active'].includes(col)) return
+  dragState.active = true
+  dragState.startRow = row
+  dragState.endRow = row
+  dragState.col = col
+  document.addEventListener('mousemove', onDragFill)
+  document.addEventListener('mouseup', endDragFill)
+}
+
+const onDragFill = (e: MouseEvent) => {
+  const cell = (e.target as HTMLElement).closest('td')
+  if (!cell) return
+  const rowAttr = cell.getAttribute('data-row')
+  const colAttr = cell.getAttribute('data-col')
+  if (colAttr === dragState.col && rowAttr) {
+    dragState.endRow = Number(rowAttr)
+  }
+}
+
+const endDragFill = () => {
+  document.removeEventListener('mousemove', onDragFill)
+  document.removeEventListener('mouseup', endDragFill)
+  if (
+    dragState.active &&
+    dragState.startRow !== null &&
+    dragState.endRow !== null &&
+    dragState.col
+  ) {
+    const start = dragState.startRow
+    const end = dragState.endRow
+    const [from, to] = start < end ? [start, end] : [end, start]
+    for (let i = from; i <= to; i++) {
+      if (i === start) continue
+      copyValue(start, i, dragState.col)
+    }
+  }
+  dragState.active = false
+  dragState.startRow = dragState.endRow = null
+  dragState.col = ''
+}
+
+const isInDragRange = (row: number, col: string) => {
+  if (
+    !dragState.active ||
+    dragState.col !== col ||
+    dragState.startRow === null ||
+    dragState.endRow === null
+  )
+    return false
+  const [from, to] =
+    dragState.startRow < dragState.endRow
+      ? [dragState.startRow, dragState.endRow]
+      : [dragState.endRow, dragState.startRow]
+  return row >= from && row <= to
+}
+
+const handleKeydown = (e: KeyboardEvent) => {
+  const target = e.target as HTMLElement
+  if (
+    ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) ||
+    target.isContentEditable
+  )
+    return
+  const { row, col } = selectedCell.value
+  if (row === null || col === null) return
+
+  if (e.ctrlKey && e.key.toLowerCase() === 'c') {
+    if (!['name', 'sku', 'active'].includes(col)) {
+      const value = variations.value[row]?.propertyValues?.[col]
+      clipboard.value = {
+        col,
+        value: JSON.parse(JSON.stringify(value ?? null)),
+      }
+      Toast.success(t('products.products.alert.toast.copied'))
+    }
+    e.preventDefault()
+  } else if (e.ctrlKey && e.key.toLowerCase() === 'v') {
+    if (clipboard.value) {
+      if (clipboard.value.col === col) {
+        if (!['name', 'sku', 'active'].includes(col)) {
+          if (clipboard.value.value === null) {
+            if (variations.value[row].propertyValues) {
+              delete variations.value[row].propertyValues[col]
+            }
+          } else {
+            if (!variations.value[row].propertyValues)
+              variations.value[row].propertyValues = {}
+            variations.value[row].propertyValues[col] = JSON.parse(
+              JSON.stringify(clipboard.value.value)
+            )
+          }
+          Toast.success(t('products.products.alert.toast.pasted'))
+        }
+      } else {
+        Toast.error(t('products.products.alert.toast.pasteDifferentColumn'))
+      }
+    }
+    e.preventDefault()
+  } else if (
+    (e.key === 'Delete' || e.key === 'Backspace') &&
+    !e.ctrlKey &&
+    !e.metaKey &&
+    !e.shiftKey &&
+    !e.altKey
+  ) {
+    if (!['name', 'sku', 'active'].includes(col)) {
+      if (variations.value[row].propertyValues) {
+        delete variations.value[row].propertyValues[col]
+      }
+    }
+    e.preventDefault()
+  } else if (!e.ctrlKey && !e.metaKey) {
+    switch (e.key) {
+      case 'ArrowUp':
+        if (row > 0) selectedCell.value.row = row - 1
+        e.preventDefault()
+        break
+      case 'ArrowDown':
+        if (row < variations.value.length - 1)
+          selectedCell.value.row = row + 1
+        e.preventDefault()
+        break
+      case 'ArrowLeft': {
+        const colIndex = columns.value.findIndex((c) => c.key === col)
+        if (colIndex > 0) selectedCell.value.col = columns.value[colIndex - 1].key
+        e.preventDefault()
+        break
+      }
+      case 'ArrowRight': {
+        const colIndex = columns.value.findIndex((c) => c.key === col)
+        if (colIndex < columns.value.length - 1)
+          selectedCell.value.col = columns.value[colIndex + 1].key
+        e.preventDefault()
+        break
+      }
+    }
+  }
+}
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mousemove', onDragFill)
+  document.removeEventListener('mouseup', endDragFill)
+  window.removeEventListener('keydown', handleKeydown)
+})
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown)
+})
+
+const columnWidths = reactive<Record<string, number>>({})
+watch(
+  columns,
+  (cols) => {
+    cols.forEach((col) => {
+      if (!columnWidths[col.key]) columnWidths[col.key] = 150
+    })
+  },
+  { immediate: true }
+)
+
+const isAlias = computed(() => props.product.type === ProductType.Alias)
+const parentId = computed(() => (isAlias.value ? props.product.aliasParentProduct.id : props.product.id))
+const parentType = computed(() => (isAlias.value ? props.product.aliasParentProduct.type : props.product.type))
+const query = computed(() =>
+  parentType.value === ProductType.Bundle ? bundleVariationsQuery : configurableVariationsQuery
+)
+const queryKey = computed(() =>
+  parentType.value === ProductType.Bundle ? 'bundleVariations' : 'configurableVariations'
+)
+
+const fetchProperties = async () => {
+  const { data: typeData } = await apolloClient.query({
+    query: propertiesQuery,
+    variables: { filter: { isProductType: { exact: true } } },
+    fetchPolicy: 'network-only',
+  })
+  if (!typeData?.properties?.edges?.length) return
+  const typePropertyId = typeData.properties.edges[0].node.id
+
+  const { data: valueData } = await apolloClient.query({
+    query: productPropertiesQuery,
+    variables: {
+      filter: {
+        property: { id: { exact: typePropertyId } },
+        product: { id: { exact: parentId.value } },
+      },
+    },
+    fetchPolicy: 'network-only',
+  })
+  if (!valueData?.productProperties?.edges?.length) return
+  const productTypeValueId = valueData.productProperties.edges[0].node.valueSelect?.id
+  if (!productTypeValueId) return
+
+  const { data: ruleData } = await apolloClient.query({
+    query: productPropertiesRulesQuery,
+    variables: { filter: { productType: { id: { exact: productTypeValueId } } } },
+    fetchPolicy: 'network-only',
+  })
+  if (!ruleData?.productPropertiesRules?.edges?.length) return
+  const items = ruleData.productPropertiesRules.edges[0].node.items
+  properties.value = items.map((item: any) => ({
+    id: item.property.id,
+    name: item.property.name,
+    type: item.property.type,
+    requireType: item.type,
+  }))
+}
+
+const selectFields = computed<Record<string, QueryFormField>>(() => {
+  const fields: Record<string, QueryFormField> = {}
+  properties.value.forEach((p) => {
+    if ([PropertyTypes.SELECT, PropertyTypes.MULTISELECT].includes(p.type)) {
+      fields[p.id] = {
+        type: FieldType.Query,
+        name: p.id,
+        labelBy: 'value',
+        valueBy: 'id',
+        query: propertySelectValuesQuerySimpleSelector,
+        dataKey: 'propertySelectValues',
+        isEdge: true,
+        queryVariables: { filter: { property: { id: { exact: p.id } } }, first: 100 },
+        multiple: p.type === PropertyTypes.MULTISELECT,
+        removable: true,
+      }
+    }
+  })
+  return fields
+})
+
+const fetchVariationProperties = async (variationId: string) => {
+  const { data } = await apolloClient.query({
+    query: productPropertiesQuery,
+    variables: { filter: { product: { id: { exact: variationId } } }, first: 100 },
+    fetchPolicy: 'network-only',
+  })
+  const edges = data?.productProperties?.edges ?? []
+  const propertyValues: Record<string, any> = {}
+  await Promise.all(
+    edges.map(async ({ node }: any) => {
+      let translation = null
+      if ([PropertyTypes.TEXT, PropertyTypes.DESCRIPTION].includes(node.property.type)) {
+        const { data: tData } = await apolloClient.query({
+          query: productPropertyTextTranslationsQuery,
+          variables: {
+            filter: {
+              productProperty: { id: { exact: node.id } },
+              language: { exact: language.value },
+            },
+          },
+          fetchPolicy: 'network-only',
+        })
+        const tNode = tData?.productPropertyTextTranslations?.edges?.[0]?.node
+        translation = tNode ? { ...tNode } : { language: language.value }
+      }
+      propertyValues[node.property.id] = { ...node, translation }
+    })
+  )
+  return propertyValues
+}
+
+const fetchVariations = async () => {
+  const { data } = await apolloClient.query({
+    query: query.value,
+    variables: {
+      filter: { parent: { id: { exact: parentId.value } } },
+      ...fetchPaginationData.value,
+    },
+    fetchPolicy: 'network-only',
+  })
+  const edges = data?.[queryKey.value]?.edges ?? []
+  pageInfo.value = data?.[queryKey.value]?.pageInfo ?? null
+  variations.value = await Promise.all(
+    edges.map(async ({ node }: any) => ({
+      ...node,
+      propertyValues: await fetchVariationProperties(node.variation.id),
+    }))
+  )
+}
+
+watch(language, async () => {
+  skipHistory.value = true
+  await fetchVariations()
+  originalVariations.value = JSON.parse(JSON.stringify(variations.value))
+  computeChanges()
+  clearHistory()
+  skipHistory.value = false
+})
+
+const fetchDefaultLanguage = async () => {
+  const { data } = await apolloClient.query({
+    query: translationLanguagesQuery,
+    fetchPolicy: 'network-only',
+  })
+  language.value = data?.translationLanguages?.defaultLanguage?.code || null
+}
+
+onMounted(async () => {
+  loading.value = true
+  await fetchDefaultLanguage()
+  skipHistory.value = true
+  await Promise.all([fetchProperties(), fetchVariations()])
+  originalVariations.value = JSON.parse(JSON.stringify(variations.value))
+  computeChanges()
+  clearHistory()
+  skipHistory.value = false
+  loading.value = false
+})
+
+const toCreate = ref<any[]>([])
+const toUpdate = ref<any[]>([])
+const toDelete = ref<object[]>([])
+
+const getPropertyType = (id: string) =>
+  properties.value.find((p) => p.id === id)?.type
+
+const isPropEmpty = (prop: any, type: string) => {
+  if (!prop) return true
+  if (prop.valueSelect) return false
+  if (prop.valueMultiSelect && prop.valueMultiSelect.length) return false
+  if (prop.valueInt !== undefined) return false
+  if (prop.valueFloat !== undefined) return false
+  if (prop.valueBoolean !== undefined) return false
+  if (type === PropertyTypes.TEXT && prop.translation?.valueText) return false
+  if (type === PropertyTypes.DESCRIPTION && prop.translation?.valueDescription) return false
+  return true
+}
+
+const computeChanges = () => {
+  toCreate.value = []
+  toUpdate.value = []
+  toDelete.value = []
+
+  variations.value.forEach((variation, index) => {
+    const original = originalVariations.value[index] || {}
+    const keys = new Set([
+      ...Object.keys(variation.propertyValues || {}),
+      ...Object.keys(original.propertyValues || {}),
+    ])
+
+    keys.forEach((key) => {
+      const type = getPropertyType(key) || ''
+      const current = variation.propertyValues[key]
+      const orig = (original.propertyValues || {})[key]
+      const origExists = !!orig && !!orig.id
+      const hasCurrent = !isPropEmpty(current, type)
+      const hadValue = !isPropEmpty(orig, type)
+
+      if (!origExists && hasCurrent) {
+        const item: any = {
+          productProperty: {
+            product: { id: variation.variation.id },
+            property: { id: key },
+          },
+        }
+        if (current.valueSelect)
+          item.productProperty.valueSelect = { id: current.valueSelect.id }
+        if (current.valueMultiSelect && current.valueMultiSelect.length)
+          item.productProperty.valueMultiSelect = current.valueMultiSelect.map(
+            (v: any) => ({ id: v.id })
+          )
+        if (current.valueInt !== undefined)
+          item.productProperty.valueInt = current.valueInt
+        if (current.valueFloat !== undefined)
+          item.productProperty.valueFloat = current.valueFloat
+        if (current.valueBoolean !== undefined)
+          item.productProperty.valueBoolean = current.valueBoolean
+        if (type === PropertyTypes.TEXT && current.translation?.valueText) {
+          item.languageCode = current.translation.language
+          item.translatedValue = current.translation.valueText
+        }
+        if (
+          type === PropertyTypes.DESCRIPTION &&
+          current.translation?.valueDescription
+        ) {
+          item.languageCode = current.translation.language
+          item.translatedValue = current.translation.valueDescription
+        }
+        toCreate.value.push(item)
+      } else if (origExists && hadValue && !hasCurrent) {
+        toDelete.value.push({id: orig.id})
+      } else if (origExists && hasCurrent) {
+        const diff: any = { id: orig.id }
+        if (current.valueSelect?.id !== orig.valueSelect?.id)
+          diff.valueSelect = current.valueSelect
+            ? { id: current.valueSelect.id }
+            : null
+        const curMulti = (current.valueMultiSelect || [])
+          .map((v: any) => v.id)
+          .sort()
+        const origMulti = (orig.valueMultiSelect || [])
+          .map((v: any) => v.id)
+          .sort()
+        if (
+          curMulti.length !== origMulti.length ||
+          curMulti.some((v: any, i: number) => v !== origMulti[i])
+        ) {
+          diff.valueMultiSelect = current.valueMultiSelect
+            ? current.valueMultiSelect.map((v: any) => ({ id: v.id }))
+            : []
+        }
+        if (current.valueInt !== orig.valueInt)
+          diff.valueInt = current.valueInt
+        if (current.valueFloat !== orig.valueFloat)
+          diff.valueFloat = current.valueFloat
+        if ((current.valueBoolean ?? null) !== (orig.valueBoolean ?? null))
+          diff.valueBoolean = current.valueBoolean
+        if (type === PropertyTypes.TEXT) {
+          const curText = current.translation?.valueText || ''
+          const origText = orig.translation?.valueText || ''
+          if (curText !== origText)
+            diff.translation = {
+              languageCode:
+                current.translation?.language || orig.translation?.language,
+              valueText: curText,
+            }
+        }
+        if (type === PropertyTypes.DESCRIPTION) {
+          const curDesc = current.translation?.valueDescription || ''
+          const origDesc = orig.translation?.valueDescription || ''
+          if (curDesc !== origDesc)
+            diff.translation = {
+              languageCode:
+                current.translation?.language || orig.translation?.language,
+              valueDescription: curDesc,
+            }
+        }
+        if (Object.keys(diff).length > 1) toUpdate.value.push(diff)
+      }
+    })
+  })
+}
+
+watch(
+  variations,
+  (newVal) => {
+    if (!skipHistory.value) {
+      history.value.push(JSON.parse(lastSnapshot.value))
+      if (history.value.length > 20) history.value.shift()
+      redoStack.value = []
+    }
+    lastSnapshot.value = JSON.stringify(toRaw(newVal))
+    computeChanges()
+  },
+  { deep: true }
+)
+
+const undo = () => {
+  if (!history.value.length) return
+  skipHistory.value = true
+  redoStack.value.push(JSON.parse(JSON.stringify(variations.value)))
+  const prev = history.value.pop()
+  variations.value = JSON.parse(JSON.stringify(prev))
+  nextTick(() => {
+    skipHistory.value = false
+  })
+  Toast.info(t('products.products.alert.toast.undo'))
+}
+
+const redo = () => {
+  if (!redoStack.value.length) return
+  skipHistory.value = true
+  history.value.push(JSON.parse(JSON.stringify(variations.value)))
+  const next = redoStack.value.pop()
+  variations.value = JSON.parse(JSON.stringify(next))
+  nextTick(() => {
+    skipHistory.value = false
+  })
+  Toast.info(t('products.products.alert.toast.redo'))
+}
+
+const clearHistory = () => {
+  history.value = []
+  redoStack.value = []
+  lastSnapshot.value = JSON.stringify(toRaw(variations.value))
+}
+
+const setPaginationVariables = async (
+  firstVal: number | null = null,
+  lastVal: number | null = null,
+  beforeVal: string | null = null,
+  afterVal: string | null = null
+) => {
+  const fetchNewPaginationData: Record<string, any> = {}
+  if (firstVal) fetchNewPaginationData['first'] = firstVal
+  if (lastVal) fetchNewPaginationData['last'] = lastVal
+  if (beforeVal) fetchNewPaginationData['before'] = beforeVal
+  if (afterVal) fetchNewPaginationData['after'] = afterVal
+  fetchPaginationData.value = fetchNewPaginationData
+  skipHistory.value = true
+  await fetchVariations()
+  originalVariations.value = JSON.parse(JSON.stringify(variations.value))
+  computeChanges()
+  clearHistory()
+  skipHistory.value = false
+}
+
+const handleQueryChanged = async (queryData) => {
+  const newQuery = queryData.query
+  const beforeValue = typeof newQuery.before === 'string' ? newQuery.before : null
+  const afterValue = typeof newQuery.after === 'string' ? newQuery.after : null
+  if (newQuery.before) {
+    await setPaginationVariables(null, limit.value, beforeValue, null)
+  }
+  if (newQuery.after) {
+    await setPaginationVariables(limit.value, null, null, afterValue)
+  }
+  if (newQuery.last === 'true') {
+    await setPaginationVariables(null, limit.value, null, null)
+  }
+  if (newQuery.first === 'true') {
+    await setPaginationVariables(limit.value, null, null, null)
+  }
+}
+
+const updateLimitPerPage = async (value: number) => {
+  limit.value = value
+  await setPaginationVariables(limit.value, null, null, null)
+}
+
+const hasChanges = computed(
+  () => toCreate.value.length || toUpdate.value.length || toDelete.value.length
+)
+
+const save = async () => {
+  const createdCount = toCreate.value.length
+  const updatedCount = toUpdate.value.length
+  const deletedCount = toDelete.value.length
+  if (createdCount)
+    await apolloClient.mutate({
+      mutation: bulkCreateProductPropertiesMutation,
+      variables: { data: toCreate.value },
+    })
+  if (updatedCount)
+    await apolloClient.mutate({
+      mutation: bulkUpdateProductPropertiesMutation,
+      variables: { data: toUpdate.value },
+    })
+  if (deletedCount)
+    await apolloClient.mutate({
+      mutation: deleteProductPropertiesMutation,
+      variables: { data: toDelete.value },
+    })
+  originalVariations.value = JSON.parse(JSON.stringify(variations.value))
+  computeChanges()
+  clearHistory()
+  const messages: any[] = []
+
+  if (createdCount) {
+    messages.push(
+      t('products.products.alert.toast.createdProductProperties', {
+        count: createdCount,
+      })
+    )
+  }
+  if (updatedCount) {
+    messages.push(
+      t('products.products.alert.toast.updatedProductProperties', {
+        count: updatedCount,
+      })
+    )
+  }
+  if (deletedCount) {
+    messages.push(
+      t('products.products.alert.toast.deletedProductProperties', {
+        count: deletedCount,
+      })
+    )
+  }
+
+  if (messages.length) {
+    Toast.success(messages.join('<br>'))
+  }
+}
+
+defineExpose({ save, hasChanges })
+
+const showTextModal = ref(false)
+const showDescriptionModal = ref(false)
+
+const selectedIndex = ref<number | null>(null)
+const selectedColKey = ref('')
+const modalValue = ref('')
+
+const openTextModal = (index: number, key: string) => {
+  selectedIndex.value = index
+  selectedColKey.value = key
+  modalValue.value =
+    variations.value[index].propertyValues[key]?.translation?.valueText || ''
+  showTextModal.value = true
+}
+
+const openDescriptionModal = (index: number, key: string) => {
+  selectedIndex.value = index
+  selectedColKey.value = key
+  modalValue.value =
+    variations.value[index].propertyValues[key]?.translation?.valueDescription || ''
+  showDescriptionModal.value = true
+}
+
+const cancelModal = () => {
+  showTextModal.value = false
+  showDescriptionModal.value = false
+}
+
+const saveModal = () => {
+  if (selectedIndex.value === null) return
+  const item = variations.value[selectedIndex.value]
+  const key = selectedColKey.value
+  if (!item.propertyValues[key]) item.propertyValues[key] = {}
+  if (!item.propertyValues[key].translation)
+    item.propertyValues[key].translation = { language: language.value }
+  if (!item.propertyValues[key].translation.language)
+    item.propertyValues[key].translation.language = language.value
+  if (showTextModal.value) {
+    item.propertyValues[key].translation.valueText = modalValue.value
+  } else if (showDescriptionModal.value) {
+    item.propertyValues[key].translation.valueDescription = modalValue.value
+  }
+  cancelModal()
+}
+
+const ensureProp = (index: number, key: string) => {
+  const item = variations.value[index]
+  if (!item.propertyValues[key]) item.propertyValues[key] = {}
+  return item.propertyValues[key]
+}
+
+const updateSelectValue = (index: number, key: string, value: any) => {
+  const item = variations.value[index]
+  if (!value) {
+    if (item.propertyValues[key]) delete item.propertyValues[key]
+    return
+  }
+  const prop = ensureProp(index, key)
+  prop.valueSelect = { id: value }
+}
+
+const updateMultiSelectValue = (index: number, key: string, value: any[]) => {
+  const item = variations.value[index]
+  if (!value || !value.length) {
+    if (item.propertyValues[key]) delete item.propertyValues[key]
+    return
+  }
+  const prop = ensureProp(index, key)
+  prop.valueMultiSelect = value.map((id) => ({ id }))
+}
+
+const updateNumberValue = (
+  index: number,
+  key: string,
+  field: 'valueInt' | 'valueFloat',
+  value: any
+) => {
+  const prop = ensureProp(index, key)
+  prop[field] = value
+}
+
+const updateBooleanValue = (
+  index: number,
+  key: string,
+  value: boolean | null
+) => {
+  const prop = ensureProp(index, key)
+  prop.valueBoolean = value
+}
+
+const MIN_COLUMN_WIDTH = 100
+const startResize = (e: MouseEvent, key: string) => {
+  const startX = e.pageX
+  const startWidth = columnWidths[key]
+
+  const onMouseMove = (event: MouseEvent) => {
+    const delta = event.pageX - startX
+    columnWidths[key] = Math.max(MIN_COLUMN_WIDTH, startWidth + delta)
+  }
+
+  const onMouseUp = () => {
+    document.removeEventListener('mousemove', onMouseMove)
+    document.removeEventListener('mouseup', onMouseUp)
+  }
+
+  document.addEventListener('mousemove', onMouseMove)
+  document.addEventListener('mouseup', onMouseUp)
+}
+
+</script>
+
+<template>
+  <div class="relative w-full min-w-0">
+    <div
+      v-if="loading"
+      class="absolute inset-0 z-10 flex items-center justify-center bg-white bg-opacity-75"
+    >
+      <LocalLoader :loading="loading" />
+    </div>
+    <Flex between middle gap="2" class="mb-4">
+      <FlexCell grow></FlexCell>
+      <FlexCell class="flex">
+        <Button
+          class="btn btn-secondary"
+          :disabled="!canUndo"
+          @click="undo"
+        >
+          <Icon name="arrow-left" />
+        </Button>
+        <Button
+          class="btn btn-secondary ml-2"
+          :disabled="!canRedo"
+          @click="redo"
+        >
+          <Icon name="arrow-right" />
+        </Button>
+      </FlexCell>
+      <FlexCell >
+        <ApolloQuery :query="translationLanguagesQuery">
+          <template v-slot="{ result: { data } }">
+            <Selector
+              v-if="data"
+              v-model="language"
+              :options="data.translationLanguages.languages"
+              :placeholder="t('products.translation.placeholders.language')"
+              class="w-32 mr-2"
+              labelBy="name"
+              valueBy="code"
+              :removable="false"
+              mandatory
+              filterable
+            />
+          </template>
+        </ApolloQuery>
+      </FlexCell>
+      <FlexCell>
+        <Button class="btn btn-primary" :disabled="!hasChanges" @click="save">
+          {{ t('shared.button.save') }}
+        </Button>
+      </FlexCell>
+    </Flex>
+    <div class="overflow-x-auto w-full max-w-full">
+      <table v-if="variations.length" class="min-w-max border border-gray-300 border-collapse select-none">
+        <thead class="bg-gray-100 sticky top-0">
+          <tr>
+            <th
+              v-for="col in columns"
+              :key="col.key"
+              class="text-left px-2 py-1 text-sm font-medium text-gray-700 relative border-r border-gray-200"
+              :style="{ width: columnWidths[col.key] + 'px' }"
+            >
+              <div class="flex items-center h-full">
+                <Icon
+                  v-if="col.requireType"
+                  name="circle-dot"
+                  :class="[getIconColor(col.requireType), 'mr-1']"
+                />
+                <span class="block truncate" :title="col.label">{{ col.label }}</span>
+                <span
+                  class="resizer select-none"
+                  @mousedown="(e) => startResize(e, col.key)"
+                />
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="(item, index) in variations"
+            :key="item.id"
+            class="border-t"
+          >
+            <td
+              v-for="col in columns"
+              :key="col.key"
+              class="px-4 py-2 py-1 border-r border-gray-200 relative cursor-pointer"
+              :class="{ 'bg-blue-100': isInDragRange(index, col.key) }"
+              :style="{ width: columnWidths[col.key] + 'px' }"
+              :data-row="index"
+              :data-col="col.key"
+              @click="selectCell(index, col.key)"
+            >
+              <div
+                v-if="selectedCell.row === index && selectedCell.col === col.key"
+                class="absolute inset-0 border-2 border-blue-500 pointer-events-none"
+              >
+                <div
+                  v-if="!['name','sku','active'].includes(col.key)"
+                  class="absolute w-2 h-2 bg-blue-500 bottom-0 right-0 pointer-events-auto cursor-row-resize"
+                  @mousedown.stop="startDragFill(index, col.key)"
+                ></div>
+              </div>
+              <template v-if="col.key === 'name'">
+                <span class="block truncate" :title="item.variation.name">
+                  {{ shortenText(item.variation.name, 32) }}
+                </span>
+              </template>
+              <template v-else-if="col.key === 'sku'">
+                <span class="block truncate" :title="item.variation.sku">
+                  {{ item.variation.sku }}
+                </span>
+              </template>
+              <template v-else-if="col.key === 'active'">
+                <Icon
+                  v-if="item.variation.active"
+                  name="check-circle"
+                  class="text-green-500"
+                />
+                <Icon
+                  v-else
+                  name="times-circle"
+                  class="text-red-500"
+                />
+              </template>
+              <template v-else>
+                <FieldQuery
+                  v-if="getPropertyType(col.key) === PropertyTypes.SELECT"
+                  :field="selectFields[col.key]"
+                  :model-value="item.propertyValues[col.key]?.valueSelect?.id"
+                  @update:modelValue="(value) => updateSelectValue(index, col.key, value)"
+                />
+                <FieldQuery
+                  v-else-if="getPropertyType(col.key) === PropertyTypes.MULTISELECT"
+                  :field="selectFields[col.key]"
+                  :model-value="item.propertyValues[col.key]?.valueMultiSelect?.map((v) => v.id)"
+                  @update:modelValue="(value) => updateMultiSelectValue(index, col.key, value)"
+                />
+                <TextInput
+                  v-else-if="getPropertyType(col.key) === PropertyTypes.INT"
+                  class="w-full"
+                  :model-value="item.propertyValues[col.key]?.valueInt"
+                  number
+                  @update:modelValue="(value) => updateNumberValue(index, col.key, 'valueInt', value)"
+                />
+                <TextInput
+                  v-else-if="getPropertyType(col.key) === PropertyTypes.FLOAT"
+                  class="w-full"
+                  :model-value="item.propertyValues[col.key]?.valueFloat"
+                  float
+                  @update:modelValue="(value) => updateNumberValue(index, col.key, 'valueFloat', value)"
+                />
+                <div
+                  v-else-if="getPropertyType(col.key) === PropertyTypes.TEXT"
+                  class="relative cursor-pointer"
+                  @dblclick="openTextModal(index, col.key)"
+                >
+                  <div class="border border-gray-300 p-1 h-8 overflow-hidden">
+                    {{
+                      shortenText(
+                        item.propertyValues[col.key]?.translation?.valueText || '',
+                        32
+                      )
+                    }}
+                  </div>
+                  <Icon
+                    name="maximize"
+                    class="absolute top-1 right-1 text-gray-400 cursor-pointer"
+                    @click.stop="openTextModal(index, col.key)"
+                  />
+                </div>
+                <div
+                  v-else-if="getPropertyType(col.key) === PropertyTypes.DESCRIPTION"
+                  class="relative cursor-pointer"
+                  @dblclick="openDescriptionModal(index, col.key)"
+                >
+                  <div class="border border-gray-300 p-1 h-16 overflow-hidden">
+                    {{
+                      shortenText(
+                        item.propertyValues[col.key]?.translation?.valueDescription || '',
+                        32
+                      )
+                    }}
+                  </div>
+                  <Icon
+                    name="maximize"
+                    class="absolute top-1 right-1 text-gray-400 cursor-pointer"
+                    @click.stop="openDescriptionModal(index, col.key)"
+                  />
+                </div>
+                <Toggle
+                  v-else-if="getPropertyType(col.key) === PropertyTypes.BOOLEAN"
+                  :model-value="item.propertyValues[col.key]?.valueBoolean ?? null"
+                  @update:modelValue="(value) => updateBooleanValue(index, col.key, value)"
+                />
+                <div
+                  v-else-if="getPropertyType(col.key) === PropertyTypes.DATE"
+                  class="pointer-events-none"
+                >
+                  <DateInput :model-value="item.propertyValues[col.key]?.valueDate" />
+                </div>
+                <div
+                  v-else-if="getPropertyType(col.key) === PropertyTypes.DATETIME"
+                  class="pointer-events-none"
+                >
+                  <DateTimeInput :model-value="item.propertyValues[col.key]?.valueDatetime" />
+                </div>
+                <input
+                  v-else
+                  type="text"
+                  class="w-full border p-1"
+                  :value="item.propertyValues[col.key]?.valueInt || ''"
+                  disabled
+                />
+              </template>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="py-2 px-2 flex items-center space-x-2">
+    <Pagination
+      v-if="pageInfo"
+      :page-info="pageInfo"
+      :change-query-params="false"
+      @query-changed="handleQueryChanged"
+    />
+    <div v-if="pageInfo && (pageInfo.hasNextPage || pageInfo.hasPreviousPage)">
+      <Selector
+        :options="perPageOptions"
+        :model-value="limit"
+        :clearable="false"
+        dropdown-position="bottom"
+        value-by="value"
+        label-by="name"
+        :placeholder="t('pagination.perPage')"
+        @update:model-value="updateLimitPerPage"
+      />
+    </div>
+  </div>
+  <Modal v-model="showTextModal">
+    <Card class="modal-content w-1/2">
+      <h3 class="text-xl font-semibold text-center mb-4">
+        {{ t('products.products.bulkEditModal.textTitle') }}
+      </h3>
+      <TextInput class="w-full" v-model="modalValue" />
+      <div class="flex justify-end gap-4 mt-4">
+        <Button class="btn btn-outline-dark" @click="cancelModal">{{ t('shared.button.cancel') }}</Button>
+        <Button class="btn btn-primary" @click="saveModal">{{ t('shared.button.edit') }}</Button>
+      </div>
+    </Card>
+  </Modal>
+  <Modal v-model="showDescriptionModal">
+    <Card class="modal-content w-2/3">
+      <h3 class="text-xl font-semibold text-center mb-4">
+        {{ t('products.products.bulkEditModal.descriptionTitle') }}
+      </h3>
+      <TextEditor class="h-64" v-model="modalValue" />
+      <div class="flex justify-end gap-4 mt-4">
+        <Button class="btn btn-outline-dark" @click="cancelModal">{{ t('shared.button.cancel') }}</Button>
+        <Button class="btn btn-primary" @click="saveModal">{{ t('shared.button.edit') }}</Button>
+      </div>
+    </Card>
+  </Modal>
+</template>
+
+<style scoped>
+.resizer {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  background-color: #e5e7eb;
+}
+</style>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -935,11 +935,19 @@
         "sameProductType": "Same product type only"
       },
       "alert": {
-        "toast": {
-          "bulkDeleteSuccess": "Products deleted successfully.",
-          "bulkDeleteError": "Failed to delete products. Please try again."
-        }
-      },
+      "toast": {
+        "bulkDeleteSuccess": "Products deleted successfully.",
+        "bulkDeleteError": "Failed to delete products. Please try again.",
+        "copied": "Copied",
+        "pasted": "Pasted",
+        "pasteDifferentColumn": "Cannot paste to different column",
+        "undo": "Undid last change",
+        "redo": "Redid last change",
+        "createdProductProperties": "Created {count} product properties.",
+        "updatedProductProperties": "Updated {count} product properties.",
+        "deletedProductProperties": "Deleted {count} product properties."
+      }
+    },
       "tabs": {
         "content": "Content",
         "aliasProducts": "Alias Products",
@@ -1183,6 +1191,10 @@
       },
       "duplicateModal": {
         "description": "Provide an SKU for the duplicated product or leave empty to auto generate."
+      },
+      "bulkEditModal": {
+        "textTitle": "Edit value",
+        "descriptionTitle": "Edit description"
       },
       "duplicateSuccessfully": "Product was successfully duplicated!"
     }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -636,6 +636,18 @@
         "dragAndDrop": "Versleep de items, of klik op ➕ om items toe te voegen",
         "noVariationsLeft": "Er zijn geen producten meer om toe te voegen"
       },
+      "alert": {
+        "toast": {
+          "copied": "Gekopieerd",
+          "pasted": "Geplakt",
+          "pasteDifferentColumn": "Kan niet plakken naar een andere kolom",
+          "undo": "Laatste wijziging ongedaan gemaakt",
+          "redo": "Laatste wijziging opnieuw toegepast",
+          "createdProductProperties": "{count} producteigenschappen aangemaakt.",
+          "updatedProductProperties": "{count} producteigenschappen bijgewerkt.",
+          "deletedProductProperties": "{count} producteigenschappen verwijderd."
+        }
+      },
       "tabs": {
         "content": "Inhoud",
         "variations": "Variaties",
@@ -855,6 +867,10 @@
       },
       "show": {
         "title": "Product"
+      },
+      "bulkEditModal": {
+        "textTitle": "Waarde bewerken",
+        "descriptionTitle": "Beschrijving bewerken"
       },
       "duplicateSuccessfully": "Product succesvol gedupliceerd!"
     }

--- a/src/shared/api/mutations/properties.js
+++ b/src/shared/api/mutations/properties.js
@@ -228,6 +228,14 @@ export const bulkCreateProductPropertiesMutation = gql`
   }
 `;
 
+export const bulkUpdateProductPropertiesMutation = gql`
+  mutation bulkUpdateProductProperties($data: [BulkProductPropertyPartialInput!]!) {
+    bulkUpdateProductProperties(productProperties: $data) {
+      id
+    }
+  }
+`;
+
 export const updateProductPropertyMutation = gql`
   mutation updateProductProperty($data: ProductPropertyPartialInput!) {
     updateProductProperty(data: $data) {
@@ -253,8 +261,8 @@ export const deleteProductPropertyMutation = gql`
 `;
 
 export const deleteProductPropertiesMutation = gql`
-  mutation deleteProductProperties($ids: [GlobalID!]!) {
-    deleteProductProperties(data: {ids: $ids}) {
+    mutation deleteProductProperties($data: [NodeInput!]!) {
+    deleteProductProperties(data: $data) {
       id
     }
   }

--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -165,7 +165,12 @@ function processAndCleanData(rawData: any) {
 
   cleanedData.value = [...newData, ...preservedItems];
 
-  if (!props.field.optional && cleanedData.value.length === 1 && (selectedValue.value === undefined || selectedValue.value === null)) {
+  if (
+    props.field.autocompleteIfOneResult !== false &&
+    !props.field.optional &&
+    cleanedData.value.length === 1 &&
+    (selectedValue.value === undefined || selectedValue.value === null)
+  ) {
     if (props.field.multiple) {
       updateValue([cleanedData.value[0][props.field.valueBy]]);
     } else {

--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -25,7 +25,7 @@ const loading = ref(true);
 const rawDataRef: Ref<any> = ref([]);
 const cleanedData: Ref<any[]> = ref([]);
 const selectedValue = ref(props.modelValue);
-const isLiveUpdate = ref(true); // in order to be live updates this always have to be true
+const isLiveUpdate = ref(props.field.isLiveUpdate ?? true);
 
 
 const dropdownPosition = props.field.dropdownPosition || 'top';

--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -38,6 +38,9 @@ const limit = props.field.limit || undefined;
 watch(() => props.modelValue, (value) => {
   if (value !== selectedValue.value) {
     selectedValue.value = value
+    if (value != null && selectedValue.value != null) {
+      ensureSelectedValuesArePresent();
+    }
   }
 }, { deep: true });
 

--- a/src/shared/components/organisms/general-form/formConfig.ts
+++ b/src/shared/components/organisms/general-form/formConfig.ts
@@ -166,6 +166,7 @@ export interface QueryFormField extends BaseFormField {
   filterable?: boolean;
   removable?: boolean;
   limit?: number;
+  isLiveUpdate?: boolean;
   createOnFlyConfig?: CreateOnTheFly;
   setDefaultKey?: string;
   defaultExpectedValue?: any; // if we have a default key but we don't give the value the default will be true

--- a/src/shared/components/organisms/general-form/formConfig.ts
+++ b/src/shared/components/organisms/general-form/formConfig.ts
@@ -166,6 +166,7 @@ export interface QueryFormField extends BaseFormField {
   filterable?: boolean;
   removable?: boolean;
   limit?: number;
+  autocompleteIfOneResult?: boolean;
   isLiveUpdate?: boolean;
   createOnFlyConfig?: CreateOnTheFly;
   setDefaultKey?: string;

--- a/src/shared/plugins/font-awesome.ts
+++ b/src/shared/plugins/font-awesome.ts
@@ -154,7 +154,8 @@ import {
   faPaperPlane,
   faUpDownLeftRight,
   faWeightHanging,
-  faCommentDots
+  faCommentDots,
+  faArrowRight
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(faBell as IconDefinition);
@@ -309,6 +310,7 @@ library.add(faPaperPlane as IconDefinition);
 library.add(faUpDownLeftRight as IconDefinition);
 library.add(faWeightHanging as IconDefinition);
 library.add(faCommentDots as IconDefinition);
+library.add(faArrowRight as IconDefinition);
 
 
 export default {


### PR DESCRIPTION
## Summary by Sourcery

Add a spreadsheet-style bulk-edit mode for product variations with GraphQL batch update support and enhance related UI and form behaviors across the product module.

New Features:
- Introduce a Bulk Edit tab in VariationsView using a new VariationsBulkEdit component for inline, spreadsheet-like editing of variation properties.
- Add bulkUpdateProductProperties GraphQL mutation and integrate it into the bulk edit save workflow with create, update, and delete operations.
- Implement undo/redo, drag-fill, text/description modals, and pagination in the VariationsBulkEdit interface.
- Debounce the search input in VariationCreate form to improve variation filtering.
- Register a new fa-arrow-right icon for navigation controls.

Enhancements:
- Make FieldQuery’s live-update behavior and single-result auto-complete configurable via new formConfig flags (isLiveUpdate, autocompleteIfOneResult).
- Sort AmazonMarketplaceTabs views by default channel and select the default view initially in AmazonView.
- Enable the filterable option in AmazonVariationThemeSection.
- Adjust form field min-width and layout classes for better responsiveness.