### PR TITLE
feat: include sales channel in bullet point translation

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -361,6 +361,7 @@ const shortDescriptionToolbarOptions = [
           :translation-id="translationId"
           :product-id="product.id"
           :language-code="currentLanguage"
+          :sales-channel-id="currentSalesChannel !== 'default' ? currentSalesChannel : undefined"
           @initial-bullet-points="previewBulletPoints = [...$event]"
         />
       </div>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -21,7 +21,7 @@ import {BULLET_POINT_SEPARATOR} from '../../../../../../../shared/utils/constant
 
 const {t} = useI18n();
 
-const props = defineProps<{ translationId: string | null; productId: string | number; languageCode: string | null }>();
+const props = defineProps<{ translationId: string | null; productId: string | number; languageCode: string | null; salesChannelId?: string }>();
 const emit = defineEmits<{
   (e: 'update:bulletPoints', value: any[]): void;
   (e: 'initial-bullet-points', value: any[]): void;
@@ -180,6 +180,7 @@ defineExpose({save, fetchPoints});
                 toTranslate=""
                 fromLanguageCode="en"
                 :toLanguageCode="props.languageCode"
+                :sales-channel-id="props.salesChannelId"
                 @translated="handleTranslatedBulletPoints"
             />
           </FlexCell>


### PR DESCRIPTION
## Summary
- add sales channel id prop to ProductTranslationBulletPoints and forward to AiContentTranslator
- pass current sales channel to ProductTranslationBulletPoints from ProductContentView

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af0f6d23c8832eb9d2984f13d4ff7c

## Summary by Sourcery

Include sales channel context for AI-based bullet point translations by adding a salesChannelId prop and propagating it from the parent view to the translation component.

Enhancements:
- Add optional salesChannelId prop to ProductTranslationBulletPoints component
- Forward salesChannelId prop to AiContentTranslator in ProductTranslationBulletPoints
- Pass currentSalesChannel from ProductContentView to ProductTranslationBulletPoints when not default