### PR TITLE
fix: stabilize history after saving variations

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -702,6 +702,7 @@ const hasChanges = computed(
 )
 
 const save = async () => {
+  skipHistory.value = true
   const createdCount = toCreate.value.length
   const updatedCount = toUpdate.value.length
   const deletedCount = toDelete.value.length
@@ -735,6 +736,8 @@ const save = async () => {
   originalVariations.value = JSON.parse(JSON.stringify(variations.value))
   computeChanges()
   clearHistory()
+  await nextTick()
+  skipHistory.value = false
   const messages: any[] = []
 
   if (createdCount) {


### PR DESCRIPTION
## Summary
- prevent created property ids from polluting undo history in variations bulk edit

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aee0a8e874832e81aed9de2eacf215

## Summary by Sourcery

Bug Fixes:
- Suppress creation of property IDs from polluting the undo history by toggling skipHistory before and after saving variations