### PR TITLE
refactor: integrate headbar filters for webhook monitor

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2844,7 +2844,21 @@
         "action": "Action",
         "status": "Status",
         "responseCode": "Response Code",
-        "subject": "Subject"
+        "subject": "Subject",
+        "date": "Date"
+      },
+      "actions": {
+        "create": "Create",
+        "update": "Update",
+        "delete": "Delete"
+      },
+      "statuses": {
+        "success": "Success",
+        "failed": "Failed"
+      },
+      "subjects": {
+        "order": "Order",
+        "product": "Product"
       },
       "autoRefresh": "Auto-refresh",
       "rpmCap": "RPM Cap"


### PR DESCRIPTION
## Summary
- hook Webhook monitor filters into global headbar filter system
- add date range filtering via URL-synced search config
- switch action, status, response code, and subject filters to selectors with translation-backed options

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: "webhookDeliveryEventsQuery" is not exported by "src/shared/api/queries/webhooks.js")*

------
https://chatgpt.com/codex/tasks/task_e_68b74aef3fb0832e8a559dbc6b8bee18