### PR TITLE
feat: add sku copy to clipboard

### DIFF
--- a/src/core/products/products/product-show/ProductShowController.vue
+++ b/src/core/products/products/product-show/ProductShowController.vue
@@ -130,6 +130,16 @@ const handleDuplicate = async (sku: string | null, createAsAlias: boolean) => {
   }
 };
 
+const copySkuToClipboard = async (sku: string) => {
+  try {
+    await navigator.clipboard.writeText(sku);
+    Toast.success(t('shared.alert.toast.clipboardSuccess'));
+  } catch (err) {
+    console.error('Failed to copy:', err);
+    Toast.error(t('shared.alert.toast.clipboardFail'));
+  }
+};
+
 </script>
 
 <template>
@@ -165,6 +175,9 @@ const handleDuplicate = async (sku: string | null, createAsAlias: boolean) => {
                     <Flex>
                       <Label semi-bold>{{ t('shared.labels.sku') }}:</Label>
                       <p class="text-white-dark">{{ getResultData(result, 'sku') }}</p>
+                      <Button class="ml-1" @click="copySkuToClipboard(getResultData(result, 'sku'))">
+                        <Icon name="clipboard" class="h-4 w-4" />
+                      </Button>
                     </Flex>
                     <Flex v-if="getResultData(result, null, 'name')">
                       <Label semi-bold>{{ t('products.products.labels.vatRate') }}:</Label>


### PR DESCRIPTION
## Summary
- add copy-to-clipboard button for product SKU

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af2664caa0832e9632d5a5dcf59e62

## Summary by Sourcery

Enable users to copy a product's SKU to the clipboard via a button in the product show view, with toast notifications on success or failure.

New Features:
- Introduce copySkuToClipboard function to copy product SKU to clipboard with success and error toast feedback
- Add clipboard icon button next to product SKU in the product show view