### PR TITLE
Skip sales channel fields for webhook integrations

### DIFF
--- a/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
+++ b/src/core/integrations/integrations/integrations-create/IntegrationCreateController.vue
@@ -331,7 +331,7 @@ const handleFinish = async () => {
     // Flatten the form fields into a single object
     const dataInput = {
       ...form.generalInfo,
-      ...form.salesChannelInfo,
+      ...(selectedIntegrationType.value !== IntegrationTypes.Webhook ? form.salesChannelInfo : {}),
       ...specificChannelInfo.value
     };
 


### PR DESCRIPTION
## Summary
- avoid including sales channel fields when creating webhook integrations

## Testing
- `npm run build` *(fails: "webhookDeliveryEventsQuery" is not exported)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d08de12c832e80540eeefb967f5e

## Summary by Sourcery

Enhancements:
- Exclude sales channel info when the selected integration type is Webhook