### PR TITLE
feat(webhooks): add replay and curl actions

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/monitor/useLiveMonitor.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/useLiveMonitor.ts
@@ -53,14 +53,19 @@ export function useLiveMonitor(options: Options = {}) {
   const fetchEvents = async () => {
     loading.value = true;
     try {
+      const filter = { ...filters.value };
+      if (timeRange.value?.from && timeRange.value?.to) {
+        filter.sentAt = {
+          gte: timeRange.value.from,
+          lte: timeRange.value.to,
+        };
+      }
       const { data } = await apolloClient.query({
         query: webhookDeliveriesQuery,
         fetchPolicy: 'network-only',
         variables: {
-          filter: filters.value,
+          filter,
           ...pagination,
-          from: timeRange.value?.from,
-          to: timeRange.value?.to,
         },
       });
       const edges = data?.webhookDeliveries?.edges || [];

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -164,6 +164,24 @@
         "httpCode": "HTTP-Code",
         "latency": "Latenz",
         "attempt": "Versuch #"
+      },
+      "drawer": {
+        "tabs": {
+          "overview": "Overview",
+          "attempts": "Attempts",
+          "payload": "Payload",
+          "headers": "Headers",
+          "replay": "Replay/cURL"
+        },
+        "headers": {
+          "redacted": "[REDACTED]"
+        },
+        "replay": {
+          "replayButton": "Replay",
+          "copyCurlButton": "Copy cURL",
+          "confirm": "Replay this delivery?",
+          "copied": "cURL command copied"
+        }
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2906,12 +2906,15 @@
           "error": "Error"
         },
         "headers": {
-          "placeholder": "Headers placeholder"
+          "redacted": "[REDACTED]"
         },
         "replay": {
-          "placeholder": "Replay placeholder"
+          "replayButton": "Replay",
+          "copyCurlButton": "Copy cURL",
+          "confirm": "Replay this delivery?",
+          "copied": "cURL command copied"
         }
       }
     }
   }
-} 
+}

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -164,6 +164,24 @@
         "httpCode": "Code HTTP",
         "latency": "Latence",
         "attempt": "Tentative #"
+      },
+      "drawer": {
+        "tabs": {
+          "overview": "Overview",
+          "attempts": "Attempts",
+          "payload": "Payload",
+          "headers": "Headers",
+          "replay": "Replay/cURL"
+        },
+        "headers": {
+          "redacted": "[REDACTED]"
+        },
+        "replay": {
+          "replayButton": "Replay",
+          "copyCurlButton": "Copy cURL",
+          "confirm": "Replay this delivery?",
+          "copied": "cURL command copied"
+        }
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1971,6 +1971,24 @@
         "httpCode": "HTTP-code",
         "latency": "Latentie",
         "attempt": "Poging #"
+      },
+      "drawer": {
+        "tabs": {
+          "overview": "Overview",
+          "attempts": "Attempts",
+          "payload": "Payload",
+          "headers": "Headers",
+          "replay": "Replay/cURL"
+        },
+        "headers": {
+          "redacted": "[REDACTED]"
+        },
+        "replay": {
+          "replayButton": "Replay",
+          "copyCurlButton": "Copy cURL",
+          "confirm": "Replay this delivery?",
+          "copied": "cURL command copied"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- enable filtering with exact lookups and time range by sentAt
- add replay and cURL copy actions with headers in webhook monitor
- localize new monitor actions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b81bf7f0f4832e9524af82f32af9fa

## Summary by Sourcery

Add replay and cURL copy actions to the webhook monitor, enhance filters with exact lookups and sentAt time-range, and update locales for new monitor actions

New Features:
- Enable exact-match filtering on status and response code and time-range filtering by sentAt in webhook monitor
- Add replay delivery action to retry webhook events from the monitor drawer
- Add copy cURL command action to clipboard including request headers and payload in webhook monitor

Enhancements:
- Display integration-specific headers including extra headers and a redacted secret in the monitor UI
- Refactor live monitor logic to integrate sentAt range into the GraphQL filter instead of separate query parameters

Documentation:
- Localize new replay and copy cURL action labels across supported locale files