### PR TITLE
feat: refine webhook configuration fields

### DIFF
--- a/src/core/integrations/integrations/integrations-create/containers/general-info-step/GeneralInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/general-info-step/GeneralInfoStep.vue
@@ -21,13 +21,13 @@ const accordionItems = [
 ];
 
 const hostnameLabel = computed(() => {
-  return props.integrationType === IntegrationTypes.Amazon
+  return [IntegrationTypes.Amazon, IntegrationTypes.Webhook].includes(props.integrationType)
     ? t('shared.labels.name')
     : t('integrations.labels.hostname');
 });
 
 const hostnamePlaceholder = computed(() => {
-  return props.integrationType === IntegrationTypes.Amazon
+  return [IntegrationTypes.Amazon, IntegrationTypes.Webhook].includes(props.integrationType)
     ? t('shared.placeholders.name')
     : 'https://example.com';
 });

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/WebhookChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/WebhookChannelInfoStep.vue
@@ -3,11 +3,42 @@ import { defineProps } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { TextInput } from '../../../../../../../shared/components/atoms/input-text';
 import { Label } from '../../../../../../../shared/components/atoms/label';
-import WebhookInfoBlock from './WebhookInfoBlock.vue';
-import type { WebhookChannelInfo } from '../../../integrations';
+import { Selector } from '../../../../../../../shared/components/atoms/selector';
+import type { WebhookChannelInfo } from '../../../../integrations';
 
 const props = defineProps<{ channelInfo: WebhookChannelInfo }>();
 const { t } = useI18n();
+
+const topicChoices = [
+  { id: 'product', text: t('integrations.webhook.choices.topic.product') },
+  { id: 'ean_code', text: t('integrations.webhook.choices.topic.ean_code') },
+  { id: 'price_list', text: t('integrations.webhook.choices.topic.price_list') },
+  { id: 'price_list_item', text: t('integrations.webhook.choices.topic.price_list_item') },
+  { id: 'media', text: t('integrations.webhook.choices.topic.media') },
+  { id: 'media_through', text: t('integrations.webhook.choices.topic.media_through') },
+  { id: 'property', text: t('integrations.webhook.choices.topic.property') },
+  { id: 'select_value', text: t('integrations.webhook.choices.topic.select_value') },
+  { id: 'property_rule', text: t('integrations.webhook.choices.topic.property_rule') },
+  { id: 'property_rule_item', text: t('integrations.webhook.choices.topic.property_rule_item') },
+  { id: 'product_property', text: t('integrations.webhook.choices.topic.product_property') },
+  { id: 'sales_channel_view_assign', text: t('integrations.webhook.choices.topic.sales_channel_view_assign') },
+  { id: 'all', text: t('integrations.webhook.choices.topic.all') },
+];
+
+const versionChoices = [
+  { id: '2025-08-01', text: t('integrations.webhook.choices.version.2025-08-01') },
+];
+
+const modeChoices = [
+  { id: 'full', text: t('integrations.webhook.choices.mode.full') },
+  { id: 'delta', text: t('integrations.webhook.choices.mode.delta') },
+];
+
+const retentionChoices = [
+  { id: '3m', text: t('integrations.webhook.choices.retentionPolicy.3m') },
+  { id: '6m', text: t('integrations.webhook.choices.retentionPolicy.6m') },
+  { id: '12m', text: t('integrations.webhook.choices.retentionPolicy.12m') },
+];
 </script>
 
 <template>
@@ -46,10 +77,14 @@ const { t } = useI18n();
                 </Label>
               </FlexCell>
               <FlexCell>
-                <TextInput
+                <Selector
                   class="w-96"
                   v-model="channelInfo.topic"
+                  :options="topicChoices"
+                  value-by="id"
+                  label-by="text"
                   :placeholder="t('integrations.placeholders.topic')"
+                  :removable="false"
                 />
               </FlexCell>
             </Flex>
@@ -67,10 +102,14 @@ const { t } = useI18n();
                 </Label>
               </FlexCell>
               <FlexCell>
-                <TextInput
+                <Selector
                   class="w-96"
                   v-model="channelInfo.version"
