### PR TITLE
Fix regenerate webhook secret mutation

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
@@ -128,7 +128,7 @@ const regenerateSecret = async () => {
   try {
     const { data } = await apolloClient.mutate({
       mutation: regenerateWebhookIntegrationSecretMutation,
-      variables: { data: { id: formData.value.id } }
+      variables: { instance: { id: formData.value.id } }
     });
     formData.value.secret = data?.regenerateWebhookIntegrationSecret?.secret || '';
     Toast.success(t('shared.alert.toast.submitSuccessUpdate'));

--- a/src/shared/api/mutations/webhooks.js
+++ b/src/shared/api/mutations/webhooks.js
@@ -67,23 +67,25 @@ export const updateWebhookIntegrationMutation = gql`
 `;
 
 export const regenerateWebhookIntegrationSecretMutation = gql`
-  mutation regenerateWebhookIntegrationSecret($data: WebhookIntegrationPartialInput!) {
-    regenerateWebhookIntegrationSecret(data: $data) {
-      id
-      hostname
-      active
-      topic
-      version
-      url
-      secret
-      userAgent
-      timeoutMs
-      mode
-      extraHeaders
-      config
-      retentionPolicy
-      requestsPerMinute
-      maxRetries
+  mutation regenerateWebhookIntegrationSecret($instance: WebhookIntegrationPartialInput!) {
+    regenerateWebhookIntegrationSecret(instance: $instance) {
+      ... on WebhookIntegrationType {
+        id
+        hostname
+        active
+        topic
+        version
+        url
+        secret
+        userAgent
+        timeoutMs
+        mode
+        extraHeaders
+        config
+        retentionPolicy
+        requestsPerMinute
+        maxRetries
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- use `instance` argument and inline fragment in regenerate secret mutation
- update webhook general info tab to pass `instance`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b87a605eb8832e9c6bab1a3e3d78b4

## Summary by Sourcery

Fix regenerateWebhookIntegrationSecret GraphQL mutation argument and response format, and update the UI to pass the correct variable.

Enhancements:
- Switch the regenerateWebhookIntegrationSecret mutation to use an instance argument instead of data
- Add an inline fragment on WebhookIntegrationType in the mutation selection set
- Update the WebhookGeneralInfoTab component to pass instance variables when calling the mutation