### PR TITLE
Fix webhook retry confirmation and mutation

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
@@ -230,7 +230,7 @@ const replaySelected = async () => {
   const defaultSwalOptions = {
     title: t('shared.alert.mutationAlert.title'),
     text: t('webhooks.monitor.drawer.replay.confirm'),
-    confirmButtonText: t('shared.alert.mutationAlert.confirmButtonText'),
+    confirmButtonText: t('webhooks.monitor.drawer.replay.confirmButtonText'),
     cancelButtonText: t('shared.alert.mutationAlert.cancelButtonText'),
     icon: 'warning',
     showCancelButton: true,
@@ -252,7 +252,7 @@ const replaySelected = async () => {
     mutation: retryWebhookDeliveryMutation,
     variables: { instance: { id: selectedEvent.value.id } },
   });
-  const updated = data?.retryWebhookDelivery?.delivery;
+  const updated = data?.retryWebhookDelivery;
   if (updated) {
     selectedEvent.value = updated;
     const idx = events.value.findIndex((e) => e.id === updated.id);

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -180,6 +180,7 @@
           "replayButton": "Replay",
           "copyCurlButton": "Copy cURL",
           "confirm": "Replay this delivery?",
+          "confirmButtonText": "Yes, replay it!",
           "copied": "cURL command copied"
         }
       }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2912,6 +2912,7 @@
           "replayButton": "Replay",
           "copyCurlButton": "Copy cURL",
           "confirm": "Replay this delivery?",
+          "confirmButtonText": "Yes, replay it!",
           "copied": "cURL command copied"
         }
       }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -180,6 +180,7 @@
           "replayButton": "Replay",
           "copyCurlButton": "Copy cURL",
           "confirm": "Replay this delivery?",
+          "confirmButtonText": "Yes, replay it!",
           "copied": "cURL command copied"
         }
       }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1987,6 +1987,7 @@
           "replayButton": "Replay",
           "copyCurlButton": "Copy cURL",
           "confirm": "Replay this delivery?",
+          "confirmButtonText": "Yes, replay it!",
           "copied": "cURL command copied"
         }
       }

--- a/src/shared/api/mutations/webhooks.js
+++ b/src/shared/api/mutations/webhooks.js
@@ -107,6 +107,7 @@ export const deleteWebhookIntegrationsMutation = gql`
 export const retryWebhookDeliveryMutation = gql`
   mutation retryWebhookDelivery($instance: WebhookDeliveryPartialInput!) {
     retryWebhookDelivery(instance: $instance) {
+      ... on WebhookDeliveryType {
         id
         outbox {
           id
@@ -122,6 +123,7 @@ export const retryWebhookDeliveryMutation = gql`
         sentAt
         errorMessage
         errorTraceback
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- Correct replay confirmation button text
- Request delivery data from retryWebhookDelivery mutation using inline fragment
- Add translations for replay confirmation button

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b82556de68832e94721ad912845d78

## Summary by Sourcery

Fix the replay confirmation dialog and mutation handling for retrying webhook deliveries

Bug Fixes:
- Fix confirm button text translation key in the replay confirmation dialog

Enhancements:
- Extend retryWebhookDeliveryMutation with an inline fragment to fetch full WebhookDeliveryType fields
- Adapt component code to consume the mutation response directly instead of nested delivery property

Documentation:
- Add localization entries for the replay confirmation button text in multiple languages