### PR TITLE
fix: preserve text in query filter

### DIFF
--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
@@ -86,7 +86,6 @@ const disabled = ref(props.filter.disabled === true);
   <div class="filter-item">
     <Label>{{ filter.label }}</Label>
         <Selector
-          v-if="!loading"
           class="h-9"
           v-model="selectedValue"
           :options="cleanedData"
@@ -100,16 +99,7 @@ const disabled = ref(props.filter.disabled === true);
           :removable="removable"
           :limit="limit"
           :disabled="disabled"
+          :is-loading="loading"
           @searched="handleInput" />
-      <Selector
-          v-else
-          class="h-9"
-          :modelValue="null"
-          :options="[]"
-          :label-by="filter.labelBy"
-          :value-by="filter.valueBy"
-          :removable="false"
-          :is-loading="true"
-          disabled />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- keep query filter input mounted during loading to avoid clearing typed text

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b88e8b240c832ea1103aaf7c872c5d

## Summary by Sourcery

Preserve filter query input state by simplifying the template to always render a single Selector component and controlling its loading state via props

Bug Fixes:
- Prevent clearing of typed text in the query filter input during loading

Enhancements:
- Replace conditional Selector instances with a single always-mounted Selector using the is-loading prop