### PR TITLE
Fix webhook integration layout issue

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
@@ -252,20 +252,21 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.secret') }}
         </Label>
-        <div class="flex gap-2">
-          <input
-            type="password"
-            :value="formData.secret"
-            disabled
-            class="text-input border border-gray-300 shadow-sm rounded-md px-3 py-2 text-sm placeholder:italic focus:outline-none focus:border-sky-500 focus:ring-sky-500 focus:ring-1 w-full"
-          />
-          <Button @click="copySecret" class="flex-shrink-0">
-            <Icon name="clipboard" class="h-5 w-5 text-gray-500" aria-hidden="true" />
-          </Button>
-          <Button @click="regenerateSecret" class="flex-shrink-0">
-            {{ t('integrations.webhook.buttons.regenerateSecret') }}
-          </Button>
-        </div>
+        <Flex gap="2" middle>
+          <FlexCell grow>
+            <TextInput v-model="formData.secret" secret disabled class="w-full" />
+          </FlexCell>
+          <FlexCell>
+            <Button @click="copySecret">
+              <Icon name="clipboard" class="h-5 w-5 text-gray-500" aria-hidden="true" />
+            </Button>
+          </FlexCell>
+          <FlexCell>
+            <Button @click="regenerateSecret">
+              {{ t('integrations.webhook.buttons.regenerateSecret') }}
+            </Button>
+          </FlexCell>
+        </Flex>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- standardize webhook secret field with TextInput and Flex layout

## Testing
- `npm run build` *(fails: "webhookDeliveryEventsQuery" is not exported by "src/shared/api/queries/webhooks.js" )*

------
https://chatgpt.com/codex/tasks/task_e_68b723846cd8832e8e68bbc7977a8d8f

## Summary by Sourcery

Enhancements:
- Replace raw password input and buttons with design system TextInput and Flex layout for the webhook secret field