### PR TITLE
feat: add webhook monitor kpi cards and polish ux

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -154,6 +154,23 @@
       },
       "autoRefresh": "Autoaktualisierung",
       "rpmCap": "RPM-Limit",
+      "kpis": {
+        "deliveries": "Deliveries",
+        "deliveriesTooltip": "Total deliveries",
+        "delivered": "Delivered",
+        "deliveredTooltip": "Successfully delivered",
+        "failed": "Failed",
+        "failedTooltip": "Failed deliveries",
+        "successRate": "Success %",
+        "successRateTooltip": "Percentage of successful deliveries",
+        "latency": "Latency ms (median / p95)",
+        "latencyTooltip": "Median and 95th percentile latency in milliseconds",
+        "rate429": "429 %",
+        "rate429Tooltip": "Percentage of HTTP 429 responses",
+        "queueDepth": "Queue depth",
+        "queueDepthTooltip": "Current depth of the webhook queue"
+      },
+      "empty": "No deliveries found",
       "table": {
         "time": "Zeit",
         "topic": "Thema",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2875,6 +2875,23 @@
       },
       "autoRefresh": "Auto-refresh",
       "rpmCap": "RPM Cap",
+      "kpis": {
+        "deliveries": "Deliveries",
+        "deliveriesTooltip": "Total deliveries",
+        "delivered": "Delivered",
+        "deliveredTooltip": "Successfully delivered",
+        "failed": "Failed",
+        "failedTooltip": "Failed deliveries",
+        "successRate": "Success %",
+        "successRateTooltip": "Percentage of successful deliveries",
+        "latency": "Latency ms (median / p95)",
+        "latencyTooltip": "Median and 95th percentile latency in milliseconds",
+        "rate429": "429 %",
+        "rate429Tooltip": "Percentage of HTTP 429 responses",
+        "queueDepth": "Queue depth",
+        "queueDepthTooltip": "Current depth of the webhook queue"
+      },
+      "empty": "No deliveries found",
       "table": {
         "time": "Time",
         "topic": "Topic",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -154,6 +154,23 @@
       },
       "autoRefresh": "Rafraîchissement auto",
       "rpmCap": "Limite RPM",
+      "kpis": {
+        "deliveries": "Deliveries",
+        "deliveriesTooltip": "Total deliveries",
+        "delivered": "Delivered",
+        "deliveredTooltip": "Successfully delivered",
+        "failed": "Failed",
+        "failedTooltip": "Failed deliveries",
+        "successRate": "Success %",
+        "successRateTooltip": "Percentage of successful deliveries",
+        "latency": "Latency ms (median / p95)",
+        "latencyTooltip": "Median and 95th percentile latency in milliseconds",
+        "rate429": "429 %",
+        "rate429Tooltip": "Percentage of HTTP 429 responses",
+        "queueDepth": "Queue depth",
+        "queueDepthTooltip": "Current depth of the webhook queue"
+      },
+      "empty": "No deliveries found",
       "table": {
         "time": "Temps",
         "topic": "Sujet",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1961,6 +1961,23 @@
       },
       "autoRefresh": "Auto-verversen",
       "rpmCap": "RPM-limiet",
+      "kpis": {
+        "deliveries": "Deliveries",
+        "deliveriesTooltip": "Total deliveries",
+        "delivered": "Delivered",
+        "deliveredTooltip": "Successfully delivered",
+        "failed": "Failed",
+        "failedTooltip": "Failed deliveries",
+        "successRate": "Success %",
+        "successRateTooltip": "Percentage of successful deliveries",
+        "latency": "Latency ms (median / p95)",
+        "latencyTooltip": "Median and 95th percentile latency in milliseconds",
+        "rate429": "429 %",
+        "rate429Tooltip": "Percentage of HTTP 429 responses",
+        "queueDepth": "Queue depth",
+        "queueDepthTooltip": "Current depth of the webhook queue"
+      },
+      "empty": "No deliveries found",
       "table": {
         "time": "Tijd",
         "topic": "Onderwerp",

--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -233,3 +233,18 @@ export const getWebhookDeliveryAttemptQuery = gql`
   }
 `;
 
+export const webhookDeliveryStatsQuery = gql`
+  query WebhookDeliveryStats($filter: WebhookDeliveryFilter) {
+    webhookDeliveryStats(filters: $filter) {
+      deliveries
+      delivered
+      failed
+      successRate
+      medianLatency
+      p95Latency
+      rate429
+      queueDepth
+    }
+  }
+`;
+


### PR DESCRIPTION
## Summary
- display webhook delivery KPIs with translations and tooltips
- fetch delivery stats and update when filters/time range change
- add skeleton loading states and empty table message

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b829efa814832eb697e8d6befc3105