### PR TITLE
refactor: use apollo client for import query

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { useQuery } from '@vue/apollo-composable';
 import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Card } from "../../../../../../../../shared/components/atoms/card";
 import { Tabs } from "../../../../../../../../shared/components/molecules/tabs";
@@ -11,13 +10,31 @@ import { Badge } from "../../../../../../../../shared/components/atoms/badge";
 import { getSalesChannelImportQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
 import { getStatusBadgeMap } from "../../configs";
 import { IntegrationTypes } from "../../../../../integrations";
+import apolloClient from "../../../../../../../../../apollo-client";
 
 const route = useRoute();
 const { t } = useI18n();
 const id = ref(String(route.params.id));
 const type = ref(String(route.params.type));
 
-const { result, loading } = useQuery(getSalesChannelImportQuery, { id: id.value });
+const result = ref(null);
+const loading = ref(false);
+
+const fetchImport = async () => {
+  try {
+    loading.value = true;
+    const { data } = await apolloClient.query({
+      query: getSalesChannelImportQuery,
+      variables: { id: id.value },
+      fetchPolicy: 'network-only'
+    });
+    result.value = data;
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchImport);
 
 const statusBadgeMap = getStatusBadgeMap(t);
 


### PR DESCRIPTION
## Summary
- fetch import details with apolloClient.query instead of useQuery

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8c40dd6ec832e857111cec97ae42c

## Summary by Sourcery

Refactor ImportShowController to fetch import details with apolloClient.query in onMounted instead of using the useQuery hook.

Enhancements:
- Replace useQuery from @vue/apollo-composable with a manual apolloClient.query call
- Manage loading and result state using Vue refs and an onMounted fetchImport function
- Set fetchPolicy to network-only for the import query