### PR TITLE
Fix webhook integration form fields and mutation

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
@@ -35,7 +35,21 @@ interface EditWebhookForm {
 
 const props = defineProps<{ data: EditWebhookForm }>();
 const { t } = useI18n();
-const formData = ref<EditWebhookForm>({ ...props.data });
+
+const removeTypename = (obj: any): any => {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => removeTypename(item));
+  } else if (obj && typeof obj === 'object') {
+    const { __typename, ...rest } = obj;
+    Object.keys(rest).forEach((key) => {
+      rest[key] = removeTypename(rest[key]);
+    });
+    return rest;
+  }
+  return obj;
+};
+
+const formData = ref<EditWebhookForm>(removeTypename(props.data));
 const fieldErrors = ref<Record<string, string>>({});
 const router = useRouter();
 const submitButtonRef = ref();
@@ -76,13 +90,17 @@ const retentionChoices = [
   { id: '12m', text: t('integrations.webhook.choices.retentionPolicy.12m') },
 ];
 
-watch(() => props.data, (newData) => {
-  formData.value = { ...newData };
-}, { deep: true });
+watch(
+  () => props.data,
+  (newData) => {
+    formData.value = removeTypename(newData);
+  },
+  { deep: true }
+);
 
 const cleanupAndMutate = async (mutate) => {
   fieldErrors.value = {};
-  await mutate({ variables: { data: formData.value } });
+  await mutate({ variables: { data: removeTypename(formData.value) } });
 };
 
 const handleError = (errors) => {
@@ -157,15 +175,17 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.topic') }}
         </Label>
-        <Selector
-          v-model="formData.topic"
-          :options="topicChoices"
-          value-by="id"
-          label-by="text"
-          :placeholder="t('integrations.placeholders.topic')"
-          :removable="false"
-          class="w-full"
-        />
+        <div>
+          <Selector
+            v-model="formData.topic"
+            :options="topicChoices"
+            value-by="id"
+            label-by="text"
+            :placeholder="t('integrations.placeholders.topic')"
+            :removable="false"
+            class="w-full"
+          />
+        </div>
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.topic') }}</p>
         </div>
@@ -177,15 +197,17 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.version') }}
         </Label>
-        <Selector
-          v-model="formData.version"
-          :options="versionChoices"
-          value-by="id"
-          label-by="text"
-          :placeholder="t('integrations.placeholders.version')"
-          :removable="false"
-          class="w-full"
-        />
+        <div>
+          <Selector
+            v-model="formData.version"
+            :options="versionChoices"
+            value-by="id"
+            label-by="text"
+            :placeholder="t('integrations.placeholders.version')"
+            :removable="false"
+            class="w-full"
+          />
+        </div>
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.version') }}</p>
         </div>
@@ -215,15 +237,17 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.mode') }}
         </Label>
-        <Selector
-          v-model="formData.mode"
-          :options="modeChoices"
-          value-by="id"
-          label-by="text"
-          :placeholder="t('integrations.placeholders.mode')"
-          :removable="false"
-          class="w-full"
-        />
+        <div>
+          <Selector
+            v-model="formData.mode"
+            :options="modeChoices"
+            value-by="id"
+            label-by="text"
+            :placeholder="t('integrations.placeholders.mode')"
+            :removable="false"
+            class="w-full"
+          />
+        </div>
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.mode') }}</p>
         </div>
@@ -235,15 +259,17 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.retentionPolicy') }}
         </Label>
-        <Selector
-          v-model="formData.retentionPolicy"
-          :options="retentionChoices"
-          value-by="id"
-          label-by="text"
-          :placeholder="t('integrations.placeholders.retentionPolicy')"
-          :removable="false"
-          class="w-full"
-        />
+        <div>
+          <Selector
+            v-model="formData.retentionPolicy"
+            :options="retentionChoices"
+            value-by="id"
+            label-by="text"
+            :placeholder="t('integrations.placeholders.retentionPolicy')"
+            :removable="false"
+            class="w-full"
+          />
+        </div>
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.retentionPolicy') }}</p>
         </div>
@@ -262,9 +288,9 @@ const regenerateSecret = async () => {
             </Button>
           </FlexCell>
           <FlexCell>
-            <Button @click="regenerateSecret">
+            <SecondaryButton @click="regenerateSecret">
               {{ t('integrations.webhook.buttons.regenerateSecret') }}
-            </Button>
+            </SecondaryButton>
           </FlexCell>
         </Flex>
       </div>

--- a/src/shared/api/mutations/webhooks.js
+++ b/src/shared/api/mutations/webhooks.js
@@ -4,6 +4,8 @@ export const createWebhookIntegrationMutation = gql`
   mutation createWebhookIntegration($data: WebhookIntegrationInput!) {
     createWebhookIntegration(data: $data) {
       id
+      hostname
+      active
       topic
       version
       url
@@ -24,6 +26,8 @@ export const createWebhookIntegrationsMutation = gql`
   mutation createWebhookIntegrations($data: [WebhookIntegrationInput!]!) {
     createWebhookIntegrations(data: $data) {
       id
+      hostname
+      active
       topic
       version
       url
@@ -44,6 +48,8 @@ export const updateWebhookIntegrationMutation = gql`
   mutation updateWebhookIntegration($data: WebhookIntegrationPartialInput!) {
     updateWebhookIntegration(data: $data) {
       id
+      hostname
+      active
       topic
       version
       url
@@ -64,6 +70,8 @@ export const regenerateWebhookIntegrationSecretMutation = gql`
   mutation regenerateWebhookIntegrationSecret($data: WebhookIntegrationPartialInput!) {
     regenerateWebhookIntegrationSecret(data: $data) {
       id
+      hostname
+      active
       topic
       version
       url

--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -6,6 +6,8 @@ export const webhookIntegrationsQuery = gql`
       edges {
         node {
           id
+          hostname
+          active
           topic
           version
           url
@@ -36,6 +38,8 @@ export const getWebhookIntegrationQuery = gql`
   query GetWebhookIntegration($id: GlobalID!) {
     webhookIntegration(id: $id) {
       id
+      hostname
+      active
       topic
       version
       url


### PR DESCRIPTION
## Summary
- Populate webhook name and active fields
- Sanitize webhook data before saving to remove GraphQL typenames
- Style regenerate secret button and fix selector heights

## Testing
- ⚠️ `npm test` *(missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b738444f94832e839e3ff98530e925

## Summary by Sourcery

Add hostname and active fields to webhook GraphQL operations, sanitize form data by stripping GraphQL typenames, populate missing form fields, and adjust selector and button styling for the webhook integration form

New Features:
- Include hostname and active fields in webhook integration GraphQL queries and mutations

Bug Fixes:
- Populate webhook name and active fields in the webhook settings form
- Strip __typename properties from form data before performing mutations

Enhancements:
- Wrap Selector components in a container to fix their height
- Use SecondaryButton for the regenerate secret action for consistent styling