### PR TITLE
Cache filter labels for query-based selectors

### DIFF
--- a/src/shared/components/atoms/selector/Selector.vue
+++ b/src/shared/components/atoms/selector/Selector.vue
@@ -33,6 +33,7 @@ const emit = defineEmits<{
   (e: 'deselected', event): void;
   (e: 'searched', search, loading): void;
   (e: 'update:modelValue', event): void;
+  (e: 'label-selected', payload: { id: any; label: string }): void;
 }>();
 
 const { t } = useI18n();
@@ -165,6 +166,19 @@ const onModelValueUpdated = (value) => {
   }
 
   emit('update:modelValue', value);
+
+  const emitLabel = (v) => {
+    const label = getLabel(v);
+    if (label !== null) {
+      emit('label-selected', { id: v, label });
+    }
+  };
+
+  if (Array.isArray(value)) {
+    value.forEach(emitLabel);
+  } else {
+    emitLabel(value);
+  }
 };
 
 const handleKeydown = (event) => {


### PR DESCRIPTION
## Summary
- emit label-selected event from selector
- cache filter option labels for 24h
- show cached labels in filter chips

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8a3d918b4832e94c4e188a27f2968

## Summary by Sourcery

Cache filter labels for query-based selectors by emitting label selection events, storing labels in localStorage with a 24-hour expiry, and using cached labels in filter chips to ensure consistent display.

New Features:
- Emit 'label-selected' event from Selector component to capture selected filter labels
- Cache filter option labels in localStorage with 24-hour expiration and prune stale entries
- Display cached filter labels in filter chips when rendering applied filters