### PR TITLE
feat(webhooks): add event stream table

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/monitor/useLiveMonitor.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/useLiveMonitor.ts
@@ -23,6 +23,7 @@ interface Options {
 
 export function useLiveMonitor(options: Options = {}) {
   const events = ref<any[]>([]);
+  const pageInfo = ref<any | null>(null);
   const loading = ref(false);
   const error = ref<unknown>(null);
 
@@ -62,7 +63,8 @@ export function useLiveMonitor(options: Options = {}) {
           to: timeRange.value?.to,
         },
       });
-      const edges = data?.webhookDeliveryEvents?.edges || [];
+      const edges = data?.webhookDeliveries?.edges || [];
+      pageInfo.value = data?.webhookDeliveries?.pageInfo || null;
       const nodes = edges.map((e: any) => e.node);
       if (nodes.length > 0) {
         events.value = nodes;
@@ -139,6 +141,7 @@ export function useLiveMonitor(options: Options = {}) {
 
   return {
     events,
+    pageInfo,
     loading,
     error,
     filters,

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -153,7 +153,19 @@
         "subject": "Betreff"
       },
       "autoRefresh": "Autoaktualisierung",
-      "rpmCap": "RPM-Limit"
+      "rpmCap": "RPM-Limit",
+      "table": {
+        "time": "Zeit",
+        "topic": "Thema",
+        "action": "Aktion",
+        "subjectId": "Betreff-ID",
+        "integration": "Integration",
+        "status": "Status",
+        "httpCode": "HTTP-Code",
+        "latency": "Latenz",
+        "attempt": "Versuch #",
+        "deliveryId": "Delivery-ID"
+      }
     }
   }
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2861,7 +2861,19 @@
         "product": "Product"
       },
       "autoRefresh": "Auto-refresh",
-      "rpmCap": "RPM Cap"
+      "rpmCap": "RPM Cap",
+      "table": {
+        "time": "Time",
+        "topic": "Topic",
+        "action": "Action",
+        "subjectId": "Subject ID",
+        "integration": "Integration",
+        "status": "Status",
+        "httpCode": "HTTP code",
+        "latency": "Latency",
+        "attempt": "Attempt #",
+        "deliveryId": "Delivery ID"
+      }
     }
   }
 }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -153,7 +153,19 @@
         "subject": "Sujet"
       },
       "autoRefresh": "Rafraîchissement auto",
-      "rpmCap": "Limite RPM"
+      "rpmCap": "Limite RPM",
+      "table": {
+        "time": "Temps",
+        "topic": "Sujet",
+        "action": "Action",
+        "subjectId": "ID sujet",
+        "integration": "Intégration",
+        "status": "Statut",
+        "httpCode": "Code HTTP",
+        "latency": "Latence",
+        "attempt": "Tentative #",
+        "deliveryId": "ID de livraison"
+      }
     }
   }
 }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1960,7 +1960,19 @@
         "subject": "Onderwerp"
       },
       "autoRefresh": "Auto-verversen",
-      "rpmCap": "RPM-limiet"
+      "rpmCap": "RPM-limiet",
+      "table": {
+        "time": "Tijd",
+        "topic": "Onderwerp",
+        "action": "Actie",
+        "subjectId": "Onderwerp-ID",
+        "integration": "Integratie",
+        "status": "Status",
+        "httpCode": "HTTP-code",
+        "latency": "Latentie",
+        "attempt": "Poging #",
+        "deliveryId": "Leverings-ID"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- add virtualized webhook delivery table with pagination and copyable IDs
- expose page info in live monitor hook
- provide translations for webhook monitor table columns

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b76cf7cc1c832eb6495bb9e4765a90

## Summary by Sourcery

Implement a virtualized webhook delivery event table with pagination, copyable delivery IDs, color-coded badges, and translations; update the live monitor hook to expose pageInfo for pagination control.

New Features:
- Add a virtualized table in the webhook monitor to render delivery events with efficient row virtualization
- Introduce copy-to-clipboard buttons for delivery IDs with success/failure toast notifications
- Integrate pagination controls to navigate through pages of webhook delivery events

Enhancements:
- Expose pageInfo in useLiveMonitor to drive pagination and update API fields to use webhookDeliveries
- Display color-coded badges for delivery status and HTTP response codes
- Add time formatting helper for event timestamps

Documentation:
- Provide translated labels for the new webhook monitor table columns in locale files