### PR TITLE
feat(webhooks): display attempt creation date

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/monitor/components/EventDrawer.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/components/EventDrawer.vue
@@ -4,6 +4,7 @@ import { Button } from '../../../../../../../shared/components/atoms/button';
 import { Title } from '../../../../../../../shared/components/atoms/title';
 
 const { t } = useI18n();
+const formatTime = (iso: string) => new Date(iso).toLocaleString();
 
 interface HeaderKV {
   key: string;
@@ -50,6 +51,7 @@ const emit = defineEmits(['close', 'update:activeTab', 'replay', 'copyCurl']);
 
         <div v-else-if="props.activeTab === 'attempts'" class="space-y-2 text-sm">
           <div v-for="att in event.attempts" :key="att.number" class="border-b pb-2">
+            <div><strong>{{ t('webhooks.monitor.drawer.attempts.createdAt') }}:</strong> {{ formatTime(att.createdAt) }}</div>
             <div><strong>{{ t('webhooks.monitor.drawer.attempts.number') }}:</strong> {{ att.number }}</div>
             <div><strong>{{ t('webhooks.monitor.drawer.attempts.responseCode') }}:</strong> {{ att.responseCode }}</div>
             <div><strong>{{ t('webhooks.monitor.drawer.attempts.latency') }}:</strong> {{ att.responseMs }}</div>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2920,7 +2920,8 @@
           "number": "Attempt",
           "responseCode": "Response code",
           "latency": "Latency",
-          "error": "Error"
+          "error": "Error",
+          "createdAt": "Created at"
         },
         "headers": {
           "redacted": "[REDACTED]"

--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -143,6 +143,7 @@ export const webhookDeliveriesQuery = gql`
           attempts(order: { number: DESC }) {
             number
             sentAt
+            createdAt
             responseCode
             responseMs
             responseBodySnippet
@@ -179,6 +180,7 @@ export const getWebhookDeliveryQuery = gql`
       responseMs
       responseBodySnippet
       sentAt
+      createdAt
       errorMessage
       errorTraceback
     }
@@ -196,6 +198,7 @@ export const webhookDeliveryAttemptsQuery = gql`
           }
           number
           sentAt
+          createdAt
           responseCode
           responseMs
           responseBodySnippet
@@ -224,6 +227,7 @@ export const getWebhookDeliveryAttemptQuery = gql`
       }
       number
       sentAt
+      createdAt
       responseCode
       responseMs
       responseBodySnippet


### PR DESCRIPTION
## Summary
- fetch `createdAt` for webhook delivery attempts
- show attempt send date in monitor drawer
- add translation for attempt creation timestamp

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b84a04cccc832e8cb98ee84be8c9fd

## Summary by Sourcery

Fetch and display the creation timestamp for webhook delivery attempts in the monitor drawer

New Features:
- Include createdAt field in webhook delivery GraphQL queries
- Display formatted attempt creation date in the event drawer UI

Documentation:
- Add translation entry for attempt creation timestamp