### PR TITLE
Update Amazon mapping terminology

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -190,12 +190,12 @@
           "description": "Amazon product types that need mapping."
         },
         "unmappedLocalProductTypes": {
-          "title": "Unmapped Local Product Types",
-          "description": "Local product types that need mapping to Amazon."
+          "title": "Unmapped OneSila Product Types",
+          "description": "OneSila product types that need mapping to Amazon."
         },
         "unmappedSelectValues": {
           "title": "Unmapped Select Values",
-          "description": "Amazon property values that need mapping in order to be imported locally."
+          "description": "Amazon property values that need mapping in order to be imported into OneSila."
         },
         "unmappedDefaultUnitConfigurators": {
           "title": "Default Unit Configurator",
@@ -2402,21 +2402,21 @@
       "propertySelectValues": {
         "title": "Amazon Property Values",
         "labels": {
-          "remoteName": "Remote Name",
-          "remoteValue": "Remote Value",
+          "remoteName": "Amazon Name",
+          "remoteValue": "Amazon Value",
           "amazonProperty": "Amazon Property",
           "marketplace": "Marketplace",
-          "localProperty": "Local Property",
-          "selectValue": "Select Value",
+          "localProperty": "OneSila Property",
+          "selectValue": "OneSila Select Value",
           "translatedRemoteName": "Translated Name"
         },
         "help": {
           "amazonProperty": "Amazon property to which this value belongs.",
           "marketplace": "Amazon marketplace for this value.",
-          "localProperty": "Local property that this Amazon property maps to.",
+          "localProperty": "OneSila property that this Amazon property maps to.",
           "remoteValue": "Value exactly as defined in Amazon.",
           "remoteName": "Name from Amazon. You can change it.",
-          "selectValue": "Choose the local value that matches this Amazon value.",
+          "selectValue": "Choose the OneSila value that matches this Amazon value.",
           "translatedRemoteName": "Translated name for this value."
         },
         "notMappedBanner": {
@@ -2433,15 +2433,15 @@
         "assignSuccess": "Values were successfully assigned"
       },
       "mapping": {
-        "mappedLocally": "Mapped Locally",
-        "mappedRemotely": "Mapped Remotely",
+        "mappedLocally": "Mapped in OneSila",
+        "mappedRemotely": "Mapped on Amazon",
         "startMapping": "Start Mapping",
         "saveAndMapNext": "Save & Map Next",
         "allMappedSuccess": "You mapped all the values"
       },
       "generateProperty": "Generate Property",
       "generateProductType": "Generate Product Type",
-      "pullLocalRules": "Pull Local Rules",
+      "pullLocalRules": "Pull OneSila Rules",
       "generatePropertySelectValue": "Generate Select Value",
       "mapProperty": "Map Property",
       "mapProductType": "Map Product Type",


### PR DESCRIPTION
## Summary
- align Amazon mapping translations with OneSila/Amazon terminology

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b191f34d58832ea82b94301457b805

## Summary by Sourcery

Align Amazon mapping terminology in the English locale file to match OneSila/Amazon standards.

Enhancements:
- Update Amazon mapping labels and terms in the English locale

Documentation:
- Revise translations in en.json to reflect updated Amazon mapping terminology