### PR TITLE
Improve webhook defaults and labels

### DIFF
--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -162,7 +162,7 @@ export function getAmazonDefaultFields(): AmazonChannelInfo {
 export function getWebhookDefaultFields(): WebhookChannelInfo {
   return {
     topic: '',
-    version: '',
+    version: '2025-08-01',
     url: '',
     secret: '',
     userAgent: 'OneSila-Webhook/1.0',

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2613,8 +2613,8 @@
       "version": "2025-08-01",
       "userAgent": "OneSila-Webhook/1.0",
       "timeoutMs": "10000",
-      "mode": "full",
-      "retentionPolicy": "6M"
+      "mode": "Full",
+      "retentionPolicy": "6 Months"
     },
     "regions": {
       "northAmerica": "North America",
@@ -2743,13 +2743,13 @@
           "2025-08-01": "2025-08-01"
         },
         "mode": {
-          "full": "full",
-          "delta": "delta"
+          "full": "Full",
+          "delta": "Delta"
         },
         "retentionPolicy": {
-          "3m": "3m",
-          "6m": "6m",
-          "12m": "12m"
+          "3m": "3 Months",
+          "6m": "6 Months",
+          "12m": "12 Months"
         }
       },
       "infoBlock": {


### PR DESCRIPTION
## Summary
- Show friendly names for webhook retention and mode options
- Default webhook version to 2025-08-01

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: "webhookDeliveryEventsQuery" is not exported by webhooks.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b0909953e4832ea4f0ebbf28559b44