### PR TITLE
Shorten alias target name in product summary

### DIFF
--- a/src/core/products/products/product-show/ProductShowController.vue
+++ b/src/core/products/products/product-show/ProductShowController.vue
@@ -213,8 +213,8 @@ const handleDuplicate = async (sku: string | null, createAsAlias: boolean) => {
                             <Label semi-bold>{{ t('products.products.labels.aliasParentProduct') }}: </Label>
                           </FlexCell>
                           <FlexCell>
-                            <Link :path="{ name: 'products.products.show', params: { id: getResultData(result, 'id', null, 'id') } }">
-                              {{ getResultData(result, 'name', null, 'name') }}
+                            <Link :path="{ name: 'products.products.show', params: { id: getResultData(result, 'id', null, 'id') } }" :title="getResultData(result, 'name', null, 'name')">
+                              {{ shortenText(getResultData(result, 'name', null, 'name'), 64) }}
                             </Link>
                           </FlexCell>
                         </Flex>


### PR DESCRIPTION
## Summary
- truncate alias target product name using shortenText with full name as title

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aee71ad324832e8f53d6eaf2d50f5e

## Summary by Sourcery

Truncate alias parent product name in ProductShowController to 64 characters and set the full name as the link’s tooltip

Enhancements:
- Shorten displayed alias parent product names to 64 characters using shortenText
- Add full alias name to the link title attribute for tooltip display