### PR TITLE
feat(webhooks): add monitor tab

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, defineAsyncComponent } from 'vue';
 import { useI18n } from 'vue-i18n';
 import GeneralTemplate from "../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../shared/components/molecules/breadcrumbs";
@@ -34,6 +34,8 @@ import { DefaultUnitConfigurators } from "./containers/default-unit-configurator
 import { Imports } from "./containers/imports";
 import { refreshSalesChannelWebsitesMutation } from "../../../../shared/api/mutations/salesChannels";
 import {Toast} from "../../../../shared/modules/toast";
+
+const WebhookMonitor = defineAsyncComponent(() => import('./containers/monitor/WebhookMonitor.vue'));
 
 const router = useRouter();
 const route = useRoute();
@@ -72,6 +74,8 @@ if (type.value !== IntegrationTypes.Webhook) {
   }
 
   tabItems.value.push({ name: 'imports', label: t('shared.tabs.imports'), icon: 'file-import' });
+} else {
+  tabItems.value.push({ name: 'monitor', label: t('webhooks.monitor.title'), icon: 'wave-square' });
 }
 
 
@@ -235,6 +239,11 @@ const pullData = async () => {
               :is="getGeneralComponent()"
               :data="integrationData"
             />
+          </template>
+
+          <!-- Monitor Tab -->
+          <template #monitor>
+            <WebhookMonitor v-if="integrationId" :integration-id="integrationId" />
           </template>
 
           <!-- Products Tab -->

--- a/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { useLiveMonitor } from './useLiveMonitor';
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  integrationId: string;
+}>();
+
+useLiveMonitor({ filters: { integrationId: props.integrationId } });
+</script>
+
+<template>
+  <div>{{ t('webhooks.monitor.title') }}</div>
+</template>
+

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -132,5 +132,10 @@
         "variationThemeDeleted": "Variation theme deleted"
       }
     }
+  },
+  "webhooks": {
+    "monitor": {
+      "title": "Monitor"
+    }
   }
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2797,5 +2797,10 @@
         }
       }
     }
+  },
+  "webhooks": {
+    "monitor": {
+      "title": "Monitor"
+    }
   }
 }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -132,5 +132,10 @@
         "variationThemeDeleted": "Variation theme deleted"
       }
     }
+  },
+  "webhooks": {
+    "monitor": {
+      "title": "Monitor"
+    }
   }
 }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1939,5 +1939,10 @@
         "notAssignedToSalesChannelView": "Niet toegewezen aan winkel"
       }
     }
+  },
+  "webhooks": {
+    "monitor": {
+      "title": "Monitor"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add monitor tab for webhook integrations
- lazy load WebhookMonitor component
- provide translation for monitor tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module '../../../integrations' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b087c09e78832eb8377555f438cc84

## Summary by Sourcery

Introduce a new asynchronously loaded Monitor tab for webhook integrations with live monitoring support and translations.

New Features:
- Add a Monitor tab to the integrations interface for webhook integrations
- Lazy-load the new WebhookMonitor component
- Implement a WebhookMonitor.vue component that initializes live monitoring via useLiveMonitor

Documentation:
- Provide localized labels for the monitor tab in de, en, fr, and nl locale files