### PR TITLE
Refactor webhook reports to use filter-based queries

### DIFF
--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -253,22 +253,8 @@ export const webhookDeliveryStatsQuery = gql`
 `;
 
 export const webhookReportsKpiQuery = gql`
-  query WebhookReportsKpi(
-    $integration: WebhookIntegrationPartialInput!
-    $timeFrom: DateTime!
-    $timeTo: DateTime!
-    $topic: String
-    $action: String
-    $status: String
-  ) {
-    webhookReportsKpi(
-      integration: $integration
-      timeFrom: $timeFrom
-      timeTo: $timeTo
-      topic: $topic
-      action: $action
-      status: $status
-    ) {
+  query WebhookReportsKpi($filter: WebhookDeliveryFilter) {
+    webhookReportsKpi(filters: $filter) {
       deliveries
       delivered
       failed
@@ -286,20 +272,12 @@ export const webhookReportsKpiQuery = gql`
 
 export const webhookReportsSeriesQuery = gql`
   query WebhookReportsSeries(
-    $integration: WebhookIntegrationPartialInput!
-    $timeFrom: DateTime!
-    $timeTo: DateTime!
-    $topic: String
-    $action: String
-    $status: String
+    $filter: WebhookDeliveryFilter
+    $bucket: String
   ) {
     webhookReportsSeries(
-      integration: $integration
-      timeFrom: $timeFrom
-      timeTo: $timeTo
-      topic: $topic
-      action: $action
-      status: $status
+      filters: $filter
+      bucket: $bucket
     ) {
       deliveryOutcomeBuckets {
         timestamp


### PR DESCRIPTION
## Summary
- update webhook report queries to accept a filter object
- build report tab filter and use new queries

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b86c019c7c832ea74f306ca79ceff4