### PR TITLE
feat: add date filter to webhook reports

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
@@ -13,7 +13,7 @@ defineProps<{
   integrationId: string;
 }>();
 
-const timeOptions = ['today', '7d', '30d', 'custom'] as const;
+const timeOptions = ['today', '7d', '30d'] as const;
 const selectedRange = ref<typeof timeOptions[number]>('today');
 
 const selectRange = (opt: typeof timeOptions[number]) => {
@@ -23,6 +23,11 @@ const selectRange = (opt: typeof timeOptions[number]) => {
 const searchConfig: SearchConfig = {
   search: false,
   filters: [
+    {
+      type: FieldType.RangeDate,
+      name: 'date',
+      label: t('webhooks.reports.filters.date'),
+    },
     {
       type: FieldType.Choice,
       name: 'topic',

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -213,12 +213,12 @@
       "timeRange": {
         "today": "Heute",
         "7d": "7d",
-        "30d": "30d",
-        "custom": "Benutzerdefiniert"
+        "30d": "30d"
       },
       "filters": {
         "integration": "Integration",
-        "responseCodeBucket": "Antwortcode-Bereich"
+        "responseCodeBucket": "Antwortcode-Bereich",
+        "date": "Datum"
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2942,12 +2942,12 @@
       "timeRange": {
         "today": "Today",
         "7d": "7d",
-        "30d": "30d",
-        "custom": "Custom"
+        "30d": "30d"
       },
       "filters": {
         "integration": "Integration",
-        "responseCodeBucket": "Response code bucket"
+        "responseCodeBucket": "Response code bucket",
+        "date": "Date"
       }
     }
   }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -213,12 +213,12 @@
       "timeRange": {
         "today": "Aujourd'hui",
         "7d": "7 j",
-        "30d": "30 j",
-        "custom": "Personnalisé"
+        "30d": "30 j"
       },
       "filters": {
         "integration": "Intégration",
-        "responseCodeBucket": "Groupe de code de réponse"
+        "responseCodeBucket": "Groupe de code de réponse",
+        "date": "Date"
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -2016,12 +2016,12 @@
       "timeRange": {
         "today": "Vandaag",
         "7d": "7 d",
-        "30d": "30 d",
-        "custom": "Aangepast"
+        "30d": "30 d"
       },
       "filters": {
         "integration": "Integratie",
-        "responseCodeBucket": "Antwoordcode-bucket"
+        "responseCodeBucket": "Antwoordcode-bucket",
+        "date": "Datum"
       }
     }
   }


### PR DESCRIPTION
## Summary
- replace custom pill with date range filter in webhook reports
- update locale files for new filter

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b84eafd8c0832eb477a9450e47dd85

## Summary by Sourcery

Introduce a date range filter for webhook reports and clean up the obsolete custom time pill option while adding necessary localization entries

New Features:
- Add a date range filter to the webhook reports filters

Enhancements:
- Remove the deprecated custom time pill option from the time range selector

Documentation:
- Update locale files with new date filter label translations