### PR TITLE
fix: adjust product SKU clipboard icon color

### DIFF
--- a/src/core/products/products/product-show/ProductShowController.vue
+++ b/src/core/products/products/product-show/ProductShowController.vue
@@ -176,7 +176,7 @@ const copySkuToClipboard = async (sku: string) => {
                       <Label semi-bold>{{ t('shared.labels.sku') }}:</Label>
                       <p class="text-white-dark">{{ getResultData(result, 'sku') }}</p>
                       <Button class="ml-1" @click="copySkuToClipboard(getResultData(result, 'sku'))">
-                        <Icon name="clipboard" class="h-4 w-4" />
+                        <Icon name="clipboard" class="h-4 w-4 text-gray-500" aria-hidden="true" />
                       </Button>
                     </Flex>
                     <Flex v-if="getResultData(result, null, 'name')">


### PR DESCRIPTION
## Summary
- match clipboard icon color on product SKU page with media show page

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b191c0bda4832eb0ad766fd85cc41e

## Summary by Sourcery

Bug Fixes:
- Adjust clipboard icon color on product SKU page to match media show page