### PR TITLE
Improve webhook reports and monitor

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
@@ -421,8 +421,21 @@ const rpmDisplay = computed(() => `${rpm.value ?? 0}/120`);
 <template>
   <div class="space-y-4">
     <FilterManager :search-config="searchConfig" />
+    <div>
+      <Title level="2">{{ t('webhooks.monitor.title') }}</Title>
+      <p class="text-sm text-gray-600">{{ t('webhooks.monitor.description') }}</p>
+    </div>
     <div class="flex items-center justify-between">
-      <Title>{{ t('webhooks.monitor.title') }}</Title>
+      <div class="flex items-center gap-2">
+        <Button
+          v-for="opt in timeOptions"
+          :key="opt"
+          :custom-class="`px-2 py-1 rounded text-sm ${selectedRange === opt ? 'bg-primary text-white' : 'bg-gray-100'}`"
+          @click="selectRange(opt)"
+        >
+          {{ t(`webhooks.monitor.timeRange.${opt}`) }}
+        </Button>
+      </div>
       <div class="flex items-center gap-2">
         <Label>{{ t('webhooks.monitor.autoRefresh') }}</Label>
         <Toggle v-model="live" />
@@ -432,18 +445,7 @@ const rpmDisplay = computed(() => `${rpm.value ?? 0}/120`);
       </div>
     </div>
 
-    <div class="flex items-center gap-2">
-      <Button
-        v-for="opt in timeOptions"
-        :key="opt"
-        :custom-class="`px-2 py-1 rounded text-sm ${selectedRange === opt ? 'bg-primary text-white' : 'bg-gray-100'}`"
-        @click="selectRange(opt)"
-      >
-        {{ t(`webhooks.monitor.timeRange.${opt}`) }}
-      </Button>
-    </div>
-
-    <hr>
+    <hr />
 
     <div class="flex flex-wrap gap-2">
       <div
@@ -458,6 +460,8 @@ const rpmDisplay = computed(() => `${rpm.value ?? 0}/120`);
 
     <KpiCards :stats="stats" :stats-loading="statsLoading" />
 
+    <hr class="my-4" />
+
     <EventTable
       :events="events"
       :loading="loading"
@@ -467,6 +471,8 @@ const rpmDisplay = computed(() => `${rpm.value ?? 0}/120`);
       :format-time="formatTime"
       :get-response-code-color="getResponseCodeColor"
     />
+
+    <hr class="my-4" />
 
     <EventDrawer
       :event="selectedEvent"

--- a/src/core/integrations/integrations/integrations-show/containers/monitor/components/EventTable.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/components/EventTable.vue
@@ -46,7 +46,7 @@ defineProps<Props>();
       </div>
     </div>
     <div>
-      <div v-if="loading">
+      <div v-if="loading && events.length === 0">
         <div v-for="n in 5" :key="n" class="grid grid-cols-8 border-b border-gray-200 bg-white">
           <div v-for="i in 8" :key="i" class="px-3 py-2">
             <div class="h-4 bg-gray-200 rounded animate-pulse"></div>
@@ -76,7 +76,7 @@ defineProps<Props>();
             <Badge :color="statusBadgeMap[ev.status].color" :text="statusBadgeMap[ev.status].text" />
           </div>
           <div class="px-3 py-2 text-sm text-gray-500">
-            <Badge :color="getResponseCodeColor(ev.responseCode)" :text="ev.responseCode" />
+            <Badge :color="getResponseCodeColor(ev.responseCode)" :text="String(ev.responseCode)" />
           </div>
           <div class="px-3 py-2 text-sm text-gray-500">
             {{ ev.responseMs }}

