### PR TITLE
Add latency percentiles legend

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
@@ -450,6 +450,14 @@ const topOffenders = computed(() => seriesData.value?.topOffenders || []);
       :series="latencySeries"
       class="mt-4"
     />
+    <div class="mt-2 text-sm text-gray-500">
+      <p>{{ t('webhooks.reports.charts.latencyLegend.title') }}</p>
+      <ul class="list-disc ml-5">
+        <li>{{ t('webhooks.reports.charts.latencyLegend.p50') }}</li>
+        <li>{{ t('webhooks.reports.charts.latencyLegend.p95') }}</li>
+        <li>{{ t('webhooks.reports.charts.latencyLegend.p99') }}</li>
+      </ul>
+    </div>
     <ApexChart
       v-if="seriesData"
       type="bar"

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -249,7 +249,13 @@
         "heatmap": "Heatmap",
         "topOffenders": "Top-Verursacher",
         "p50": "p50",
-        "p95": "p95"
+        "p95": "p95",
+        "latencyLegend": {
+          "title": "Latency percentiles:",
+          "p50": "p50 = median (half of deliveries are faster)",
+          "p95": "p95 = 95% are faster (only 1 in 20 slower)",
+          "p99": "p99 = 99% are faster (only 1 in 100 slower)"
+        }
       }
       ,
       "heatmap": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2980,7 +2980,13 @@
         "heatmap": "Heatmap",
         "topOffenders": "Top offenders",
         "p50": "p50",
-        "p95": "p95"
+        "p95": "p95",
+        "latencyLegend": {
+          "title": "Latency percentiles:",
+          "p50": "p50 = median (half of deliveries are faster)",
+          "p95": "p95 = 95% are faster (only 1 in 20 slower)",
+          "p99": "p99 = 99% are faster (only 1 in 100 slower)"
+        }
       },
       "heatmap": {
         "metric": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -249,7 +249,13 @@
         "heatmap": "Carte thermique",
         "topOffenders": "Principaux responsables",
         "p50": "p50",
-        "p95": "p95"
+        "p95": "p95",
+        "latencyLegend": {
+          "title": "Latency percentiles:",
+          "p50": "p50 = median (half of deliveries are faster)",
+          "p95": "p95 = 95% are faster (only 1 in 20 slower)",
+          "p99": "p99 = 99% are faster (only 1 in 100 slower)"
+        }
       }
       ,
       "heatmap": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -2054,7 +2054,13 @@
         "heatmap": "Heatmap",
         "topOffenders": "Top-veroorzakers",
         "p50": "p50",
-        "p95": "p95"
+        "p95": "p95",
+        "latencyLegend": {
+          "title": "Latency percentiles:",
+          "p50": "p50 = median (half of deliveries are faster)",
+          "p95": "p95 = 95% are faster (only 1 in 20 slower)",
+          "p99": "p99 = 99% are faster (only 1 in 100 slower)"
+        }
       }
       ,
       "heatmap": {


### PR DESCRIPTION
## Summary
- add legend explaining p50, p95, and p99 latency percentiles
- document latency percentile legend in translations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8730bca60832eaa752bf8e306ff6b