+                  :options="versionChoices"
+                  value-by="id"
+                  label-by="text"
                   :placeholder="t('integrations.placeholders.version')"
+                  :removable="false"
                 />
               </FlexCell>
             </Flex>
@@ -131,10 +170,14 @@ const { t } = useI18n();
                 </Label>
               </FlexCell>
               <FlexCell>
-                <TextInput
+                <Selector
                   class="w-96"
                   v-model="channelInfo.mode"
+                  :options="modeChoices"
+                  value-by="id"
+                  label-by="text"
                   :placeholder="t('integrations.placeholders.mode')"
+                  :removable="false"
                 />
               </FlexCell>
             </Flex>
@@ -152,10 +195,14 @@ const { t } = useI18n();
                 </Label>
               </FlexCell>
               <FlexCell>
-                <TextInput
+                <Selector
                   class="w-96"
                   v-model="channelInfo.retentionPolicy"
+                  :options="retentionChoices"
+                  value-by="id"
+                  label-by="text"
                   :placeholder="t('integrations.placeholders.retentionPolicy')"
+                  :removable="false"
                 />
               </FlexCell>
             </Flex>
@@ -166,6 +213,5 @@ const { t } = useI18n();
         </Flex>
       </FlexCell>
     </Flex>
-    <WebhookInfoBlock class="mt-8" />
   </div>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { TextInput } from "../../../../../../../shared/components/atoms/input-text";
 import { Label } from "../../../../../../../shared/components/atoms/label";
+import { Selector } from "../../../../../../../shared/components/atoms/selector";
 import { Toggle } from "../../../../../../../shared/components/atoms/toggle";
 import { Accordion } from "../../../../../../../shared/components/atoms/accordion";
 import { Button } from "../../../../../../../shared/components/atoms/button";