--- a/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
@@ -251,7 +251,6 @@ const deliveryOutcomeOptions = computed(() => ({
   chart: { type: 'area', stacked: true, toolbar: { show: false } },
   xaxis: { type: 'datetime' },
   colors: ['#22c55e', '#ef4444', '#f97316', '#3b82f6'],
-  title: { text: t('webhooks.reports.charts.deliveryOutcome') },
 }));
 
 const latencySeries = computed(() => {
@@ -271,7 +270,6 @@ const latencySeries = computed(() => {
 const latencyOptions = computed(() => ({
   chart: { type: 'line', toolbar: { show: false } },
   xaxis: { type: 'datetime' },
-  title: { text: t('webhooks.reports.charts.latency') },
 }));
 
 const topicsSeries = computed(() => {
@@ -303,7 +301,7 @@ const topicsOptions = computed(() => ({
     },
   },
   stroke: { width: [0, 3] },
-  plotOptions: { bar: { horizontal: true } },
+  plotOptions: { bar: { horizontal: false } },
   xaxis: { categories: seriesData.value ? seriesData.value.topicsBreakdown.map((b: any) => b.topic) : [] },
   yaxis: [
     { title: { text: t('webhooks.reports.kpis.deliveries') } },
@@ -315,7 +313,6 @@ const topicsOptions = computed(() => ({
     },
   ],
   tooltip: { shared: true, intersect: false },
-  title: { text: t('webhooks.reports.charts.topics') },
 }));
 
 const responseCodesSeries = computed(() => {
@@ -355,7 +352,6 @@ const responseCodesOptions = computed(() => {
     plotOptions: { bar: { distributed: true } },
     colors,
     xaxis: { categories },
-    title: { text: t('webhooks.reports.charts.responseCodes') },
   };
 });
 
@@ -396,7 +392,6 @@ const retriesOptions = computed(() => {
     plotOptions: { bar: { distributed: true } },
     colors,
     xaxis: { categories },
-    title: { text: t('webhooks.reports.charts.retries') },
   };
 });
 
@@ -421,11 +416,6 @@ const heatmapSeries = computed(() => {
 const heatmapOptions = computed(() => ({
   chart: { type: 'heatmap', toolbar: { show: false } },
   dataLabels: { enabled: false },
-  title: {
-    text: `${t('webhooks.reports.charts.heatmap')} - ${t(
-      `webhooks.reports.heatmap.metric.${heatmapMetric.value}`,
-    )}`,
-  },
 }));
 
 const topOffenders = computed(() => seriesData.value?.topOffenders || []);
@@ -435,7 +425,7 @@ const topOffenders = computed(() => seriesData.value?.topOffenders || []);
   <div class="space-y-4">
     <FilterManager :search-config="searchConfig" />
     <div>
-      <Title level="2">{{ t('integrations.show.tabs.reports') }}</Title>
+      <Title level="1">{{ t('integrations.show.tabs.reports') }}</Title>
       <p class="text-sm text-gray-600">{{ t('webhooks.reports.description') }}</p>
     </div>
     <hr />
@@ -468,59 +458,47 @@ const topOffenders = computed(() => seriesData.value?.topOffenders || []);
     </div>
     <KpiCards :stats="stats" :stats-loading="statsLoading" />
     <hr class="my-4" />
-    <ApexChart
-      v-if="seriesData"
-      type="area"
-      height="300"
-      :options="deliveryOutcomeOptions"
-      :series="deliveryOutcomeSeries"
-    />
-    <hr class="my-4" v-if="seriesData" />
-    <ApexChart
-      v-if="seriesData"
-      type="line"
-      height="300"
-      :options="latencyOptions"
-      :series="latencySeries"
-      class="mt-4"
-    />
-    <hr class="my-4" v-if="seriesData" />
-    <div class="mt-2 text-sm text-gray-500">
-      <p>{{ t('webhooks.reports.charts.latencyLegend.title') }}</p>
-      <ul class="list-disc ml-5">
-        <li>{{ t('webhooks.reports.charts.latencyLegend.p50') }}</li>
-        <li>{{ t('webhooks.reports.charts.latencyLegend.p95') }}</li>
-        <li>{{ t('webhooks.reports.charts.latencyLegend.p99') }}</li>
-      </ul>
+    <div v-if="seriesData">
+      <Title level="3">{{ t('webhooks.reports.charts.deliveryOutcome') }}</Title>
+      <p class="text-sm text-gray-600">{{ t('webhooks.reports.chartDescriptions.deliveryOutcome') }}</p>
+      <ApexChart type="area" height="300" :options="deliveryOutcomeOptions" :series="deliveryOutcomeSeries" />
     </div>
-    <ApexChart
-      v-if="seriesData"
-      type="bar"
-      height="300"
-      :options="topicsOptions"
-      :series="topicsSeries"
-      class="mt-4"
-    />
     <hr class="my-4" v-if="seriesData" />
-    <ApexChart
-      v-if="seriesData"
-      type="bar"
-      height="300"
-      :options="responseCodesOptions"
-      :series="responseCodesSeries"
-      class="mt-4"
-    />
+    <div v-if="seriesData">
+      <Title level="3">{{ t('webhooks.reports.charts.latency') }}</Title>
+      <p class="text-sm text-gray-600">{{ t('webhooks.reports.chartDescriptions.latency') }}</p>
+      <ApexChart type="line" height="300" :options="latencyOptions" :series="latencySeries" class="mt-4" />
+      <div class="mt-2 text-sm text-gray-500">
+        <p>{{ t('webhooks.reports.charts.latencyLegend.title') }}</p>
+        <ul class="list-disc ml-5">
+          <li>{{ t('webhooks.reports.charts.latencyLegend.p50') }}</li>
+          <li>{{ t('webhooks.reports.charts.latencyLegend.p95') }}</li>
+          <li>{{ t('webhooks.reports.charts.latencyLegend.p99') }}</li>
+        </ul>
+      </div>
+    </div>
     <hr class="my-4" v-if="seriesData" />
-    <ApexChart
-      v-if="seriesData"
-      type="bar"
-      height="300"
-      :options="retriesOptions"
-      :series="retriesSeries"
-      class="mt-4"
-    />
+    <div v-if="seriesData">
+      <Title level="3">{{ t('webhooks.reports.charts.topics') }}</Title>
+      <p class="text-sm text-gray-600">{{ t('webhooks.reports.chartDescriptions.topics') }}</p>
+      <ApexChart type="bar" height="300" :options="topicsOptions" :series="topicsSeries" class="mt-4" />
+    </div>
     <hr class="my-4" v-if="seriesData" />
-    <div class="mt-4">
+    <div v-if="seriesData">
+      <Title level="3">{{ t('webhooks.reports.charts.responseCodes') }}</Title>
+      <p class="text-sm text-gray-600">{{ t('webhooks.reports.chartDescriptions.responseCodes') }}</p>
+      <ApexChart type="bar" height="300" :options="responseCodesOptions" :series="responseCodesSeries" class="mt-4" />
+    </div>
+    <hr class="my-4" v-if="seriesData" />
+    <div v-if="seriesData">
+      <Title level="3">{{ t('webhooks.reports.charts.retries') }}</Title>
+      <p class="text-sm text-gray-600">{{ t('webhooks.reports.chartDescriptions.retries') }}</p>
+      <ApexChart type="bar" height="300" :options="retriesOptions" :series="retriesSeries" class="mt-4" />
+    </div>
+    <hr class="my-4" v-if="seriesData" />
+    <div v-if="seriesData" class="mt-4">
+      <Title level="3">{{ t('webhooks.reports.charts.heatmap') }}</Title>
+      <p class="text-sm text-gray-600">{{ t('webhooks.reports.chartDescriptions.heatmap') }}</p>
       <div class="flex items-center gap-2 mb-2">
         <Button
           v-for="m in heatmapMetrics"
@@ -531,32 +509,27 @@ const topOffenders = computed(() => seriesData.value?.topOffenders || []);
           {{ t(`webhooks.reports.heatmap.metric.${m}`) }}
         </Button>
       </div>
-      <ApexChart
-        v-if="seriesData"
-        type="heatmap"
-        height="300"
-        :options="heatmapOptions"
-        :series="heatmapSeries"
-      />
+      <ApexChart type="heatmap" height="300" :options="heatmapOptions" :series="heatmapSeries" />
     </div>
-    <hr class="my-4" v-if="seriesData" />
-    <table
-      v-if="topOffenders.length"
-      class="mt-4 w-full text-sm border-collapse"
-    >
-      <thead>
-        <tr>
-          <th class="p-2 text-left">{{ t('webhooks.reports.topOffenders.columns.failureRate') }}</th>
-          <th class="p-2 text-left">{{ t('webhooks.reports.topOffenders.columns.latencyP95') }}</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="o in topOffenders" :key="o.integrationId" class="odd:bg-gray-50">
-          <td class="p-2">{{ o.failureRate.toFixed(2) }}%</td>
-          <td class="p-2">{{ o.latencyP95 }}</td>
-        </tr>
-      </tbody>
-    </table>
+    <hr class="my-4" v-if="topOffenders.length" />
+    <div v-if="topOffenders.length">
+      <Title level="3">{{ t('webhooks.reports.charts.topOffenders') }}</Title>
+      <p class="text-sm text-gray-600">{{ t('webhooks.reports.chartDescriptions.topOffenders') }}</p>
+      <table class="mt-4 w-full text-sm border-collapse">
+        <thead>
+          <tr>
+            <th class="p-2 text-left">{{ t('webhooks.reports.topOffenders.columns.failureRate') }}</th>
+            <th class="p-2 text-left">{{ t('webhooks.reports.topOffenders.columns.latencyP95') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="o in topOffenders" :key="o.integrationId" class="odd:bg-gray-50">
+            <td class="p-2">{{ o.failureRate.toFixed(2) }}%</td>
+            <td class="p-2">{{ o.latencyP95 }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </template>
 

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -144,6 +144,7 @@
   "webhooks": {
     "monitor": {
       "title": "Monitor",
+      "description": "Echtzeitübersicht der Webhook-Lieferungen.",
       "timeRange": {
         "live": "Live",
         "last15m": "Letzte 15 Min",
@@ -211,6 +212,15 @@
     },
     "reports": {
       "description": "Detailed insights into webhook deliveries.",
+      "chartDescriptions": {
+        "deliveryOutcome": "Verteilung der Lieferstatus im Zeitverlauf.",
+        "latency": "Webhook-Latenz-Perzentile im Zeitverlauf.",
+        "topics": "Top-Themen nach Volumen und Erfolgsrate.",
+        "responseCodes": "Verteilung der HTTP-Antwortcodes.",
+        "retries": "Lieferungen nach Anzahl der Versuche gruppiert.",
+        "heatmap": "Fehler oder Latenz nach Wochentag und Stunde.",
+        "topOffenders": "Integrationen mit höchsten Fehlerraten und Latenzen."
+      },
       "timeRange": {
         "today": "Heute",
         "7d": "7d",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2834,6 +2834,7 @@
   "webhooks": {
     "monitor": {
       "title": "Monitor",
+      "description": "Real-time overview of webhook deliveries.",
       "timeRange": {
         "live": "Live",
         "last15m": "Last 15m",
@@ -2940,6 +2941,15 @@
     },
     "reports": {
       "description": "Detailed insights into webhook deliveries.",
+      "chartDescriptions": {
+        "deliveryOutcome": "Distribution of delivery statuses over time.",
+        "latency": "Webhook latency percentiles over time.",
+        "topics": "Top topics by volume and success rate.",
+        "responseCodes": "HTTP response code distribution.",
+        "retries": "Deliveries grouped by retry attempts.",
+        "heatmap": "Failures or latency by weekday and hour.",
+        "topOffenders": "Integrations with highest failure rates and latency."
+      },
       "timeRange": {
         "today": "Today",
         "7d": "7d",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -144,6 +144,7 @@
   "webhooks": {
     "monitor": {
       "title": "Monitor",
+      "description": "Vue en temps réel des livraisons de webhooks.",
       "timeRange": {
         "live": "En direct",
         "last15m": "Dernières 15 min",
@@ -211,6 +212,15 @@
     },
     "reports": {
       "description": "Detailed insights into webhook deliveries.",
+      "chartDescriptions": {
+        "deliveryOutcome": "Répartition des statuts de livraison dans le temps.",
+        "latency": "Percentiles de latence des webhooks dans le temps.",
+        "topics": "Principaux sujets par volume et taux de réussite.",
+        "responseCodes": "Répartition des codes de réponse HTTP.",
+        "retries": "Livraisons regroupées par nombre de tentatives.",
+        "heatmap": "Échecs ou latence par jour et heure.",
+        "topOffenders": "Intégrations avec les taux d'échec et la latence les plus élevés."
+      },
       "timeRange": {
         "today": "Aujourd'hui",
         "7d": "7 j",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1947,6 +1947,7 @@
   "webhooks": {
     "monitor": {
       "title": "Monitor",
+      "description": "Realtime overzicht van webhook-leveringen.",
       "timeRange": {
         "live": "Live",
         "last15m": "Laatste 15m",
@@ -2014,6 +2015,15 @@
     },
     "reports": {
       "description": "Detailed insights into webhook deliveries.",
+      "chartDescriptions": {
+        "deliveryOutcome": "Verdeling van leveringsstatussen in de tijd.",
+        "latency": "Webhook-latentiepercentielen in de tijd.",
+        "topics": "Toponderwerpen naar volume en succespercentage.",
+        "responseCodes": "Verdeling van HTTP-responscodes.",
+        "retries": "Leveringen gegroepeerd op aantal pogingen.",
+        "heatmap": "Fouten of latentie per weekdag en uur.",
+        "topOffenders": "Integraties met de hoogste foutpercentages en latentie."
+      },
       "timeRange": {
         "today": "Vandaag",
         "7d": "7 d",


### PR DESCRIPTION
## Summary
- Fix topics chart by switching to vertical bars to support multiple y-axes
- Enhance reports and monitor views with clearer section titles, descriptions, and separators
- Smooth monitor auto-refresh and fix HTTP code badge warnings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b879291014832e85ecba6ac2a0a282