### PR TITLE
feat: add advanced webhook reports visuals

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -246,8 +246,33 @@
         "topics": "Topics breakdown",
         "responseCodes": "Response codes distribution",
         "retries": "Retries distribution",
+        "heatmap": "Heatmap",
+        "topOffenders": "Top-Verursacher",
         "p50": "p50",
         "p95": "p95"
+      }
+      ,
+      "heatmap": {
+        "metric": {
+          "failures": "Fehler",
+          "latency": "Medianlatenz"
+        },
+        "weekdays": {
+          "1": "Mo",
+          "2": "Di",
+          "3": "Mi",
+          "4": "Do",
+          "5": "Fr",
+          "6": "Sa",
+          "7": "So"
+        }
+      },
+      "topOffenders": {
+        "columns": {
+          "integration": "Integration",
+          "failureRate": "Fehler %",
+          "latencyP95": "p95 Latenz"
+        }
       }
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2977,8 +2977,32 @@
         "topics": "Topics breakdown",
         "responseCodes": "Response codes distribution",
         "retries": "Retries distribution",
+        "heatmap": "Heatmap",
+        "topOffenders": "Top offenders",
         "p50": "p50",
         "p95": "p95"
+      },
+      "heatmap": {
+        "metric": {
+          "failures": "Failures",
+          "latency": "Median latency"
+        },
+        "weekdays": {
+          "1": "Mon",
+          "2": "Tue",
+          "3": "Wed",
+          "4": "Thu",
+          "5": "Fri",
+          "6": "Sat",
+          "7": "Sun"
+        }
+      },
+      "topOffenders": {
+        "columns": {
+          "integration": "Integration",
+          "failureRate": "Failure %",
+          "latencyP95": "p95 latency"
+        }
       }
     }
   }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -246,8 +246,33 @@
         "topics": "Topics breakdown",
         "responseCodes": "Response codes distribution",
         "retries": "Retries distribution",
+        "heatmap": "Carte thermique",
+        "topOffenders": "Principaux responsables",
         "p50": "p50",
         "p95": "p95"
+      }
+      ,
+      "heatmap": {
+        "metric": {
+          "failures": "Échecs",
+          "latency": "Latence médiane"
+        },
+        "weekdays": {
+          "1": "Lun",
+          "2": "Mar",
+          "3": "Mer",
+          "4": "Jeu",
+          "5": "Ven",
+          "6": "Sam",
+          "7": "Dim"
+        }
+      },
+      "topOffenders": {
+        "columns": {
+          "integration": "Intégration",
+          "failureRate": "% d'échec",
+          "latencyP95": "Latence p95"
+        }
       }
     }
   }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -2051,8 +2051,33 @@
         "topics": "Topics breakdown",
         "responseCodes": "Response codes distribution",
         "retries": "Retries distribution",
+        "heatmap": "Heatmap",
+        "topOffenders": "Top-veroorzakers",
         "p50": "p50",
         "p95": "p95"
+      }
+      ,
+      "heatmap": {
+        "metric": {
+          "failures": "Fouten",
+          "latency": "Median latentie"
+        },
+        "weekdays": {
+          "1": "Ma",
+          "2": "Di",
+          "3": "Wo",
+          "4": "Do",
+          "5": "Vr",
+          "6": "Za",
+          "7": "Zo"
+        }
+      },
+      "topOffenders": {
+        "columns": {
+          "integration": "Integratie",
+          "failureRate": "Fout %",
+          "latencyP95": "p95 latentie"
+        }
       }
     }
   }

--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -306,6 +306,18 @@ export const webhookReportsSeriesQuery = gql`
         attempts
         count
       }
+      heatmap {
+        weekday
+        hour
+        failures
+        medianLatency
+      }
+      topOffenders {
+        integrationId
+        integrationHostname
+        failureRate
+        latencyP95
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- add auto-refresh toggle and heatmap/top offenders visuals to webhook reports
- query heatmap and top offenders data
- localize new report labels

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b87006c6a4832eaa734ce592b28494