### PR TITLE
feat: add filter options for webhook reports

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
@@ -20,6 +20,45 @@ const selectRange = (opt: typeof timeOptions[number]) => {
   selectedRange.value = opt;
 };
 
+const actionOptions = [
+  { label: t('webhooks.monitor.actions.create'), value: 'CREATE' },
+  { label: t('webhooks.monitor.actions.update'), value: 'UPDATE' },
+  { label: t('webhooks.monitor.actions.delete'), value: 'DELETE' },
+];
+
+const statusOptions = [
+  { label: t('webhooks.monitor.statuses.pending'), value: 'PENDING' },
+  { label: t('webhooks.monitor.statuses.sending'), value: 'SENDING' },
+  { label: t('webhooks.monitor.statuses.delivered'), value: 'DELIVERED' },
+  { label: t('webhooks.monitor.statuses.failed'), value: 'FAILED' },
+];
+
+const responseCodeOptions = [
+  { label: '200', value: '200' },
+  { label: '400', value: '400' },
+  { label: '500', value: '500' },
+];
+
+const topicOptions = [
+  { label: t('webhooks.monitor.topics.product'), value: 'product' },
+  { label: t('webhooks.monitor.topics.ean_code'), value: 'ean_code' },
+  { label: t('webhooks.monitor.topics.price_list'), value: 'price_list' },
+  { label: t('webhooks.monitor.topics.price_list_item'), value: 'price_list_item' },
+  { label: t('webhooks.monitor.topics.media'), value: 'media' },
+  { label: t('webhooks.monitor.topics.media_through'), value: 'media_through' },
+  { label: t('webhooks.monitor.topics.property'), value: 'property' },
+  { label: t('webhooks.monitor.topics.select_value'), value: 'select_value' },
+  { label: t('webhooks.monitor.topics.property_rule'), value: 'property_rule' },
+  { label: t('webhooks.monitor.topics.property_rule_item'), value: 'property_rule_item' },
+  { label: t('webhooks.monitor.topics.product_property'), value: 'product_property' },
+  { label: t('webhooks.monitor.topics.sales_channel_view_assign'), value: 'sales_channel_view_assign' },
+  { label: t('webhooks.monitor.topics.all'), value: 'all' },
+];
+
+const integrationOptions = [
+  { label: t('webhooks.monitor.topics.all'), value: 'all' },
+];
+
 const searchConfig: SearchConfig = {
   search: false,
   filters: [
@@ -32,7 +71,7 @@ const searchConfig: SearchConfig = {
       type: FieldType.Choice,
       name: 'topic',
       label: t('webhooks.monitor.filters.topic'),
-      options: [],
+      options: topicOptions,
       labelBy: 'label',
       valueBy: 'value',
     },
@@ -40,7 +79,7 @@ const searchConfig: SearchConfig = {
       type: FieldType.Choice,
       name: 'action',
       label: t('webhooks.monitor.filters.action'),
-      options: [],
+      options: actionOptions,
       labelBy: 'label',
       valueBy: 'value',
     },
@@ -48,7 +87,7 @@ const searchConfig: SearchConfig = {
       type: FieldType.Choice,
       name: 'integration',
       label: t('webhooks.reports.filters.integration'),
-      options: [],
+      options: integrationOptions,
       labelBy: 'label',
       valueBy: 'value',
     },
@@ -56,7 +95,7 @@ const searchConfig: SearchConfig = {
       type: FieldType.Choice,
       name: 'status',
       label: t('webhooks.monitor.filters.status'),
-      options: [],
+      options: statusOptions,
       labelBy: 'label',
       valueBy: 'value',
     },
@@ -64,7 +103,7 @@ const searchConfig: SearchConfig = {
       type: FieldType.Choice,
       name: 'responseCode',
       label: t('webhooks.reports.filters.responseCodeBucket'),
-      options: [],
+      options: responseCodeOptions,
       labelBy: 'label',
       valueBy: 'value',
     },


### PR DESCRIPTION
## Summary
- populate webhook reports filters with action, topic, status, response code and integration options

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b850d8fe94832eaf6c26d5b365f7da