### PR TITLE
feat(webhooks): add live polling and details drawer

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2884,7 +2884,34 @@
         "httpCode": "HTTP code",
         "latency": "Latency",
         "attempt": "Attempt #"
+      },
+      "drawer": {
+        "tabs": {
+          "overview": "Overview",
+          "attempts": "Attempts",
+          "payload": "Payload",
+          "headers": "Headers",
+          "replay": "Replay/cURL"
+        },
+        "overview": {
+          "status": "Status",
+          "attemptCount": "Attempt count",
+          "lastError": "Last error",
+          "idempotencyKey": "Idempotency key"
+        },
+        "attempts": {
+          "number": "Attempt",
+          "responseCode": "Response code",
+          "latency": "Latency",
+          "error": "Error"
+        },
+        "headers": {
+          "placeholder": "Headers placeholder"
+        },
+        "replay": {
+          "placeholder": "Replay placeholder"
+        }
       }
     }
   }
-}
+} 


### PR DESCRIPTION
## Summary
- poll webhook deliveries with jitter and dedupe for live updates
- show webhook rows and open detail drawer with overview, attempts, payload and placeholders
- add translations for new drawer tabs and labels

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b776daf08c832e8c1aade0c159ed36