### PR TITLE
Move latency legend beneath webhook KPI cards

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
@@ -459,6 +459,13 @@ const rpmDisplay = computed(() => `${rpm.value ?? 0}/120`);
     </div>
 
     <KpiCards :stats="stats" :stats-loading="statsLoading" />
+    <div class="mt-2 text-sm text-gray-500">
+      <p>{{ t('webhooks.reports.charts.latencyLegend.title') }}</p>
+      <ul class="list-disc ml-5">
+        <li>{{ t('webhooks.reports.charts.latencyLegend.p50') }}</li>
+        <li>{{ t('webhooks.reports.charts.latencyLegend.p95') }}</li>
+      </ul>
+    </div>
 
     <hr class="my-4" />
 

--- a/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
@@ -457,6 +457,14 @@ const topOffenders = computed(() => seriesData.value?.topOffenders || []);
       </div>
     </div>
     <KpiCards :stats="stats" :stats-loading="statsLoading" />
+    <div class="mt-2 text-sm text-gray-500">
+      <p>{{ t('webhooks.reports.charts.latencyLegend.title') }}</p>
+      <ul class="list-disc ml-5">
+        <li>{{ t('webhooks.reports.charts.latencyLegend.p50') }}</li>
+        <li>{{ t('webhooks.reports.charts.latencyLegend.p95') }}</li>
+        <li>{{ t('webhooks.reports.charts.latencyLegend.p99') }}</li>
+      </ul>
+    </div>
     <hr class="my-4" />
     <div v-if="seriesData">
       <Title level="3">{{ t('webhooks.reports.charts.deliveryOutcome') }}</Title>
@@ -468,14 +476,6 @@ const topOffenders = computed(() => seriesData.value?.topOffenders || []);
       <Title level="3">{{ t('webhooks.reports.charts.latency') }}</Title>
       <p class="text-sm text-gray-600">{{ t('webhooks.reports.chartDescriptions.latency') }}</p>
       <ApexChart type="line" height="300" :options="latencyOptions" :series="latencySeries" class="mt-4" />
-      <div class="mt-2 text-sm text-gray-500">
-        <p>{{ t('webhooks.reports.charts.latencyLegend.title') }}</p>
-        <ul class="list-disc ml-5">
-          <li>{{ t('webhooks.reports.charts.latencyLegend.p50') }}</li>
-          <li>{{ t('webhooks.reports.charts.latencyLegend.p95') }}</li>
-          <li>{{ t('webhooks.reports.charts.latencyLegend.p99') }}</li>
-        </ul>
-      </div>
     </div>
     <hr class="my-4" v-if="seriesData" />
     <div v-if="seriesData">


### PR DESCRIPTION
## Summary
- reposition webhook reports latency legend below KPI cards
- show latency legend on monitor with p50 and p95 entries

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8878d91ac832e8d3089486b5171b1

## Summary by Sourcery

Move and consolidate the latency legends below the KPI cards on webhook Reports and Monitor pages.

Enhancements:
- Reposition latency legend under KpiCards on the WebhookReports page and include p99 entries
- Add latency legend under KpiCards on the WebhookMonitor page with p50 and p95 entries
- Remove duplicate legend from the Reports chart section for clarity