### PR TITLE
fix: retain created property IDs in variations bulk edit

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -705,11 +705,23 @@ const save = async () => {
   const createdCount = toCreate.value.length
   const updatedCount = toUpdate.value.length
   const deletedCount = toDelete.value.length
-  if (createdCount)
-    await apolloClient.mutate({
+  if (createdCount) {
+    const { data } = await apolloClient.mutate({
       mutation: bulkCreateProductPropertiesMutation,
       variables: { data: toCreate.value },
     })
+    const created = data?.bulkCreateProductProperties || []
+    created.forEach((pp: any) => {
+      const variation = variations.value.find(
+        (v: any) => v.variation.id === pp.product.id
+      )
+      if (!variation) return
+      if (!variation.propertyValues) variation.propertyValues = {}
+      if (!variation.propertyValues[pp.property.id])
+        variation.propertyValues[pp.property.id] = {}
+      variation.propertyValues[pp.property.id].id = pp.id
+    })
+  }
   if (updatedCount)
     await apolloClient.mutate({
       mutation: bulkUpdateProductPropertiesMutation,


### PR DESCRIPTION
## Summary
- update newly created property values with returned IDs to avoid repeated creation

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aed850276c832e8d4d8ae0b938f207

## Summary by Sourcery

Update the bulk creation logic in VariationsBulkEdit to assign returned property value IDs to local variation state and prevent duplicate creations.

Bug Fixes:
- Persist IDs of newly created product property values in the component state to avoid repeated creations

Enhancements:
- Destructure mutation response to extract created entries and map their IDs back into variations
- Wrap the creation mutation in a block to process its returned data before proceeding