@@ -42,6 +43,37 @@ const submitContinueButtonRef = ref();
 
 const accordionItems = [
   { name: 'throttling', label: t('integrations.show.sections.throttling'), icon: 'gauge' }
+];
+
+const topicChoices = [
+  { id: 'product', text: t('integrations.webhook.choices.topic.product') },
+  { id: 'ean_code', text: t('integrations.webhook.choices.topic.ean_code') },
+  { id: 'price_list', text: t('integrations.webhook.choices.topic.price_list') },
+  { id: 'price_list_item', text: t('integrations.webhook.choices.topic.price_list_item') },
+  { id: 'media', text: t('integrations.webhook.choices.topic.media') },
+  { id: 'media_through', text: t('integrations.webhook.choices.topic.media_through') },
+  { id: 'property', text: t('integrations.webhook.choices.topic.property') },
+  { id: 'select_value', text: t('integrations.webhook.choices.topic.select_value') },
+  { id: 'property_rule', text: t('integrations.webhook.choices.topic.property_rule') },
+  { id: 'property_rule_item', text: t('integrations.webhook.choices.topic.property_rule_item') },
+  { id: 'product_property', text: t('integrations.webhook.choices.topic.product_property') },
+  { id: 'sales_channel_view_assign', text: t('integrations.webhook.choices.topic.sales_channel_view_assign') },
+  { id: 'all', text: t('integrations.webhook.choices.topic.all') },
+];
+
+const versionChoices = [
+  { id: '2025-08-01', text: t('integrations.webhook.choices.version.2025-08-01') },
+];
+
+const modeChoices = [
+  { id: 'full', text: t('integrations.webhook.choices.mode.full') },
+  { id: 'delta', text: t('integrations.webhook.choices.mode.delta') },
+];
+
+const retentionChoices = [
+  { id: '3m', text: t('integrations.webhook.choices.retentionPolicy.3m') },
+  { id: '6m', text: t('integrations.webhook.choices.retentionPolicy.6m') },
+  { id: '12m', text: t('integrations.webhook.choices.retentionPolicy.12m') },
 ];
 
 watch(() => props.data, (newData) => {
@@ -125,7 +157,15 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.topic') }}
         </Label>
-        <TextInput v-model="formData.topic" :placeholder="t('integrations.placeholders.topic')" class="w-full" />
+        <Selector
+          v-model="formData.topic"
+          :options="topicChoices"
+          value-by="id"
+          label-by="text"
+          :placeholder="t('integrations.placeholders.topic')"
+          :removable="false"
+          class="w-full"
+        />
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.topic') }}</p>
         </div>
@@ -137,7 +177,15 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.version') }}
         </Label>
-        <TextInput v-model="formData.version" :placeholder="t('integrations.placeholders.version')" class="w-full" />
+        <Selector
+          v-model="formData.version"
+          :options="versionChoices"
+          value-by="id"
+          label-by="text"
+          :placeholder="t('integrations.placeholders.version')"
+          :removable="false"
+          class="w-full"
+        />
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.version') }}</p>
         </div>
@@ -167,7 +215,15 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.mode') }}
         </Label>
-        <TextInput v-model="formData.mode" :placeholder="t('integrations.placeholders.mode')" class="w-full" />
+        <Selector
+          v-model="formData.mode"
+          :options="modeChoices"
+          value-by="id"
+          label-by="text"
+          :placeholder="t('integrations.placeholders.mode')"
+          :removable="false"
+          class="w-full"
+        />
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.mode') }}</p>
         </div>
@@ -179,7 +235,15 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.retentionPolicy') }}
         </Label>
-        <TextInput v-model="formData.retentionPolicy" :placeholder="t('integrations.placeholders.retentionPolicy')" class="w-full" />
+        <Selector
+          v-model="formData.retentionPolicy"
+          :options="retentionChoices"
+          value-by="id"
+          label-by="text"
+          :placeholder="t('integrations.placeholders.retentionPolicy')"
+          :removable="false"
+          class="w-full"
+        />
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.retentionPolicy') }}</p>
         </div>

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -166,7 +166,7 @@ export function getWebhookDefaultFields(): WebhookChannelInfo {
     url: '',
     secret: '',
     userAgent: 'OneSila-Webhook/1.0',
-    timeoutMs: 0,
+    timeoutMs: 10000,
     mode: '',
     extraHeaders: {},
     config: {},

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2612,7 +2612,7 @@
       "topic": "products",
       "version": "2025-08-01",
       "userAgent": "OneSila-Webhook/1.0",
-      "timeoutMs": "3000",
+      "timeoutMs": "10000",
       "mode": "full",
       "retentionPolicy": "6M"
     },
@@ -2722,6 +2722,35 @@
         "timeoutMs": "Milliseconds to wait for a response before failing.",
         "mode": "Use 'delta' for changes only or 'full' for the entire payload.",
         "retentionPolicy": "How long webhook deliveries are retained."
+      },
+      "choices": {
+        "topic": {
+          "product": "product",
+          "ean_code": "ean_code",
+          "price_list": "price_list",
+          "price_list_item": "price_list_item",
+          "media": "media",
+          "media_through": "media_through",
+          "property": "property",
+          "select_value": "select_value",
+          "property_rule": "property_rule",
+          "property_rule_item": "property_rule_item",
+          "product_property": "product_property",
+          "sales_channel_view_assign": "sales_channel_view_assign",
+          "all": "all"
+        },
+        "version": {
+          "2025-08-01": "2025-08-01"
+        },
+        "mode": {
+          "full": "full",
+          "delta": "delta"
+        },
+        "retentionPolicy": {
+          "3m": "3m",
+          "6m": "6m",
+          "12m": "12m"
+        }
       },
       "infoBlock": {
         "payloadExample": "Payload structure example",


### PR DESCRIPTION
## Summary
- use `Name` instead of `Hostname` for webhook integrations
- convert topic, version, mode and retention policy to selects with translated choices
- default webhook timeout to 10 seconds and drop info block from channel step

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b07c3d0184832e962df92f07535c9f

## Summary by Sourcery

Refine the webhook integration form by replacing free-text fields with dropdown selectors, updating labels and defaults, and cleaning up UI elements.

Enhancements:
- Convert topic, version, mode, and retentionPolicy fields from text inputs to Selector components with predefined translated options
- Change the general info step to use the 'Name' label instead of 'Hostname' for webhook integrations
- Set the default webhook timeout to 10 seconds in the default channel configuration
- Remove the informational WebhookInfoBlock from the webhook channel configuration step

Documentation:
- Add translation keys for webhook topic, version, mode, and retentionPolicy choices