### PR TITLE
Align webhook report queries with backend API changes

### DIFF
--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -253,8 +253,22 @@ export const webhookDeliveryStatsQuery = gql`
 `;
 
 export const webhookReportsKpiQuery = gql`
-  query WebhookReportsKpi($filter: WebhookDeliveryFilter) {
-    webhookReportsKpi(filters: $filter) {
+  query WebhookReportsKpi(
+    $integration: WebhookIntegrationPartialInput!
+    $timeFrom: DateTime!
+    $timeTo: DateTime!
+    $topic: String
+    $action: String
+    $status: String
+  ) {
+    webhookReportsKpi(
+      integration: $integration
+      timeFrom: $timeFrom
+      timeTo: $timeTo
+      topic: $topic
+      action: $action
+      status: $status
+    ) {
       deliveries
       delivered
       failed
@@ -271,8 +285,22 @@ export const webhookReportsKpiQuery = gql`
 `;
 
 export const webhookReportsSeriesQuery = gql`
-  query WebhookReportsSeries($filter: WebhookDeliveryFilter) {
-    webhookReportsSeries(filters: $filter) {
+  query WebhookReportsSeries(
+    $integration: WebhookIntegrationPartialInput!
+    $timeFrom: DateTime!
+    $timeTo: DateTime!
+    $topic: String
+    $action: String
+    $status: String
+  ) {
+    webhookReportsSeries(
+      integration: $integration
+      timeFrom: $timeFrom
+      timeTo: $timeTo
+      topic: $topic
+      action: $action
+      status: $status
+    ) {
       deliveryOutcomeBuckets {
         timestamp
         delivered


### PR DESCRIPTION
## Summary
- update webhook KPI and series queries to use integration and time range arguments
- adjust webhook reports component to send new variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b866a5c95c832e9e7f1c5ec527da76