### PR TITLE
feat: add date range filter

### DIFF
--- a/src/shared/components/organisms/general-search/containers/filter-modal/FilterModal.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/FilterModal.vue
@@ -14,6 +14,7 @@ import { FilterQuery } from './containers/filter-query';
 import { FilterDate } from './containers/filter-date';
 import { FilterSlider } from './containers/filter-slider';
 import { FilterCheckbox } from './containers/filter-checkbox';
+import { FilterDateRange } from './containers/filter-date-range';
 
 const { t } = useI18n();
 
@@ -31,6 +32,7 @@ const getFilterComponent = (type) => {
     case FieldType.Choice: return FilterChoice;
     case FieldType.Query: return FilterQuery;
     case FieldType.Date: return FilterDate;
+    case FieldType.RangeDate: return FilterDateRange;
     case FieldType.Slider: return FilterSlider;
     case FieldType.Checkbox: return FilterCheckbox;
     default: return null;

--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-date-range/FilterDateRange.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-date-range/FilterDateRange.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref, watch, watchEffect } from 'vue';
+import { useRoute } from 'vue-router';
+import { Label } from '../../../../../../atoms/label';
+import { RangeDateInput } from '../../../../../../atoms/input-date-range';
+import { DateRangeFilter } from '../../../../searchConfig';
+
+const props = defineProps<{ filter: DateRangeFilter }>();
+const emit = defineEmits(['update-value']);
+const route = useRoute();
+
+const dateRange = ref<any>(props.filter.default ?? null);
+
+const formatDate = (date: Date | string) => {
+  const d = new Date(date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+watch(
+  () => route.query[props.filter.name],
+  (newValue) => {
+    if (typeof newValue === 'string' && newValue.includes(',')) {
+      const [start, end] = newValue.split(',');
+      dateRange.value = [start ? new Date(start) : null, end ? new Date(end) : null];
+    } else if (newValue === undefined) {
+      dateRange.value = null;
+    }
+  },
+  { immediate: true }
+);
+
+watchEffect(() => {
+  if (Array.isArray(dateRange.value) && dateRange.value[0] && dateRange.value[1]) {
+    const start = formatDate(dateRange.value[0]);
+    const end = formatDate(dateRange.value[1]);
+    emit('update-value', `${start},${end}`);
+  } else {
+    emit('update-value', null);
+  }
+});
+</script>
+
+<template>
+  <div class="filter-item">
+    <Label>{{ filter.label }}</Label>
+    <RangeDateInput v-model:model-value="dateRange" class="mb-2" />
+  </div>
+</template>

--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-date-range/index.ts
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-date-range/index.ts
@@ -1,0 +1,1 @@
+export { default as FilterDateRange } from "./FilterDateRange.vue";

--- a/src/shared/components/organisms/general-search/searchConfig.ts
+++ b/src/shared/components/organisms/general-search/searchConfig.ts
@@ -75,6 +75,10 @@ export interface DateFilter extends BaseFilter {
   type: FieldType.Date;
 }
 
+export interface DateRangeFilter extends BaseFilter {
+  type: FieldType.RangeDate;
+}
+
 export interface SliderFilter extends BaseFilter {
   type: FieldType.Slider;
 }
@@ -91,7 +95,7 @@ export interface OrderCriteria {
   type: OrderType;
 }
 
-export type SearchFilter = BooleanFilter | ValueFilter | ChoiceFilter | QueryFilter | DateFilter | SliderFilter | CheckboxFilter;
+export type SearchFilter = BooleanFilter | ValueFilter | ChoiceFilter | QueryFilter | DateFilter | DateRangeFilter | SliderFilter | CheckboxFilter;
 
 export interface SearchConfig {
   search: boolean;


### PR DESCRIPTION
## Summary
- add DateRangeFilter interface to search config
- implement `FilterDateRange` component and wire it in FilterModal

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0da07c55c832e9b6efbe6e5f44492

## Summary by Sourcery

Add support for date range filtering by extending the search configuration with a new DateRangeFilter type, creating a corresponding FilterDateRange Vue component, and integrating it into the filter modal.

New Features:
- Introduce a DateRangeFilter interface and include it in the SearchFilter union
- Implement a FilterDateRange component that handles selecting and formatting date ranges from the route query
- Wire the RangeDate filter into FilterModal so it renders the new FilterDateRange component for date range fields