### PR TITLE
Add webhook report charts

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -239,6 +239,15 @@
         "avgAttemptsTooltip": "Average attempts per delivery",
         "avgSolveMs": "Avg solve ms",
         "avgSolveMsTooltip": "Average milliseconds to solve a request"
+      },
+      "charts": {
+        "deliveryOutcome": "Delivery outcome over time",
+        "latency": "Latency over time",
+        "topics": "Topics breakdown",
+        "responseCodes": "Response codes distribution",
+        "retries": "Retries distribution",
+        "p50": "p50",
+        "p95": "p95"
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2946,7 +2946,8 @@
       },
       "filters": {
         "integration": "Integration",
-        "responseCodeBucket": "Response code bucket"
+        "responseCodeBucket": "Response code bucket",
+        "date": "Date"
       },
       "kpis": {
         "deliveries": "Deliveries",
@@ -2969,6 +2970,15 @@
         "avgSolveMsTooltip": "Average milliseconds to solve a request",
         "responseCodeBucket": "Response code bucket",
         "date": "Date"
+      },
+      "charts": {
+        "deliveryOutcome": "Delivery outcome over time",
+        "latency": "Latency over time",
+        "topics": "Topics breakdown",
+        "responseCodes": "Response codes distribution",
+        "retries": "Retries distribution",
+        "p50": "p50",
+        "p95": "p95"
       }
     }
   }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -239,6 +239,15 @@
         "avgAttemptsTooltip": "Average attempts per delivery",
         "avgSolveMs": "Avg solve ms",
         "avgSolveMsTooltip": "Average milliseconds to solve a request"
+      },
+      "charts": {
+        "deliveryOutcome": "Delivery outcome over time",
+        "latency": "Latency over time",
+        "topics": "Topics breakdown",
+        "responseCodes": "Response codes distribution",
+        "retries": "Retries distribution",
+        "p50": "p50",
+        "p95": "p95"
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -2020,7 +2020,8 @@
       },
       "filters": {
         "integration": "Integratie",
-        "responseCodeBucket": "Antwoordcode-bucket"
+        "responseCodeBucket": "Antwoordcode-bucket",
+        "date": "Datum"
       },
       "kpis": {
         "deliveries": "Deliveries",
@@ -2043,6 +2044,15 @@
         "avgSolveMsTooltip": "Average milliseconds to solve a request",
         "responseCodeBucket": "Antwoordcode-bucket",
         "date": "Datum"
+      },
+      "charts": {
+        "deliveryOutcome": "Delivery outcome over time",
+        "latency": "Latency over time",
+        "topics": "Topics breakdown",
+        "responseCodes": "Response codes distribution",
+        "retries": "Retries distribution",
+        "p50": "p50",
+        "p95": "p95"
       }
     }
   }

--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -270,3 +270,36 @@ export const webhookReportsKpiQuery = gql`
   }
 `;
 
+export const webhookReportsSeriesQuery = gql`
+  query WebhookReportsSeries($filter: WebhookDeliveryFilter) {
+    webhookReportsSeries(filters: $filter) {
+      deliveryOutcomeBuckets {
+        timestamp
+        delivered
+        failed
+        pending
+        sending
+      }
+      latencyBuckets {
+        timestamp
+        p50
+        p95
+      }
+      topicsBreakdown {
+        topic
+        deliveries
+        delivered
+        failed
+        successRate
+      }
+      responseCodesBreakdown {
+        codeBucket
+        count
+      }
+      retriesDistribution {
+        attempts
+        count
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- add webhook reports series query
- render delivery, latency, and breakdown charts with ApexCharts
- add chart translation strings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b855a92960832e914db08d24ba4eb3

## Summary by Sourcery

Add series data fetching and render multiple webhook report charts in WebhookReports component using ApexCharts

New Features:
- Add GraphQL query to fetch time-series data for webhook reports
- Render delivery outcome, latency, topics breakdown, response codes, and retry distribution charts with ApexCharts
- Enable chart dataPointSelection handlers to update filters via URL query
- Support custom date range selection alongside preset time ranges

Enhancements:
- Include 'attempt' in report filters
- Add localization entries for new chart titles and labels