### PR TITLE
feat: add import detail view

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/components/AmazonImportsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/components/AmazonImportsListing.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 import { Link } from "../../../../../../../shared/components/atoms/link";
 import { Button } from "../../../../../../../shared/components/atoms/button";
 import { ApolloSubscription } from "../../../../../../../shared/components/molecules/apollo-subscription";
@@ -17,6 +18,7 @@ import {Icon} from "../../../../../../../shared/components/atoms/icon";
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const { t } = useI18n();
+const route = useRoute();
 
 const statusBadgeMap = getStatusBadgeMap(t);
 
@@ -80,7 +82,11 @@ const retryImport = async (importId: string) => {
             </thead>
             <tbody class="divide-y divide-gray-200 bg-white">
               <tr v-for="importItem in (result as SalesChannelSubscriptionResult).salesChannel.amazonImports" :key="importItem.id" class="border-b dark:border-[#191e3a]">
-                <td class="p-2">{{ formatDate(importItem.createdAt) }}</td>
+                <td class="p-2">
+                  <Link :path="{ name: 'integrations.imports.show', params: { type: route.params.type, id: importItem.id } }">
+                    {{ formatDate(importItem.createdAt) }}
+                  </Link>
+                </td>
                 <td class="p-2">{{ t(`integrations.imports.types.${importItem.type}`) }}</td>
                 <td class="p-2">
                   <Badge :color="statusBadgeMap[importItem.status]?.color" :text="statusBadgeMap[importItem.status]?.text" />

--- a/src/core/integrations/integrations/integrations-show/containers/imports/components/GeneralImportsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/components/GeneralImportsListing.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 import { Link } from "../../../../../../../shared/components/atoms/link";
 import { Button } from "../../../../../../../shared/components/atoms/button";
 import { ApolloSubscription } from "../../../../../../../shared/components/molecules/apollo-subscription";
@@ -15,6 +16,7 @@ import { getStatusBadgeMap, SalesChannelSubscriptionResult } from "../configs";
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const { t } = useI18n();
+const route = useRoute();
 
 const statusBadgeMap = getStatusBadgeMap(t);
 
@@ -77,7 +79,11 @@ const retryImport = async (importId: string) => {
             </thead>
             <tbody class="divide-y divide-gray-200 bg-white">
               <tr v-for="importItem in (result as SalesChannelSubscriptionResult).salesChannel.saleschannelimportSet" :key="importItem.id" class="border-b dark:border-[#191e3a]">
-                <td class="p-2">{{ formatDate(importItem.createdAt) }}</td>
+                <td class="p-2">
+                  <Link :path="{ name: 'integrations.imports.show', params: { type: route.params.type, id: importItem.id } }">
+                    {{ formatDate(importItem.createdAt) }}
+                  </Link>
+                </td>
                 <td class="p-2">
                   <Badge :color="statusBadgeMap[importItem.status]?.color" :text="statusBadgeMap[importItem.status]?.text" />
                 </td>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { useQuery } from '@vue/apollo-composable';
+import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
+import { Card } from "../../../../../../../../shared/components/atoms/card";
+import { Tabs } from "../../../../../../../../shared/components/molecules/tabs";
+import { DiscreteLoader } from "../../../../../../../../shared/components/atoms/discrete-loader";
+import { Badge } from "../../../../../../../../shared/components/atoms/badge";
+import { getSalesChannelImportQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
+import { getStatusBadgeMap } from "../../configs";
+import { IntegrationTypes } from "../../../../../integrations";
+
+const route = useRoute();
+const { t } = useI18n();
+const id = ref(String(route.params.id));
+const type = ref(String(route.params.type));
+
+const { result, loading } = useQuery(getSalesChannelImportQuery, { id: id.value });
+
+const statusBadgeMap = getStatusBadgeMap(t);
+
+const tabItems = ref([
+  { name: 'general', label: t('shared.tabs.general'), icon: 'circle-info', alwaysRender: true },
+]);
+
+if (type.value === IntegrationTypes.Amazon) {
+  tabItems.value.push({ name: 'issues', label: t('shared.labels.issues'), icon: 'triangle-exclamation', alwaysRender: true });
+}
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+};
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template #content>
+      <Card>
+        <Tabs :tabs="tabItems">
+          <template #general>
+            <div v-if="!loading && result?.salesChannelImport" class="p-4 space-y-2">
+              <div class="flex">
+                <span class="w-1/3 font-medium">{{ t('shared.labels.createdAt') }}</span>
+                <span>{{ formatDate(result.salesChannelImport.createdAt) }}</span>
+              </div>
+              <div class="flex">
+                <span class="w-1/3 font-medium">{{ t('shared.labels.status') }}</span>
+                <Badge :color="statusBadgeMap[result.salesChannelImport.status]?.color" :text="statusBadgeMap[result.salesChannelImport.status]?.text" />
+              </div>
+              <div class="flex">
+                <span class="w-1/3 font-medium">{{ t('shared.labels.progress') }}</span>
+                <span>{{ result.salesChannelImport.percentage }}%</span>
+              </div>
+              <div class="flex">
+                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.createOnly') }}</span>
+                <span>{{ result.salesChannelImport.createOnly ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
+              </div>
+              <div class="flex">
+                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.updateOnly') }}</span>
+                <span>{{ result.salesChannelImport.updateOnly ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
+              </div>
+              <div class="flex">
+                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.skipBrokenRecords') }}</span>
+                <span>{{ result.salesChannelImport.skipBrokenRecords ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
+              </div>
+              <div class="flex">
+                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.totalRecords') }}</span>
+                <span>{{ result.salesChannelImport.totalRecords }}</span>
+              </div>
+              <div class="flex">
+                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.processedRecords') }}</span>
+                <span>{{ result.salesChannelImport.processedRecords }}</span>
+              </div>
+              <div v-if="result.salesChannelImport.errorTraceback" class="flex">
+                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.errorTraceback') }}</span>
+                <span class="whitespace-pre-wrap">{{ result.salesChannelImport.errorTraceback }}</span>
+              </div>
+            </div>
+            <DiscreteLoader v-else :loading="true" />
+          </template>
+          <template #issues v-if="type === IntegrationTypes.Amazon">
+            <div class="p-4">{{ t('shared.labels.comingSoon') }}</div>
+          </template>
+        </Tabs>
+      </Card>
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/routes.ts
+++ b/src/core/integrations/routes.ts
@@ -72,6 +72,12 @@ export const routes = [
     meta: { title: 'integrations.imports.create.title' },
     component: () => import('./integrations/integrations-show/containers/imports/containers/create-import/ImportCreateController.vue'),
   },
+  {
+    path: '/integrations/:type/import-process/:id',
+    name: 'integrations.imports.show',
+    meta: { title: 'integrations.imports.show.title' },
+    component: () => import('./integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue'),
+  },
   // temporary commented since we no longer to oAuth
   // {
   //   path: '/integrations/shopify/installed',

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2829,6 +2829,17 @@
           }
         }
       }
+    },
+    "show": {
+      "title": "Import"
+    },
+    "labels": {
+      "createOnly": "Create only",
+      "updateOnly": "Update only",
+      "skipBrokenRecords": "Skip broken records",
+      "totalRecords": "Total records",
+      "processedRecords": "Processed records",
+      "errorTraceback": "Error traceback"
     }
   },
   "webhooks": {

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -663,6 +663,24 @@ export const salesChannelImportsQuery = gql`
   }
 `;
 
+export const getSalesChannelImportQuery = gql`
+  query getSalesChannelImport($id: GlobalID!) {
+    salesChannelImport(id: $id) {
+      id
+      status
+      percentage
+      createdAt
+      name
+      createOnly
+      updateOnly
+      skipBrokenRecords
+      totalRecords
+      processedRecords
+      errorTraceback
+    }
+  }
+`;
+
 
 export const magentoRemoteAttributesQuery = gql`
   query MagentoRemoteAttributes($salesChannelId: ID!) {


### PR DESCRIPTION
## Summary
- add query and route for viewing import details
- show import fields and placeholder issues tab
- link import listings to new detail view

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8bca8d578832e859a33c8524fdb8d