### PR TITLE
feat: add reports tab for webhook integrations

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -36,6 +36,7 @@ import { refreshSalesChannelWebsitesMutation } from "../../../../shared/api/muta
 import {Toast} from "../../../../shared/modules/toast";
 
 const WebhookMonitor = defineAsyncComponent(() => import('./containers/monitor/WebhookMonitor.vue'));
+const WebhookReports = defineAsyncComponent(() => import('./containers/reports/WebhookReports.vue'));
 
 const router = useRouter();
 const route = useRoute();
@@ -75,7 +76,10 @@ if (type.value !== IntegrationTypes.Webhook) {
 
   tabItems.value.push({ name: 'imports', label: t('shared.tabs.imports'), icon: 'file-import' });
 } else {
-  tabItems.value.push({ name: 'monitor', label: t('webhooks.monitor.title'), icon: 'wave-square' });
+  tabItems.value.push(
+    { name: 'monitor', label: t('webhooks.monitor.title'), icon: 'wave-square' },
+    { name: 'reports', label: t('integrations.show.tabs.reports'), icon: 'chart-simple' },
+  );
 }
 
 
@@ -244,6 +248,11 @@ const pullData = async () => {
           <!-- Monitor Tab -->
           <template #monitor>
             <WebhookMonitor v-if="integrationId" :integration-id="integrationId" />
+          </template>
+
+          <!-- Reports Tab -->
+          <template #reports>
+            <WebhookReports v-if="integrationId" :integration-id="integrationId" />
           </template>
 
           <!-- Products Tab -->

--- a/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Button } from '../../../../../../shared/components/atoms/button';
+import { Title } from '../../../../../../shared/components/atoms/title';
+import { FilterManager } from '../../../../../../shared/components/molecules/filter-manager';
+import { FieldType } from '../../../../../../shared/utils/constants';
+import type { SearchConfig } from '../../../../../../shared/components/organisms/general-search/searchConfig';
+
+const { t } = useI18n();
+
+defineProps<{
+  integrationId: string;
+}>();
+
+const timeOptions = ['today', '7d', '30d', 'custom'] as const;
+const selectedRange = ref<typeof timeOptions[number]>('today');
+
+const selectRange = (opt: typeof timeOptions[number]) => {
+  selectedRange.value = opt;
+};
+
+const searchConfig: SearchConfig = {
+  search: false,
+  filters: [
+    {
+      type: FieldType.Choice,
+      name: 'topic',
+      label: t('webhooks.monitor.filters.topic'),
+      options: [],
+      labelBy: 'label',
+      valueBy: 'value',
+    },
+    {
+      type: FieldType.Choice,
+      name: 'action',
+      label: t('webhooks.monitor.filters.action'),
+      options: [],
+      labelBy: 'label',
+      valueBy: 'value',
+    },
+    {
+      type: FieldType.Choice,
+      name: 'integration',
+      label: t('webhooks.reports.filters.integration'),
+      options: [],
+      labelBy: 'label',
+      valueBy: 'value',
+    },
+    {
+      type: FieldType.Choice,
+      name: 'status',
+      label: t('webhooks.monitor.filters.status'),
+      options: [],
+      labelBy: 'label',
+      valueBy: 'value',
+    },
+    {
+      type: FieldType.Choice,
+      name: 'responseCode',
+      label: t('webhooks.reports.filters.responseCodeBucket'),
+      options: [],
+      labelBy: 'label',
+      valueBy: 'value',
+    },
+  ],
+  orders: [],
+};
+</script>
+
+<template>
+  <div class="space-y-4">
+    <FilterManager :search-config="searchConfig" />
+    <div class="flex items-center justify-between">
+      <Title>{{ t('integrations.show.tabs.reports') }}</Title>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <Button
+        v-for="opt in timeOptions"
+        :key="opt"
+        :custom-class="`px-2 py-1 rounded text-sm ${selectedRange === opt ? 'bg-primary text-white' : 'bg-gray-100'}`"
+        @click="selectRange(opt)"
+      >
+        {{ t(`webhooks.reports.timeRange.${opt}`) }}
+      </Button>
+    </div>
+  </div>
+</template>
+

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -134,6 +134,13 @@
       }
     }
   },
+  "integrations": {
+    "show": {
+      "tabs": {
+        "reports": "Berichte"
+      }
+    }
+  },
   "webhooks": {
     "monitor": {
       "title": "Monitor",
@@ -200,6 +207,18 @@
           "confirmButtonText": "Yes, replay it!",
           "copied": "cURL command copied"
         }
+      }
+    },
+    "reports": {
+      "timeRange": {
+        "today": "Heute",
+        "7d": "7d",
+        "30d": "30d",
+        "custom": "Benutzerdefiniert"
+      },
+      "filters": {
+        "integration": "Integration",
+        "responseCodeBucket": "Antwortcode-Bereich"
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2309,6 +2309,9 @@
     "title": "Integrations",
     "show": {
       "title": "Integration",
+      "tabs": {
+        "reports": "Reports"
+      },
       "amazon": {
         "title": "Amazon Integration"
       },
@@ -2932,6 +2935,18 @@
           "confirmButtonText": "Yes, replay it!",
           "copied": "cURL command copied"
         }
+      }
+    },
+    "reports": {
+      "timeRange": {
+        "today": "Today",
+        "7d": "7d",
+        "30d": "30d",
+        "custom": "Custom"
+      },
+      "filters": {
+        "integration": "Integration",
+        "responseCodeBucket": "Response code bucket"
       }
     }
   }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -134,6 +134,13 @@
       }
     }
   },
+  "integrations": {
+    "show": {
+      "tabs": {
+        "reports": "Rapports"
+      }
+    }
+  },
   "webhooks": {
     "monitor": {
       "title": "Monitor",
@@ -200,6 +207,18 @@
           "confirmButtonText": "Yes, replay it!",
           "copied": "cURL command copied"
         }
+      }
+    },
+    "reports": {
+      "timeRange": {
+        "today": "Aujourd'hui",
+        "7d": "7 j",
+        "30d": "30 j",
+        "custom": "Personnalisé"
+      },
+      "filters": {
+        "integration": "Intégration",
+        "responseCodeBucket": "Groupe de code de réponse"
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1929,6 +1929,9 @@
           "store": "Winkel",
           "excludeStores": "Winkels uitsluiten"
         }
+      },
+      "tabs": {
+        "reports": "Rapporten"
       }
     }
   }
@@ -2007,6 +2010,18 @@
           "confirmButtonText": "Yes, replay it!",
           "copied": "cURL command copied"
         }
+      }
+    },
+    "reports": {
+      "timeRange": {
+        "today": "Vandaag",
+        "7d": "7 d",
+        "30d": "30 d",
+        "custom": "Aangepast"
+      },
+      "filters": {
+        "integration": "Integratie",
+        "responseCodeBucket": "Antwoordcode-bucket"
       }
     }
   }


### PR DESCRIPTION
## Summary
- add reports tab skeleton for webhook integrations
- stub time range and filter selectors
- add translations for reports tab

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b84a3f7e78832ea712485a09e625eb