### PR TITLE
feat: add webhook queries and mutations

### DIFF
--- a/src/shared/api/mutations/webhooks.js
+++ b/src/shared/api/mutations/webhooks.js
@@ -1,0 +1,120 @@
+import { gql } from 'graphql-tag';
+
+export const createWebhookIntegrationMutation = gql`
+  mutation createWebhookIntegration($data: WebhookIntegrationInput!) {
+    createWebhookIntegration(data: $data) {
+      id
+      topic
+      version
+      url
+      secret
+      userAgent
+      timeoutMs
+      mode
+      extraHeaders
+      config
+      retentionPolicy
+      requestsPerMinute
+      maxRetries
+    }
+  }
+`;
+
+export const createWebhookIntegrationsMutation = gql`
+  mutation createWebhookIntegrations($data: [WebhookIntegrationInput!]!) {
+    createWebhookIntegrations(data: $data) {
+      id
+      topic
+      version
+      url
+      secret
+      userAgent
+      timeoutMs
+      mode
+      extraHeaders
+      config
+      retentionPolicy
+      requestsPerMinute
+      maxRetries
+    }
+  }
+`;
+
+export const updateWebhookIntegrationMutation = gql`
+  mutation updateWebhookIntegration($data: WebhookIntegrationPartialInput!) {
+    updateWebhookIntegration(data: $data) {
+      id
+      topic
+      version
+      url
+      secret
+      userAgent
+      timeoutMs
+      mode
+      extraHeaders
+      config
+      retentionPolicy
+      requestsPerMinute
+      maxRetries
+    }
+  }
+`;
+
+export const regenerateWebhookIntegrationSecretMutation = gql`
+  mutation regenerateWebhookIntegrationSecret($data: WebhookIntegrationPartialInput!) {
+    regenerateWebhookIntegrationSecret(data: $data) {
+      id
+      topic
+      version
+      url
+      secret
+      userAgent
+      timeoutMs
+      mode
+      extraHeaders
+      config
+      retentionPolicy
+      requestsPerMinute
+      maxRetries
+    }
+  }
+`;
+
+export const deleteWebhookIntegrationMutation = gql`
+  mutation deleteWebhookIntegration($id: GlobalID!) {
+    deleteWebhookIntegration(data: {id: $id}) {
+      id
+    }
+  }
+`;
+
+export const deleteWebhookIntegrationsMutation = gql`
+  mutation deleteWebhookIntegrations($ids: [GlobalID!]!) {
+    deleteWebhookIntegrations(data: {ids: $ids}) {
+      id
+    }
+  }
+`;
+
+export const retryWebhookDeliveryMutation = gql`
+  mutation retryWebhookDelivery($data: WebhookDeliveryPartialInput!) {
+    retryWebhookDelivery(data: $data) {
+      id
+      outbox {
+        id
+      }
+      webhookIntegration {
+        id
+      }
+      status
+      attempt
+      responseCode
+      responseMs
+      responseBodySnippet
+      sentAt
+      errorMessage
+      errorTraceback
+    }
+  }
+`;
+

--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -1,0 +1,204 @@
+import { gql } from 'graphql-tag';
+
+export const webhookIntegrationsQuery = gql`
+  query WebhookIntegrations($first: Int, $last: Int, $after: String, $before: String, $order: WebhookIntegrationOrder, $filter: WebhookIntegrationFilter) {
+    webhookIntegrations(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          topic
+          version
+          url
+          secret
+          userAgent
+          timeoutMs
+          mode
+          extraHeaders
+          config
+          retentionPolicy
+          requestsPerMinute
+          maxRetries
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getWebhookIntegrationQuery = gql`
+  query GetWebhookIntegration($id: GlobalID!) {
+    webhookIntegration(id: $id) {
+      id
+      topic
+      version
+      url
+      secret
+      userAgent
+      timeoutMs
+      mode
+      extraHeaders
+      config
+      retentionPolicy
+      requestsPerMinute
+      maxRetries
+    }
+  }
+`;
+
+export const webhookOutboxesQuery = gql`
+  query WebhookOutboxes($first: Int, $last: Int, $after: String, $before: String, $order: WebhookOutboxOrder, $filter: WebhookOutboxFilter) {
+    webhookOutboxes(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          webhookIntegration {
+            id
+          }
+          topic
+          action
+          subjectType
+          subjectId
+          sequence
+          payload
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getWebhookOutboxQuery = gql`
+  query GetWebhookOutbox($id: GlobalID!) {
+    webhookOutbox(id: $id) {
+      id
+      webhookIntegration {
+        id
+      }
+      topic
+      action
+      subjectType
+      subjectId
+      sequence
+      payload
+    }
+  }
+`;
+
+export const webhookDeliveriesQuery = gql`
+  query WebhookDeliveries($first: Int, $last: Int, $after: String, $before: String, $order: WebhookDeliveryOrder, $filter: WebhookDeliveryFilter) {
+    webhookDeliveries(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          outbox {
+            id
+          }
+          webhookIntegration {
+            id
+          }
+          status
+          attempt
+          responseCode
+          responseMs
+          responseBodySnippet
+          sentAt
+          errorMessage
+          errorTraceback
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getWebhookDeliveryQuery = gql`
+  query GetWebhookDelivery($id: GlobalID!) {
+    webhookDelivery(id: $id) {
+      id
+      outbox {
+        id
+      }
+      webhookIntegration {
+        id
+      }
+      status
+      attempt
+      responseCode
+      responseMs
+      responseBodySnippet
+      sentAt
+      errorMessage
+      errorTraceback
+    }
+  }
+`;
+
+export const webhookDeliveryAttemptsQuery = gql`
+  query WebhookDeliveryAttempts($first: Int, $last: Int, $after: String, $before: String, $order: WebhookDeliveryAttemptOrder, $filter: WebhookDeliveryAttemptFilter) {
+    webhookDeliveryAttempts(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          delivery {
+            id
+          }
+          number
+          sentAt
+          responseCode
+          responseMs
+          responseBodySnippet
+          errorText
+          errorTraceback
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getWebhookDeliveryAttemptQuery = gql`
+  query GetWebhookDeliveryAttempt($id: GlobalID!) {
+    webhookDeliveryAttempt(id: $id) {
+      id
+      delivery {
+        id
+      }
+      number
+      sentAt
+      responseCode
+      responseMs
+      responseBodySnippet
+      errorText
+      errorTraceback
+    }
+  }
+`;
+


### PR DESCRIPTION
## Summary
- add GraphQL queries for webhook outboxes, deliveries, and delivery attempts
- add mutation to retry webhook deliveries
- add mutation to regenerate webhook integration secret

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b05c7fd720832e8b38b38290d9c18a

## Summary by Sourcery

Add comprehensive GraphQL API to manage webhooks, including queries for integrations, outboxes, deliveries, and delivery attempts, as well as mutations for creating, updating, deleting, regenerating secrets, and retrying deliveries.

New Features:
- Introduce GraphQL queries to list and fetch webhook integrations, outboxes, deliveries, and delivery attempts
- Add GraphQL mutations to create, update, delete, and regenerate secrets for webhook integrations, including batch creation
- Provide GraphQL mutation to retry failed webhook deliveries