### PR TITLE
Expand webhook deliveries query

### DIFF
--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -99,17 +99,23 @@ export const getWebhookOutboxQuery = gql`
 `;
 
 export const webhookDeliveriesQuery = gql`
-  query WebhookDeliveries($first: Int, $last: Int, $after: String, $before: String, $order: WebhookDeliveryOrder, $filter: WebhookDeliveryFilter) {
-    webhookDeliveries(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+  query WebhookDeliveries(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $filter: WebhookDeliveryFilter
+  ) {
+    webhookDeliveries(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      filters: $filter
+    ) {
       edges {
         node {
           id
-          outbox {
-            id
-          }
-          webhookIntegration {
-            id
-          }
           status
           attempt
           responseCode
@@ -118,6 +124,26 @@ export const webhookDeliveriesQuery = gql`
           sentAt
           errorMessage
           errorTraceback
+          outbox {
+            id
+            topic
+            action
+            subjectType
+            subjectId
+            payload
+            webhookIntegration {
+              hostname
+            }
+          }
+          attempts(order: { number: DESC }) {
+            number
+            sentAt
+            responseCode
+            responseMs
+            responseBodySnippet
+            errorText
+            errorTraceback
+          }
         }
         cursor
       }


### PR DESCRIPTION
## Summary
- extend `webhookDeliveriesQuery` with outbox and attempt details
- remove unused `webhookDeliveryEventsQuery`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b07f55ff10832e856871ffc7ff45ff

## Summary by Sourcery

Extend the webhookDeliveries GraphQL query to include outbox metadata and delivery attempt details, and remove the unused webhookDeliveryEventsQuery.

Enhancements:
- Extend webhookDeliveriesQuery to return outbox fields including topic, action, subject, payload, and integration hostname
- Add attempts field to webhookDeliveriesQuery to include detailed delivery attempt history
- Remove unused webhookDeliveryEventsQuery