### PR TITLE
refactor: split webhook monitor into components

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/monitor/components/EventDrawer.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/components/EventDrawer.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Button } from '../../../../../../shared/components/atoms/button';
+import { Title } from '../../../../../../shared/components/atoms/title';
+
+const { t } = useI18n();
+
+interface HeaderKV {
+  key: string;
+  value: string;
+}
+
+interface Props {
+  event: any | null;
+  activeTab: string;
+  drawerTabs: readonly string[];
+  integrationHeaders: HeaderKV[];
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits(['close', 'update:activeTab', 'replay', 'copyCurl']);
+</script>
+
+<template>
+  <transition name="fade">
+    <div v-if="event" class="fixed inset-0 z-50 flex">
+      <div class="flex-1 bg-black/50" @click="emit('close')"></div>
+      <div class="w-96 bg-white h-full overflow-y-auto p-4">
+        <div class="flex items-center justify-between mb-4">
+          <Title>{{ t('webhooks.monitor.title') }}</Title>
+          <button @click="emit('close')">×</button>
+        </div>
+        <div class="flex items-center gap-2 mb-4">
+          <Button
+            v-for="tab in drawerTabs"
+            :key="tab"
+            :custom-class="`px-2 py-1 rounded text-sm ${props.activeTab === tab ? 'bg-primary text-white' : 'bg-gray-100'}`"
+            @click="emit('update:activeTab', tab)"
+          >
+            {{ t(`webhooks.monitor.drawer.tabs.${tab}`) }}
+          </Button>
+        </div>
+
+        <div v-if="props.activeTab === 'overview'" class="space-y-2 text-sm">
+          <div><strong>{{ t('webhooks.monitor.drawer.overview.status') }}:</strong> {{ event.status }}</div>
+          <div><strong>{{ t('webhooks.monitor.drawer.overview.attemptCount') }}:</strong> {{ event.attempt }}</div>
+          <div v-if="event.errorMessage"><strong>{{ t('webhooks.monitor.drawer.overview.lastError') }}:</strong> {{ event.errorMessage }}</div>
+          <div><strong>{{ t('webhooks.monitor.drawer.overview.idempotencyKey') }}:</strong> {{ event.outbox.id }}</div>
+        </div>
+
+        <div v-else-if="props.activeTab === 'attempts'" class="space-y-2 text-sm">
+          <div v-for="att in event.attempts" :key="att.number" class="border-b pb-2">
+            <div><strong>{{ t('webhooks.monitor.drawer.attempts.number') }}:</strong> {{ att.number }}</div>
+            <div><strong>{{ t('webhooks.monitor.drawer.attempts.responseCode') }}:</strong> {{ att.responseCode }}</div>
+            <div><strong>{{ t('webhooks.monitor.drawer.attempts.latency') }}:</strong> {{ att.responseMs }}</div>
+            <div v-if="att.errorText"><strong>{{ t('webhooks.monitor.drawer.attempts.error') }}:</strong> {{ att.errorText }}</div>
+          </div>
+        </div>
+
+        <div v-else-if="props.activeTab === 'payload'" class="text-sm">
+          <pre class="bg-gray-100 p-2 rounded overflow-auto">{{ JSON.stringify(event.outbox.payload, null, 2) }}</pre>
+        </div>
+
+        <div v-else-if="props.activeTab === 'headers'" class="space-y-2 text-sm">
+          <div v-for="h in integrationHeaders" :key="h.key">
+            <strong>{{ h.key }}</strong>: {{ h.value }}
+          </div>
+        </div>
+
+        <div v-else-if="props.activeTab === 'replay'" class="flex flex-col gap-2 text-sm">
+          <Button :custom-class="'bg-primary text-white px-2 py-1 rounded'" @click="emit('replay')">
+            {{ t('webhooks.monitor.drawer.replay.replayButton') }}
+          </Button>
+          <Button :custom-class="'bg-gray-100 px-2 py-1 rounded'" @click="emit('copyCurl')">
+            {{ t('webhooks.monitor.drawer.replay.copyCurlButton') }}
+          </Button>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/monitor/components/EventTable.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/components/EventTable.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { Badge } from '../../../../../../shared/components/atoms/badge';
+
+const { t } = useI18n();
+
+interface Props {
+  events: any[];
+  loading: boolean;
+  optionLabelMap: Record<string, Record<string, string>>;
+  statusBadgeMap: Record<string, { text: string; color: string }>;
+  openDrawer: (ev: any) => void;
+  formatTime: (iso: string) => string;
+  getResponseCodeColor: (code?: number | null) => string;
+}
+
+defineProps<Props>();
+</script>
+
+<template>
+  <div class="mt-4">
+    <div class="grid grid-cols-8 bg-gray-50 border-b border-gray-300">
+      <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+        {{ t('webhooks.monitor.table.time') }}
+      </div>
+      <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+        {{ t('webhooks.monitor.table.topic') }}
+      </div>
+      <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+        {{ t('webhooks.monitor.table.action') }}
+      </div>
+      <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+        {{ t('webhooks.monitor.table.subjectId') }}
+      </div>
+      <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+        {{ t('webhooks.monitor.table.status') }}
+      </div>
+      <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+        {{ t('webhooks.monitor.table.httpCode') }}
+      </div>
+      <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+        {{ t('webhooks.monitor.table.latency') }}
+      </div>
+      <div class="px-3 py-2 text-left text-sm font-semibold text-gray-900">
+        {{ t('webhooks.monitor.table.attempt') }}
+      </div>
+    </div>
+    <div class="max-h-96 overflow-auto">
+      <div v-if="loading">
+        <div v-for="n in 5" :key="n" class="grid grid-cols-8 border-b border-gray-200 bg-white">
+          <div v-for="i in 8" :key="i" class="px-3 py-2">
+            <div class="h-4 bg-gray-200 rounded animate-pulse"></div>
+          </div>
+        </div>
+      </div>
+      <transition-group v-else name="list" tag="div">
+        <div
+          v-for="ev in events"
+          :key="ev.outbox.id"
+          class="grid grid-cols-8 border-b border-gray-200 bg-white cursor-pointer"
+          @click="openDrawer(ev)"
+        >
+          <div class="px-3 py-2 text-sm text-gray-500">
+            {{ formatTime(ev.sentAt) }}
+          </div>
+          <div class="px-3 py-2 text-sm text-gray-500">
+            {{ optionLabelMap.topic[ev.outbox.topic] || ev.outbox.topic }}
+          </div>
+          <div class="px-3 py-2 text-sm text-gray-500">
+            {{ optionLabelMap.action[ev.outbox.action] }}
+          </div>
+          <div class="px-3 py-2 text-sm text-gray-500">
+            {{ ev.outbox.subjectId }}
+          </div>
+          <div class="px-3 py-2 text-sm text-gray-500">
+            <Badge :color="statusBadgeMap[ev.status].color" :text="statusBadgeMap[ev.status].text" />
+          </div>
+          <div class="px-3 py-2 text-sm text-gray-500">
+            <Badge :color="getResponseCodeColor(ev.responseCode)" :text="ev.responseCode" />
+          </div>
+          <div class="px-3 py-2 text-sm text-gray-500">
+            {{ ev.responseMs }}
+          </div>
+          <div class="px-3 py-2 text-sm text-gray-500">
+            {{ ev.attempt }}
+          </div>
+        </div>
+      </transition-group>
+      <div v-if="!loading && events.length === 0" class="text-center py-4 text-sm text-gray-500">
+        {{ t('webhooks.monitor.empty') }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/monitor/components/KpiCards.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/components/KpiCards.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
+interface Props {
+  stats: any;
+  statsLoading: boolean;
+}
+
+defineProps<Props>();
+
+const kpis = [
+  { key: 'deliveries', format: (s: any) => s?.deliveries ?? 0 },
+  { key: 'delivered', format: (s: any) => s?.delivered ?? 0 },
+  { key: 'failed', format: (s: any) => s?.failed ?? 0 },
+  { key: 'successRate', format: (s: any) => `${(s?.successRate ?? 0).toFixed(1)}%` },
+  { key: 'latency', format: (s: any) => `${s?.medianLatency ?? 0} / ${s?.p95Latency ?? 0}` },
+  { key: 'rate429', format: (s: any) => `${(s?.rate429 ?? 0).toFixed(1)}%` },
+  { key: 'queueDepth', format: (s: any) => s?.queueDepth ?? 0 },
+];
+</script>
+
+<template>
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+    <div
+      v-for="kpi in kpis"
+      :key="kpi.key"
+      class="p-4 bg-gray-50 rounded"
+      :title="t(`webhooks.monitor.kpis.${kpi.key}Tooltip`)">
+      <div class="text-sm text-gray-500">
+        {{ t(`webhooks.monitor.kpis.${kpi.key}`) }}
+      </div>
+      <div v-if="!statsLoading" class="text-xl font-semibold">
+        {{ kpi.format(stats) }}
+      </div>
+      <div v-else class="h-6 w-20 bg-gray-200 rounded animate-pulse"></div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- extract KPI cards, event table, and drawer into dedicated components
- simplify WebhookMonitor by delegating to new components

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b840fce7d0832e8416a5fb16bacbe3