### PR TITLE
fix: align webhook monitor table and drop delivery id

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
@@ -14,8 +14,6 @@ import { FieldType } from '../../../../../../shared/utils/constants';
 import type { SearchConfig } from '../../../../../../shared/components/organisms/general-search/searchConfig';
 import apolloClient from '../../../../../../../apollo-client';
 import { getWebhookIntegrationQuery } from '../../../../../../shared/api/queries/webhooks.js';
-import { Icon } from '../../../../../../shared/components/atoms/icon';
-import { Toast } from '../../../../../../shared/modules/toast';
 import { useLiveMonitor } from './useLiveMonitor';
 
 const { t } = useI18n();
@@ -156,15 +154,6 @@ const getResponseCodeColor = (code?: number | null) => {
   if (code >= 400 && code < 500) return 'yellow';
   if (code >= 500 && code < 600) return 'red';
   return 'gray';
-};
-
-const copyDeliveryId = async (id: string) => {
-  try {
-    await navigator.clipboard.writeText(id);
-    Toast.success(t('shared.alert.toast.clipboardSuccess'));
-  } catch {
-    Toast.error(t('shared.alert.toast.clipboardFail'));
-  }
 };
 
 const formatTime = (iso: string) => new Date(iso).toLocaleString();
@@ -332,86 +321,74 @@ const rpmDisplay = computed(() => `${rpm.value ?? 0}/120`);
       </div>
     </div>
 
-    <div ref="parentRef" class="max-h-96 overflow-auto mt-4">
-      <table class="min-w-full divide-y divide-gray-300">
-        <thead class="bg-gray-50">
-          <tr>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.time') }}
-            </th>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.topic') }}
-            </th>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.action') }}
-            </th>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.subjectId') }}
-            </th>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.status') }}
-            </th>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.httpCode') }}
-            </th>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.latency') }}
-            </th>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.attempt') }}
-            </th>
-            <th class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
-              {{ t('webhooks.monitor.table.deliveryId') }}
-            </th>
-          </tr>
-        </thead>
-        <tbody :style="{ height: totalSize + 'px', position: 'relative' }" class="divide-y divide-gray-200 bg-white">
-          <tr
+    <div class="mt-4">
+      <div class="grid grid-cols-8 bg-gray-50 border-b border-gray-300">
+        <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+          {{ t('webhooks.monitor.table.time') }}
+        </div>
+        <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+          {{ t('webhooks.monitor.table.topic') }}
+        </div>
+        <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+          {{ t('webhooks.monitor.table.action') }}
+        </div>
+        <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+          {{ t('webhooks.monitor.table.subjectId') }}
+        </div>
+        <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+          {{ t('webhooks.monitor.table.status') }}
+        </div>
+        <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+          {{ t('webhooks.monitor.table.httpCode') }}
+        </div>
+        <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+          {{ t('webhooks.monitor.table.latency') }}
+        </div>
+        <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+          {{ t('webhooks.monitor.table.attempt') }}
+        </div>
+      </div>
+      <div ref="parentRef" class="max-h-96 overflow-auto">
+        <div :style="{ height: totalSize + 'px', position: 'relative' }">
+          <div
             v-for="virtualRow in virtualRows"
             :key="virtualRow.index"
             :style="{ position: 'absolute', top: virtualRow.start + 'px', width: '100%' }"
+            class="grid grid-cols-8 border-b border-gray-200 bg-white"
           >
-            <td class="px-3 py-2 text-sm text-gray-500">
+            <div class="px-3 py-2 text-sm text-gray-500">
               {{ formatTime(events[virtualRow.index].sentAt) }}
-            </td>
-            <td class="px-3 py-2 text-sm text-gray-500">
+            </div>
+            <div class="px-3 py-2 text-sm text-gray-500">
               {{ optionLabelMap.topic[events[virtualRow.index].outbox.topic] || events[virtualRow.index].outbox.topic }}
-            </td>
-            <td class="px-3 py-2 text-sm text-gray-500">
+            </div>
+            <div class="px-3 py-2 text-sm text-gray-500">
               {{ optionLabelMap.action[events[virtualRow.index].outbox.action] }}
-            </td>
-            <td class="px-3 py-2 text-sm text-gray-500">
+            </div>
+            <div class="px-3 py-2 text-sm text-gray-500">
               {{ events[virtualRow.index].outbox.subjectId }}
-            </td>
-            <td class="px-3 py-2 text-sm text-gray-500">
+            </div>
+            <div class="px-3 py-2 text-sm text-gray-500">
               <Badge
                 :color="statusBadgeMap[events[virtualRow.index].status].color"
                 :text="statusBadgeMap[events[virtualRow.index].status].text"
               />
-            </td>
-            <td class="px-3 py-2 text-sm text-gray-500">
+            </div>
+            <div class="px-3 py-2 text-sm text-gray-500">
               <Badge
                 :color="getResponseCodeColor(events[virtualRow.index].responseCode)"
                 :text="events[virtualRow.index].responseCode"
               />
-            </td>
-            <td class="px-3 py-2 text-sm text-gray-500">
+            </div>
+            <div class="px-3 py-2 text-sm text-gray-500">
               {{ events[virtualRow.index].responseMs }}
-            </td>
-            <td class="px-3 py-2 text-sm text-gray-500">
+            </div>
+            <div class="px-3 py-2 text-sm text-gray-500">
               {{ events[virtualRow.index].attempt }}
-            </td>
-            <td class="px-3 py-2 text-sm text-gray-500">
-              <div class="flex items-center gap-1">
-                <span>{{ events[virtualRow.index].id }}</span>
-                <Button :custom-class="'p-1'" @click="copyDeliveryId(events[virtualRow.index].id)">
-                  <Icon name="clipboard" class="h-4 w-4 text-gray-500" />
-                </Button>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <Pagination v-if="pageInfo" class="mt-4" :page-info="pageInfo" :change-query-params="false" @query-changed="handlePageChange" />

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -163,8 +163,7 @@
         "status": "Status",
         "httpCode": "HTTP-Code",
         "latency": "Latenz",
-        "attempt": "Versuch #",
-        "deliveryId": "Delivery-ID"
+        "attempt": "Versuch #"
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2883,8 +2883,7 @@
         "status": "Status",
         "httpCode": "HTTP code",
         "latency": "Latency",
-        "attempt": "Attempt #",
-        "deliveryId": "Delivery ID"
+        "attempt": "Attempt #"
       }
     }
   }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -163,8 +163,7 @@
         "status": "Statut",
         "httpCode": "Code HTTP",
         "latency": "Latence",
-        "attempt": "Tentative #",
-        "deliveryId": "ID de livraison"
+        "attempt": "Tentative #"
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1970,8 +1970,7 @@
         "status": "Status",
         "httpCode": "HTTP-code",
         "latency": "Latentie",
-        "attempt": "Poging #",
-        "deliveryId": "Leverings-ID"
+        "attempt": "Poging #"
       }
     }
   }


### PR DESCRIPTION
## Summary
- align WebhookMonitor table by switching to grid layout
- remove Delivery ID column and related code
- update locale files to drop Delivery ID labels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b774502a64832eb20b188bb23169b4