### PR TITLE
feat: support bullet point translation in product forms

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -16,6 +16,8 @@ import {
 import { processGraphQLErrors } from '../../../../../../../shared/utils';
 import { Toast } from '../../../../../../../shared/modules/toast';
 import { AiBulletPointsGenerator } from '../../../../../../../shared/components/organisms/ai-bullet-points-generator';
+import { AiContentTranslator } from '../../../../../../../shared/components/organisms/ai-content-translator';
+import { BULLET_POINT_SEPARATOR } from '../../../../../../../shared/utils/constants';
 
 const { t } = useI18n();
 
@@ -33,6 +35,17 @@ const handleGeneratedBulletPoints = (list: any[]) => {
   bulletPoints.value = list.map((bp, idx) => ({
     id: null,
     text: bp.text,
+    sortOrder: idx,
+  }));
+};
+
+const handleTranslatedBulletPoints = (text: string) => {
+  const points = text
+    ? text.split(BULLET_POINT_SEPARATOR).filter((p) => p.trim())
+    : [];
+  bulletPoints.value = points.map((bp, idx) => ({
+    id: null,
+    text: bp,
     sortOrder: idx,
   }));
 };
@@ -152,6 +165,16 @@ defineExpose({ save, fetchPoints });
           :product-id="props.productId"
           :language-code="props.languageCode"
           @generated="handleGeneratedBulletPoints"
+        />
+      </FlexCell>
+      <FlexCell v-if="props.languageCode && props.languageCode !== 'en'">
+        <AiContentTranslator
+          :product="{ id: props.productId }"
+          productContentType="BULLET_POINTS"
+          toTranslate=""
+          fromLanguageCode="en"
+          :toLanguageCode="props.languageCode"
+          @translated="handleTranslatedBulletPoints"
         />
       </FlexCell>
       <FlexCell>

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -1,5 +1,6 @@
 export const PUBLIC_ROUTES = ['auth.login', 'auth.register', 'auth.register.company', 'auth.recover', 'auth.recover.token', 'auth.accept.invite.token'];
 export  const DEFAULT_LANGUAGE = {"code": "en", "name": "English"}
+export const BULLET_POINT_SEPARATOR = "__BULLET_SEPARATOR__";
 
 export  interface Url {
   name: string;


### PR DESCRIPTION
## Summary
- allow product bullet points to be translated via AI translator
- split translated bullet points using `__BULLET_SEPARATOR__` constant

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af0b53f544832e97defd331f6de192

## Summary by Sourcery

Add AI-powered translation support for product bullet points in product forms.

New Features:
- Integrate AiContentTranslator component to translate bullet points for non-English languages
- Introduce BULLET_POINT_SEPARATOR constant for parsing translated bullet point text

Enhancements:
- Implement handleTranslatedBulletPoints to split translated text and map it to bullet point objects