### PR TITLE
feat: add webhook integration wizard

### DIFF
--- a/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
+++ b/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
@@ -6,7 +6,7 @@ import { Breadcrumbs } from "../../../../shared/components/molecules/breadcrumbs
 import { Wizard } from "../../../../shared/components/molecules/wizard";
 import { Icon } from "../../../../shared/components/atoms/icon";
 import { Modal } from "../../../../shared/components/atoms/modal";
-import { MagentoInfoCard, WoocommerceInfoCard, ShopifyInfoCard } from "./containers/type-step/info-cards";
+import { MagentoInfoCard, WoocommerceInfoCard, ShopifyInfoCard, WebhookInfoCard } from "./containers/type-step/info-cards";
 import GeneralTemplate from "../../../../shared/templates/GeneralTemplate.vue";
 import {useRoute, useRouter} from "vue-router";
 import {
@@ -16,12 +16,14 @@ import {
   getMagentoDefaultFields,
   getShopifyDefaultFields,
   getWoocommerceDefaultFields,
+  getWebhookDefaultFields,
   IntegrationCreateWizardForm,
   IntegrationTypes,
   AmazonChannelInfo,
   MagentoChannelInfo,
   ShopifyChannelInfo,
   WoocommerceChannelInfo,
+  WebhookChannelInfo,
 } from "../integrations";
 import { TypeStep } from "./containers/type-step";
 import { GeneralInfoStep } from "./containers/general-info-step";
@@ -30,6 +32,7 @@ import { MagentoChannelInfoStep } from "./containers/integration-specific-step/m
 import { ShopifyChannelInfoStep } from "./containers/integration-specific-step/shopify";
 import { WoocommerceChannelInfoStep } from "./containers/integration-specific-step/woocommerce";
 import { AmazonChannelInfoStep } from "./containers/integration-specific-step/amazon";
+import { WebhookChannelInfoStep } from "./containers/integration-specific-step/webhook";
 import {
   createMagentoSalesChannelMutation,
   createShopifySalesChannelMutation,
@@ -38,6 +41,7 @@ import {
   getShopifyRedirectUrlMutation,
   getAmazonRedirectUrlMutation
 } from "../../../../shared/api/mutations/salesChannels.js";
+import { createWebhookIntegrationMutation } from "../../../../shared/api/mutations/webhookIntegrations.js";
 import { Toast } from "../../../../shared/modules/toast";
 import { processGraphQLErrors } from "../../../../shared/utils";
 import apolloClient from "../../../../../apollo-client";
@@ -74,7 +78,7 @@ const form = reactive<IntegrationCreateWizardForm>({
   }
 });
 
-const specificChannelInfo = ref<ShopifyChannelInfo | MagentoChannelInfo | WoocommerceChannelInfo | AmazonChannelInfo | {}>({});
+const specificChannelInfo = ref<ShopifyChannelInfo | MagentoChannelInfo | WoocommerceChannelInfo | AmazonChannelInfo | WebhookChannelInfo | {}>({});
 
 
 watch(selectedIntegrationType, (newType) => {
@@ -91,6 +95,8 @@ watch(selectedIntegrationType, (newType) => {
     Object.assign(specificChannelInfo.value, getWoocommerceDefaultFields());
   } else if (newType === IntegrationTypes.Amazon) {
     Object.assign(specificChannelInfo.value, getAmazonDefaultFields());
+  } else if (newType === IntegrationTypes.Webhook) {
+    Object.assign(specificChannelInfo.value, getWebhookDefaultFields());
   } else {
     specificChannelInfo.value = {};
   }
@@ -114,18 +120,23 @@ const stepFourLabel = computed(() => {
     return t('integrations.create.wizard.step4.amazon.title');
   }
 
+  if (selectedIntegrationType.value === IntegrationTypes.Webhook) {
+    return t('integrations.create.wizard.step4.webhook.title');
+  }
+
   return t('integrations.create.wizard.step4.title');
 });
 
 const wizardSteps = computed(() => {
-  const baseSteps = [
+  const steps = [
     { title: t('integrations.create.wizard.step1.title'), name: 'typeStep' },
     { title: t('integrations.create.wizard.step2.title'), name: 'generalInfoStep' },
-    { title: t('integrations.create.wizard.step3.title'), name: 'salesChannelStep' },
-    { title: stepFourLabel.value, name: 'specificChannelStep' },
   ];
-
-  return baseSteps;
+  if (selectedIntegrationType.value !== IntegrationTypes.Webhook) {
+    steps.push({ title: t('integrations.create.wizard.step3.title'), name: 'salesChannelStep' });
+  }
+  steps.push({ title: stepFourLabel.value, name: 'specificChannelStep' });
+  return steps;
 });
 
 
@@ -140,6 +151,8 @@ const openInfoModal = () => {
     infoComponent.value = ShopifyInfoCard;
   } else if (selectedIntegrationType.value === IntegrationTypes.Woocommerce) {
     infoComponent.value = WoocommerceInfoCard;
+  } else if (selectedIntegrationType.value === IntegrationTypes.Webhook) {
+    infoComponent.value = WebhookInfoCard;
   } else {
     infoComponent.value = null;
   }
@@ -231,6 +244,13 @@ const allowNextStep = computed(() => {
   return false;
 }
 
+  if (stepName === 'specificChannelStep' && selectedIntegrationType.value === IntegrationTypes.Webhook) {
+    const info = specificChannelInfo.value as WebhookChannelInfo;
+    if (!info.url || info.url.trim() === '' || !info.topic || info.topic.trim() === '') {
+      return false;
+    }
+  }
+
 
   return true;
 });
@@ -238,7 +258,8 @@ const allowNextStep = computed(() => {
 const hasInfoCard = computed(() =>
   selectedIntegrationType.value === IntegrationTypes.Magento ||
   selectedIntegrationType.value === IntegrationTypes.Woocommerce ||
-  selectedIntegrationType.value === IntegrationTypes.Shopify
+  selectedIntegrationType.value === IntegrationTypes.Shopify ||
+  selectedIntegrationType.value === IntegrationTypes.Webhook
 );
 
 const getIntegrationComponent = () => {
@@ -254,6 +275,9 @@ const getIntegrationComponent = () => {
   if (selectedIntegrationType.value === IntegrationTypes.Amazon) {
     return AmazonChannelInfoStep;
   }
+  if (selectedIntegrationType.value === IntegrationTypes.Webhook) {
+    return WebhookChannelInfoStep;
+  }
   return null;
 };
 
@@ -268,6 +292,8 @@ const getIntegrationMutation = () => {
       return createWoocommerceSalesChannelMutation;
     case IntegrationTypes.Amazon:
       return createAmazonSalesChannelMutation;
+    case IntegrationTypes.Webhook:
+      return createWebhookIntegrationMutation;
     default:
       return null;
   }
@@ -283,6 +309,8 @@ const getIntegrationMutationKey = () => {
       return 'createWoocommerceSalesChannel';
     case IntegrationTypes.Amazon:
       return 'createAmazonSalesChannel';
+    case IntegrationTypes.Webhook:
+      return 'createWebhookIntegration';
     default:
       return '';
   }
@@ -472,7 +500,7 @@ const handleSalesChannelSuccess = async (channelData: any, integrationType: stri
           <GeneralInfoStep
               :general-info="form.generalInfo"
               :integration-type="selectedIntegrationType"
-              :max-requests-per-minute="selectedIntegrationType === IntegrationTypes.Shopify ? 120 : undefined"
+              :max-requests-per-minute="selectedIntegrationType === IntegrationTypes.Shopify || selectedIntegrationType === IntegrationTypes.Webhook ? 120 : undefined"
               :show-ssl="
                 selectedIntegrationType !== IntegrationTypes.Shopify &&
                 selectedIntegrationType !== IntegrationTypes.Amazon

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/WebhookChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/WebhookChannelInfoStep.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { TextInput } from '../../../../../../../shared/components/atoms/input-text';
+import { Label } from '../../../../../../../shared/components/atoms/label';
+import WebhookInfoBlock from './WebhookInfoBlock.vue';
+import type { WebhookChannelInfo } from '../../../integrations';
+
+const props = defineProps<{ channelInfo: WebhookChannelInfo }>();
+const { t } = useI18n();
+</script>
+
+<template>
+  <div>
+    <h1 class="text-2xl text-center mb-2">{{ t('integrations.create.wizard.step4.webhook.content') }}</h1>
+    <hr />
+    <Flex vertical>
+      <FlexCell>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.url') }}<span class="text-red-500">*</span>
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                  class="w-96"
+                  v-model="channelInfo.url"
+                  :placeholder="t('integrations.placeholders.url')"
+                />
+              </FlexCell>
+            </Flex>
+            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+              <p>{{ t('integrations.webhook.helpText.url') }}</p>
+            </div>
+          </FlexCell>
+        </Flex>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.topic') }}<span class="text-red-500">*</span>
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                  class="w-96"
+                  v-model="channelInfo.topic"
+                  :placeholder="t('integrations.placeholders.topic')"
+                />
+              </FlexCell>
+            </Flex>
+            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+              <p>{{ t('integrations.webhook.helpText.topic') }}</p>
+            </div>
+          </FlexCell>
+        </Flex>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.version') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                  class="w-96"
+                  v-model="channelInfo.version"
+                  :placeholder="t('integrations.placeholders.version')"
+                />
+              </FlexCell>
+            </Flex>
+            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+              <p>{{ t('integrations.webhook.helpText.version') }}</p>
+            </div>
+          </FlexCell>
+        </Flex>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.userAgent') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                  class="w-96"
+                  v-model="channelInfo.userAgent"
+                  :placeholder="t('integrations.placeholders.userAgent')"
+                />
+              </FlexCell>
+            </Flex>
+            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+              <p>{{ t('integrations.webhook.helpText.userAgent') }}</p>
+            </div>
+          </FlexCell>
+        </Flex>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.timeoutMs') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                  class="w-96"
+                  v-model="channelInfo.timeoutMs"
+                  :number="true"
+                  :placeholder="t('integrations.placeholders.timeoutMs')"
+                />
+              </FlexCell>
+            </Flex>
+            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+              <p>{{ t('integrations.webhook.helpText.timeoutMs') }}</p>
+            </div>
+          </FlexCell>
+        </Flex>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.mode') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                  class="w-96"
+                  v-model="channelInfo.mode"
+                  :placeholder="t('integrations.placeholders.mode')"
+                />
+              </FlexCell>
+            </Flex>
+            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+              <p>{{ t('integrations.webhook.helpText.mode') }}</p>
+            </div>
+          </FlexCell>
+        </Flex>
+        <Flex class="mt-4 gap-4" center>
+          <FlexCell center>
+            <Flex vertical class="gap-2">
+              <FlexCell>
+                <Label class="font-semibold block text-sm leading-6 text-gray-900">
+                  {{ t('integrations.labels.retentionPolicy') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <TextInput
+                  class="w-96"
+                  v-model="channelInfo.retentionPolicy"
+                  :placeholder="t('integrations.placeholders.retentionPolicy')"
+                />
+              </FlexCell>
+            </Flex>
+            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+              <p>{{ t('integrations.webhook.helpText.retentionPolicy') }}</p>
+            </div>
+          </FlexCell>
+        </Flex>
+      </FlexCell>
+    </Flex>
+    <WebhookInfoBlock class="mt-8" />
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/WebhookInfoBlock.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/WebhookInfoBlock.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { Tabs } from '../../../../../../../shared/components/molecules/tabs';
+import { Button } from '../../../../../../../shared/components/atoms/button';
+import { useI18n } from 'vue-i18n';
+
+const payloadExample = `{
+  "id": "<outbox.webhook_id>",
+  "event": "<topic>",
+  "action": "<CREATE|UPDATE|DELETE>",
+  "version": "<integration.version>",
+  "occurred_at": "<utc iso8601>",
+  "subject": {"type": "...", "id": "...", "sku": "optional"},
+  "mode": "<delta|full>",
+  "data": {
+    "before": { ... },
+    "after": { ... },
+    "changed_fields": [ ... ]
+  }
+}`;
+
+const { t } = useI18n();
+
+const tabs = [
+  { name: 'python', label: t('integrations.webhook.infoBlock.languages.python') },
+  { name: 'node', label: t('integrations.webhook.infoBlock.languages.node') },
+  { name: 'php', label: t('integrations.webhook.infoBlock.languages.php') }
+];
+
+const codes = {
+  python: `import hmac, hashlib, time\n\nsecret = b"<your_webhook_secret>"\nheader = request.headers["X-OneSila-Signature"]  # "t=timestamp,v1=hash"\ntimestamp, signature = header.split(",")\ntimestamp = int(timestamp.split("=")[1])\nexpected_sig = hmac.new(secret, f"{timestamp}.{request.body}".encode(), hashlib.sha256).hexdigest()\n\nif not hmac.compare_digest(signature.split("=")[1], expected_sig):\n    raise Exception("Invalid signature")`,
+    node: `const crypto = require("crypto");\n\nfunction verify(body, header, secret) {\n  const [tPart, v1Part] = header.split(",");\n  const timestamp = tPart.split("=")[1];\n  const signature = v1Part.split("=")[1];\n\n  const payload = \`\${timestamp}.\${body}\`;\n  const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");\n\n  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));\n}`,
+  php: `$secret = "<your_webhook_secret>";\n$header = $_SERVER["HTTP_X_ONESILA_SIGNATURE"]; // "t=...,v1=..."\nlist($tPart, $v1Part) = explode(",", $header);\n$timestamp = explode("=", $tPart)[1];\n$signature = explode("=", $v1Part)[1];\n\n$payload = $timestamp . "." . $body;\n$expected = hash_hmac("sha256", $payload, $secret);\n\nif (!hash_equals($signature, $expected)) {\n    throw new Exception("Invalid signature");\n}`
+};
+
+function copyCode(lang: string) {
+  navigator.clipboard.writeText(codes[lang]);
+}
+</script>
+
+<template>
+  <div>
+    <h3 class="text-lg font-semibold">{{ t('integrations.webhook.infoBlock.payloadExample') }}</h3>
+    <pre class="bg-gray-100 p-4 rounded text-xs overflow-auto">{{ payloadExample }}</pre>
+
+    <h3 class="text-lg font-semibold mt-6">{{ t('integrations.webhook.infoBlock.signatureValidation') }}</h3>
+    <Tabs :tabs="tabs">
+      <template #python>
+        <div>
+          <pre class="bg-gray-100 p-4 rounded text-xs overflow-auto">{{ codes.python }}</pre>
+          <Button class="mt-2" @click="copyCode('python')">{{ t('shared.button.copy') }}</Button>
+        </div>
+      </template>
+      <template #node>
+        <div>
+          <pre class="bg-gray-100 p-4 rounded text-xs overflow-auto">{{ codes.node }}</pre>
+          <Button class="mt-2" @click="copyCode('node')">{{ t('shared.button.copy') }}</Button>
+        </div>
+      </template>
+      <template #php>
+        <div>
+          <pre class="bg-gray-100 p-4 rounded text-xs overflow-auto">{{ codes.php }}</pre>
+          <Button class="mt-2" @click="copyCode('php')">{{ t('shared.button.copy') }}</Button>
+        </div>
+      </template>
+    </Tabs>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/index.ts
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/index.ts
@@ -1,0 +1,1 @@
+export { default as WebhookChannelInfoStep } from './WebhookChannelInfoStep.vue';

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/TypeStep.vue
@@ -12,7 +12,7 @@ import { Icon } from "../../../../../../shared/components/atoms/icon";
 import { Modal } from "../../../../../../shared/components/atoms/modal";
 import {Badge} from "../../../../../../shared/components/atoms/badge";
 import {Button} from "../../../../../../shared/components/atoms/button";
-import { MagentoInfoCard, WoocommerceInfoCard, ShopifyInfoCard } from "./info-cards";
+import { MagentoInfoCard, WoocommerceInfoCard, ShopifyInfoCard, WebhookInfoCard } from "./info-cards";
 
 const props = defineProps<{ type: IntegrationTypes }>();
 const emit = defineEmits<{ (e: 'update:type', value: IntegrationTypes): void }>();
@@ -38,7 +38,8 @@ const typeChoices = [
   { name: IntegrationTypes.Magento, disabled: false },
   { name: IntegrationTypes.Shopify, disabled: false, banner: t('shared.labels.beta') },
   { name: IntegrationTypes.Amazon, banner: t('shared.labels.beta') },
-  { name: IntegrationTypes.Woocommerce, banner: t('shared.labels.beta') }
+  { name: IntegrationTypes.Woocommerce, banner: t('shared.labels.beta') },
+  { name: IntegrationTypes.Webhook, disabled: false }
 ];
 
 const onModalOpen = () => {
@@ -53,6 +54,11 @@ const onShopifyModalOpen = () => {
 
 const onWoocommerceModalOpen = () => {
   infoComponent.value = WoocommerceInfoCard;
+  showInfoModal.value = true;
+};
+
+const onWebhookModalOpen = () => {
+  infoComponent.value = WebhookInfoCard;
   showInfoModal.value = true;
 };
 
@@ -120,6 +126,19 @@ const closeModal = () => {
           </Flex>
           <p class="mb-4">{{ t('integrations.create.wizard.step1.woocommerceExample') }}</p>
           <Image :source="woocomerceType" alt="woocommerce" class="w-full max-h-[35rem]" />
+        </div>
+      </template>
+      <template #webhook>
+        <div>
+          <Flex gap="2">
+            <FlexCell center>
+              <h3 class="text-lg font-bold">{{ t('integrations.create.wizard.step1.webhookTitle') }}</h3>
+            </FlexCell>
+            <FlexCell center>
+              <Icon class="text-gray-500" @click.stop="onWebhookModalOpen" name="circle-info" size="lg" />
+            </FlexCell>
+          </Flex>
+          <p class="mb-4">{{ t('integrations.create.wizard.step1.webhookExample') }}</p>
         </div>
       </template>
     </OptionSelector>

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/WebhookInfoCard.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/WebhookInfoCard.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Card } from '../../../../../../../shared/components/atoms/card';
+import { Button } from '../../../../../../../shared/components/atoms/button';
+import WebhookInfoBlock from '../../integration-specific-step/webhook/WebhookInfoBlock.vue';
+
+const emit = defineEmits<{ (e: 'close'): void }>();
+const { t } = useI18n();
+const close = () => emit('close');
+</script>
+
+<template>
+  <Card class="modal-content w-[80%] px-10 pt-10">
+    <WebhookInfoBlock />
+    <hr />
+    <div class="flex justify-end gap-4 mt-4">
+      <Button class="btn btn-outline-dark" @click="close">{{ t('shared.button.cancel') }}</Button>
+    </div>
+  </Card>
+</template>

--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/index.ts
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/index.ts
@@ -1,3 +1,4 @@
 export { default as MagentoInfoCard } from './MagentoInfoCard.vue';
 export { default as WoocommerceInfoCard } from './WoocommerceInfoCard.vue';
 export { default as ShopifyInfoCard } from './ShopifyInfoCard.vue';
+export { default as WebhookInfoCard } from './WebhookInfoCard.vue';

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -3,6 +3,7 @@ export enum IntegrationTypes {
   Shopify = 'shopify',
   Woocommerce = 'woocommerce',
   Amazon = 'amazon',
+  Webhook = 'webhook',
   None = 'none',
 }
 
@@ -103,6 +104,19 @@ export interface AmazonChannelInfo extends SpecificChannelInfo {
   country: string | null;
 }
 
+export interface WebhookChannelInfo extends SpecificChannelInfo {
+  topic: string;
+  version: string;
+  url: string;
+  secret: string;
+  userAgent: string;
+  timeoutMs: number;
+  mode: string;
+  extraHeaders: Record<string, any>;
+  config: Record<string, any>;
+  retentionPolicy: string;
+}
+
 
 /**
  * The complete integration create wizard form.
@@ -145,6 +159,21 @@ export function getAmazonDefaultFields(): AmazonChannelInfo {
   };
 }
 
+export function getWebhookDefaultFields(): WebhookChannelInfo {
+  return {
+    topic: '',
+    version: '',
+    url: '',
+    secret: '',
+    userAgent: 'OneSila-Webhook/1.0',
+    timeoutMs: 0,
+    mode: '',
+    extraHeaders: {},
+    config: {},
+    retentionPolicy: ''
+  };
+}
+
 export const getDefaultFields = (type: IntegrationTypes) => {
   switch (type) {
     case IntegrationTypes.Magento:
@@ -155,6 +184,8 @@ export const getDefaultFields = (type: IntegrationTypes) => {
       return getWoocommerceDefaultFields();
     case IntegrationTypes.Amazon:
       return getAmazonDefaultFields();
+    case IntegrationTypes.Webhook:
+      return getWebhookDefaultFields();
     default:
       return {};
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -358,6 +358,7 @@
       "duplicate": "Duplicate",
       "deleteAll": "Delete all",
       "editAll": "Edit all",
+      "copy": "Copy",
       "change": "Change",
       "createAnyway": "Create anyway",
       "abort": "Abort"
@@ -2469,6 +2470,8 @@
           "amazonExample": "Amazon integration to manage your marketplace listings.",
           "woocommerceTitle": "Woocommerce",
           "woocommerceExample": "WooCommerce integration to manage your products.",
+          "webhookTitle": "Webhook",
+          "webhookExample": "Send events to your application via HTTP",
           "magentoInfoModal": {
             "title": "How to connect your Magento store",
             "section": {
@@ -2555,6 +2558,10 @@
             "title": "Amazon Channel Details",
             "content": "Provide Amazon-specific configuration to connect your marketplace."
           },
+          "webhook": {
+            "title": "Webhook Settings",
+            "content": "Configure your webhook endpoint and options."
+          },
           "title": "Specific Channel Info"
         }
       }
@@ -2583,7 +2590,14 @@
       "country": "Country",
       "expirationDate": "Access Token Expiration",
       "pullData": "Pull Data",
-      "defaultUnits": "Default Units"
+      "defaultUnits": "Default Units",
+      "url": "URL",
+      "topic": "Topic",
+      "version": "Version",
+      "userAgent": "User Agent",
+      "timeoutMs": "Timeout (ms)",
+      "mode": "Mode",
+      "retentionPolicy": "Retention Policy"
     },
     "placeholders": {
       "hostApiUsername": "Enter API Username",
@@ -2592,7 +2606,14 @@
       "apiSecret": "Enter API Secret",
       "attributeSetSkeletonId": "Enter attribute set skeleton ID",
       "eanCodeAttribute": "Enter EAN code attribute",
-      "accessToken": "Enter Access Token"
+      "accessToken": "Enter Access Token",
+      "url": "https://example.com/webhook",
+      "topic": "products",
+      "version": "2025-08-01",
+      "userAgent": "OneSila-Webhook/1.0",
+      "timeoutMs": "3000",
+      "mode": "full",
+      "retentionPolicy": "6M"
     },
     "regions": {
       "northAmerica": "North America",
@@ -2688,6 +2709,26 @@
         },
         "issues": {
           "title": "Issues"
+        }
+      }
+    },
+    "webhook": {
+      "helpText": {
+        "url": "Endpoint that will receive webhook POST requests.",
+        "topic": "Event topic that triggers the webhook.",
+        "version": "Webhook payload version.",
+        "userAgent": "User-Agent header sent with requests.",
+        "timeoutMs": "Milliseconds to wait for a response before failing.",
+        "mode": "Use 'delta' for changes only or 'full' for the entire payload.",
+        "retentionPolicy": "How long webhook deliveries are retained."
+      },
+      "infoBlock": {
+        "payloadExample": "Payload structure example",
+        "signatureValidation": "Signature validation",
+        "languages": {
+          "python": "Python",
+          "node": "Node.js",
+          "php": "PHP"
         }
       }
     },

--- a/src/shared/api/mutations/webhookIntegrations.js
+++ b/src/shared/api/mutations/webhookIntegrations.js
@@ -1,0 +1,1 @@
+export * from './webhooks.js';

--- a/src/shared/api/queries/webhookIntegrations.js
+++ b/src/shared/api/queries/webhookIntegrations.js
@@ -1,0 +1,1 @@
+export * from './webhooks.js';


### PR DESCRIPTION
## Summary
- add webhook integration type and defaults
- extend wizard with webhook step and inline docs
- support creating webhook integrations via API
- localize webhook wizard strings and add field help text

## Testing
- `npm run build` *(fails: process terminated without output in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b06390e5fc832eb2362f8076b21999