### PR TITLE
feat: add select current button for Amazon browse nodes

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
@@ -278,6 +278,13 @@ const goBack = () => {
   const target = pathStack.value.length - 2;
   goToLevel(target >= 0 ? target : null);
 };
+
+const selectCurrent = () => {
+  const node = pathStack.value[pathStack.value.length - 1];
+  if (node) {
+    selectNode(node);
+  }
+};
 const selectNode = (node: BrowseNode) => {
   pendingNode.value = node;
 };
@@ -459,13 +466,17 @@ const showAlert = computed(
             >{{ crumb.name }}</span
           >
         </template>
-        <Button
-          v-if="pathStack.length"
-          class="btn btn-sm btn-outline-primary ml-auto"
-          @click="goBack"
-        >
-          {{ t('shared.button.back') }}
-        </Button>
+        <div v-if="pathStack.length" class="flex gap-1 ml-auto">
+          <Button
+            class="btn btn-sm btn-outline-primary"
+            @click="selectCurrent"
+          >
+            {{ t('products.products.amazon.selectCurrentNode') }}
+          </Button>
+          <Button class="btn btn-sm btn-outline-primary" @click="goBack">
+            {{ t('shared.button.back') }}
+          </Button>
+        </div>
       </div>
 
       <input

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -116,6 +116,7 @@
         "browseNodeDeleted": "Browse node deleted",
         "noBrowseNodeSelected": "No browse node selected",
         "browseNodeRoot": "Root",
+        "selectCurrentNode": "Select current",
         "recommendedProductTypes": "Recommended product types",
         "createProductTypeTitle": "Create product type",
         "createProductTypeConfirm": "This will create and map the product type \"{type}\". Do you want to continue?",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1006,6 +1006,7 @@
         "browseNodeDeleted": "Browse node deleted",
         "noBrowseNodeSelected": "No browse node selected",
         "browseNodeRoot": "Root",
+        "selectCurrentNode": "Select current",
         "recommendedProductTypes": "Recommended product types",
         "createProductTypeTitle": "Create product type",
         "createProductTypeConfirm": "This will create and map the product type \"{type}\". Do you want to continue?",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -116,6 +116,7 @@
         "browseNodeDeleted": "Browse node deleted",
         "noBrowseNodeSelected": "No browse node selected",
         "browseNodeRoot": "Root",
+        "selectCurrentNode": "Select current",
         "recommendedProductTypes": "Recommended product types",
         "createProductTypeTitle": "Create product type",
         "createProductTypeConfirm": "This will create and map the product type \"{type}\". Do you want to continue?",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -703,6 +703,7 @@
         "browseNodeDeleted": "Browse node deleted",
         "noBrowseNodeSelected": "No browse node selected",
         "browseNodeRoot": "Root",
+        "selectCurrentNode": "Select current",
         "recommendedProductTypes": "Recommended product types",
         "createProductTypeTitle": "Create product type",
         "createProductTypeConfirm": "This will create and map the product type \"{type}\". Do you want to continue?",


### PR DESCRIPTION
## Summary
- add button to select current browse node in Amazon tab
- add translations for new button label

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b189c933a0832e9144d4e26c6f2399

## Summary by Sourcery

Add a button to select the current browse node directly in the Amazon tab and include translations for its label across supported locales.

New Features:
- Add a 'Select current node' button to the Amazon browse nodes section

Enhancements:
- Add translation keys for the new button label in English, German, French, and Dutch