### PR TITLE
Ensure company invite requires name or email before submit

### DIFF
--- a/src/core/profile/company/containers/company-invite-member/CompanyInviteMember.vue
+++ b/src/core/profile/company/containers/company-invite-member/CompanyInviteMember.vue
@@ -48,7 +48,11 @@ const afterInvite = () => {
       <template v-slot="{ mutate, loading, error }">
         <div class="flex justify-end gap-4 mt-4">
           <Button class="btn btn-outline-dark" @click="emit('cancelClicked')">{{ t('shared.button.cancel') }}</Button>
-          <Button class="btn btn-primary" :disabled="loading" @click="mutate()">{{ t('shared.button.submit') }}</Button>
+          <Button
+            class="btn btn-primary"
+            :disabled="loading || !form.username || (!form.firstName && !form.lastName)"
+            @click="mutate()"
+          >{{ t('shared.button.submit') }}</Button>
         </div>
       </template>
     </ApolloMutation>


### PR DESCRIPTION
## Summary
- disable invite submit until email and first or last name present

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af1e301d9c832ebcdb039418b66cf4

## Summary by Sourcery

Enhancements:
- Disable the invite submit button when loading, no email is entered, or both first and last names are missing