### PR TITLE
Support sales channel in AI content translator

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
@@ -42,6 +42,10 @@ const props = defineProps({
     type: String as PropType<string | undefined>,
     default: undefined,
   },
+  salesChannelId: {
+    type: String as PropType<string | undefined>,
+    default: undefined,
+  },
 });
 
 const emit = defineEmits<{
@@ -64,6 +68,7 @@ const emit = defineEmits<{
             toTranslate=""
             fromLanguageCode="en"
             :toLanguageCode="currentLanguage"
+            :sales-channel-id="salesChannelId"
             @translated="val => form.name = val"
           />
         </FlexCell>
@@ -96,6 +101,7 @@ const emit = defineEmits<{
             toTranslate=""
             fromLanguageCode="en"
             :toLanguageCode="currentLanguage"
+            :sales-channel-id="salesChannelId"
             @translated="val => emit('shortDescription', val)"
           />
         </FlexCell>
@@ -131,6 +137,7 @@ const emit = defineEmits<{
             toTranslate=""
             fromLanguageCode="en"
             :toLanguageCode="currentLanguage"
+            :sales-channel-id="salesChannelId"
             @translated="val => emit('description', val)"
           />
         </FlexCell>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -351,6 +351,7 @@ const shortDescriptionToolbarOptions = [
           :show-short-description="fieldRules.shortDescription"
           :show-url-key="fieldRules.urlKey"
           :sales-channel-type="currentChannelType"
+          :sales-channel-id="currentSalesChannel !== 'default' ? currentSalesChannel : undefined"
           @description="handleGeneratedDescriptionContent"
           @shortDescription="handleGeneratedShortDescriptionContent"
         />

--- a/src/shared/api/mutations/llm.js
+++ b/src/shared/api/mutations/llm.js
@@ -20,8 +20,8 @@ mutation generateProductAiContentMutation($data: ProductAiContentInput!) {
 `;
 
 export const generateAiTranslationMutation = gql`
-  mutation generateAiTranslationMutation($data: AITranslationInput!) {
-    generateAiTranslation(instance: $data) {
+  mutation generateAiTranslationMutation($data: AITranslationInput!, $salesChannel: SalesChannelPartialInput) {
+    generateAiTranslation(instance: $data, sales_channel: $salesChannel) {
       ... on AiContent {
         content
         points

--- a/src/shared/components/organisms/ai-content-translator/AiContentTranslator.vue
+++ b/src/shared/components/organisms/ai-content-translator/AiContentTranslator.vue
@@ -10,6 +10,7 @@ interface Props {
   toLanguageCode: string;
   product?: any;
   productContentType?: string;
+  salesChannelId?: string;
 }
 
 const props = defineProps<Props>();
@@ -34,7 +35,13 @@ const mutationVariables = computed(() => {
     data.productContentType = props.productContentType;
   }
 
-  return { data };
+  const variables: any = { data };
+
+  if (props.salesChannelId) {
+    variables.salesChannel = { id: props.salesChannelId };
+  }
+
+  return variables;
 });
 
 


### PR DESCRIPTION
## Summary
- allow `AiContentTranslator` to accept optional `salesChannelId` and forward it to the translation mutation
- update `generateAiTranslationMutation` to accept optional `SalesChannelPartialInput`
- propagate optional `salesChannelId` from product content tab to translators when a sales channel is selected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aede77c98c832eab3f94519e87d34b