### PR TITLE
fix(webhooks): improve headers and retry

### DIFF
--- a/src/shared/api/mutations/webhooks.js
+++ b/src/shared/api/mutations/webhooks.js
@@ -105,23 +105,25 @@ export const deleteWebhookIntegrationsMutation = gql`
 `;
 
 export const retryWebhookDeliveryMutation = gql`
-  mutation retryWebhookDelivery($data: WebhookDeliveryPartialInput!) {
-    retryWebhookDelivery(data: $data) {
-      id
-      outbox {
+  mutation retryWebhookDelivery($instance: WebhookDeliveryPartialInput!) {
+    retryWebhookDelivery(instance: $instance) {
+      delivery {
         id
+        outbox {
+          id
+        }
+        webhookIntegration {
+          id
+        }
+        status
+        attempt
+        responseCode
+        responseMs
+        responseBodySnippet
+        sentAt
+        errorMessage
+        errorTraceback
       }
-      webhookIntegration {
-        id
-      }
-      status
-      attempt
-      responseCode
-      responseMs
-      responseBodySnippet
-      sentAt
-      errorMessage
-      errorTraceback
     }
   }
 `;


### PR DESCRIPTION
## Summary
- compute webhook HMAC signature and build headers for replay/cURL
- switch to SweetAlert2 for webhook delivery retry and copy feedback
- update retryWebhookDelivery mutation to new API

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b820d7f030832e82bc97e10b324586

## Summary by Sourcery

Enhance webhook monitor UI by computing HMAC signatures for replay headers, using SweetAlert2 for confirmations and copy feedback, and updating the retryWebhookDelivery mutation to the new API schema

Enhancements:
- Compute webhook HMAC signature and dynamically build full headers for replay and cURL commands
- Replace native confirm and alert dialogs with SweetAlert2 modals for retry confirmations and copy feedback

Chores:
- Update retryWebhookDelivery GraphQL mutation variables and response handling to match new API