### PR TITLE
Allow SKU input for configurable products

### DIFF
--- a/src/core/products/products/product-create/containers/general-info-step/GeneralInfoStep.vue
+++ b/src/core/products/products/product-create/containers/general-info-step/GeneralInfoStep.vue
@@ -97,8 +97,8 @@ onMounted(fetchProductType)
         </Flex>
       </FlexCell>
 
-      <FlexCell v-if="form.type !== ProductType.Configurable" class="py-8 px-96"><hr></FlexCell>
-      <FlexCell v-if="form.type !== ProductType.Configurable">
+      <FlexCell class="py-8 px-96"><hr></FlexCell>
+      <FlexCell>
         <Flex center class="gap-4">
           <FlexCell center>
             <Flex vertical class="gap-2">


### PR DESCRIPTION
## Summary
- Always display SKU input when creating configurable products

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aee74393e8832e8a8087f6d5fa4cb9