### PR TITLE
feat: improve import details and list broken records

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/components/AmazonImportsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/components/AmazonImportsListing.vue
@@ -83,7 +83,7 @@ const retryImport = async (importId: string) => {
             <tbody class="divide-y divide-gray-200 bg-white">
               <tr v-for="importItem in (result as SalesChannelSubscriptionResult).salesChannel.amazonImports" :key="importItem.id" class="border-b dark:border-[#191e3a]">
                 <td class="p-2">
-                  <Link :path="{ name: 'integrations.imports.show', params: { type: route.params.type, id: importItem.proxyId } }">
+                  <Link :path="{ name: 'integrations.imports.show', params: { type: route.params.type, id: (importItem as any).proxyId } }">
                     {{ formatDate(importItem.createdAt) }}
                   </Link>
                 </td>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue
@@ -7,6 +7,8 @@ import { Card } from "../../../../../../../../shared/components/atoms/card";
 import { Tabs } from "../../../../../../../../shared/components/molecules/tabs";
 import { DiscreteLoader } from "../../../../../../../../shared/components/atoms/discrete-loader";
 import { Badge } from "../../../../../../../../shared/components/atoms/badge";
+import { Breadcrumbs } from "../../../../../../../../shared/components/molecules/breadcrumbs";
+import AmazonImportBrokenRecordsListing from "./components/AmazonImportBrokenRecordsListing.vue";
 import { getSalesChannelImportQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
 import { getStatusBadgeMap } from "../../configs";
 import { IntegrationTypes } from "../../../../../integrations";
@@ -16,8 +18,9 @@ const route = useRoute();
 const { t } = useI18n();
 const id = ref(String(route.params.id));
 const type = ref(String(route.params.type));
+const integrationId = ref('');
 
-const result = ref(null);
+const result = ref<any>(null);
 const loading = ref(false);
 
 const fetchImport = async () => {
@@ -29,6 +32,7 @@ const fetchImport = async () => {
       fetchPolicy: 'network-only'
     });
     result.value = data;
+    integrationId.value = data.salesChannelImport.salesChannel.integrationPtr.id;
   } finally {
     loading.value = false;
   }
@@ -61,52 +65,63 @@ const formatDate = (dateString: string) => {
 
 <template>
   <GeneralTemplate>
+    <template #breadcrumbs>
+      <Breadcrumbs
+        :links="[
+          { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
+          { path: { name: 'integrations.integrations.show', params: { id: integrationId, type: type }, query: { tab: 'imports' } }, name: t('integrations.show.title') },
+          { name: t('integrations.imports.show.title') }
+        ]"
+      />
+    </template>
     <template #content>
       <Card>
         <Tabs :tabs="tabItems">
           <template #general>
-            <div v-if="!loading && result?.salesChannelImport" class="p-4 space-y-2">
-              <div class="flex">
-                <span class="w-1/3 font-medium">{{ t('shared.labels.createdAt') }}</span>
-                <span>{{ formatDate(result.salesChannelImport.createdAt) }}</span>
-              </div>
-              <div class="flex">
-                <span class="w-1/3 font-medium">{{ t('shared.labels.status') }}</span>
-                <Badge :color="statusBadgeMap[result.salesChannelImport.status]?.color" :text="statusBadgeMap[result.salesChannelImport.status]?.text" />
-              </div>
-              <div class="flex">
-                <span class="w-1/3 font-medium">{{ t('shared.labels.progress') }}</span>
-                <span>{{ result.salesChannelImport.percentage }}%</span>
-              </div>
-              <div class="flex">
-                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.createOnly') }}</span>
-                <span>{{ result.salesChannelImport.createOnly ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
-              </div>
-              <div class="flex">
-                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.updateOnly') }}</span>
-                <span>{{ result.salesChannelImport.updateOnly ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
-              </div>
-              <div class="flex">
-                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.skipBrokenRecords') }}</span>
-                <span>{{ result.salesChannelImport.skipBrokenRecords ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
-              </div>
-              <div class="flex">
-                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.totalRecords') }}</span>
-                <span>{{ result.salesChannelImport.totalRecords }}</span>
-              </div>
-              <div class="flex">
-                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.processedRecords') }}</span>
-                <span>{{ result.salesChannelImport.processedRecords }}</span>
-              </div>
-              <div v-if="result.salesChannelImport.errorTraceback" class="flex">
-                <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.errorTraceback') }}</span>
-                <span class="whitespace-pre-wrap">{{ result.salesChannelImport.errorTraceback }}</span>
+            <div v-if="!loading && result?.salesChannelImport" class="p-4">
+              <div class="divide-y divide-gray-200">
+                <div class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('shared.labels.createdAt') }}</span>
+                  <span>{{ formatDate(result.salesChannelImport.createdAt) }}</span>
+                </div>
+                <div class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('shared.labels.status') }}</span>
+                  <Badge :color="statusBadgeMap[result.salesChannelImport.status]?.color" :text="statusBadgeMap[result.salesChannelImport.status]?.text" />
+                </div>
+                <div class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('shared.labels.progress') }}</span>
+                  <span>{{ result.salesChannelImport.percentage }}%</span>
+                </div>
+                <div class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.createOnly') }}</span>
+                  <span>{{ result.salesChannelImport.createOnly ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
+                </div>
+                <div class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.updateOnly') }}</span>
+                  <span>{{ result.salesChannelImport.updateOnly ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
+                </div>
+                <div class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.skipBrokenRecords') }}</span>
+                  <span>{{ result.salesChannelImport.skipBrokenRecords ? t('shared.labels.yes') : t('shared.labels.no') }}</span>
+                </div>
+                <div class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.totalRecords') }}</span>
+                  <span>{{ result.salesChannelImport.totalRecords }}</span>
+                </div>
+                <div class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.processedRecords') }}</span>
+                  <span>{{ result.salesChannelImport.processedRecords }}</span>
+                </div>
+                <div v-if="result.salesChannelImport.errorTraceback" class="flex items-center py-2">
+                  <span class="w-1/3 font-medium">{{ t('integrations.imports.labels.errorTraceback') }}</span>
+                  <span class="whitespace-pre-wrap">{{ result.salesChannelImport.errorTraceback }}</span>
+                </div>
               </div>
             </div>
             <DiscreteLoader v-else :loading="true" />
           </template>
           <template #issues v-if="type === IntegrationTypes.Amazon">
-            <div class="p-4">{{ t('shared.labels.comingSoon') }}</div>
+            <AmazonImportBrokenRecordsListing :import-id="id" />
           </template>
         </Tabs>
       </Card>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/AmazonImportBrokenRecordsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/AmazonImportBrokenRecordsListing.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Selector } from '../../../../../../../../../shared/components/atoms/selector';
+import { Badge } from '../../../../../../../../../shared/components/atoms/badge';
+import { Button } from '../../../../../../../../../shared/components/atoms/button';
+import { Card } from '../../../../../../../../../shared/components/atoms/card';
+import { DiscreteLoader } from '../../../../../../../../../shared/components/atoms/discrete-loader';
+import { Pagination } from '../../../../../../../../../shared/components/molecules/pagination';
+import { Tabs } from '../../../../../../../../../shared/components/molecules/tabs';
+import { Modal } from '../../../../../../../../../shared/components/atoms/modal';
+import apolloClient from '../../../../../../../../../../apollo-client';
+import { amazonImportBrokenRecordsQuery } from '../../../../../../../../../shared/api/queries/salesChannels.js';
+
+const props = defineProps<{ importId: string }>();
+const { t } = useI18n();
+
+const codeFilter = ref<string | undefined>();
+const records = ref<any[]>([]);
+const pageInfo = ref({ endCursor: '', startCursor: '', hasNextPage: false, hasPreviousPage: false });
+const loading = ref(false);
+const showModal = ref(false);
+const modalRecord = ref<any | null>(null);
+
+const codeOptions = [
+  { id: 'BROKEN_IMPORT_PROCESS', name: t('integrations.imports.brokenRecords.codes.BROKEN_IMPORT_PROCESS') },
+  { id: 'MISSING_DATA', name: t('integrations.imports.brokenRecords.codes.MISSING_DATA') },
+  { id: 'NO_MAPPED_PRODUCT_TYPE', name: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE') },
+  { id: 'PRODUCT_TYPE_MISMATCH', name: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH') },
+  { id: 'UPDATE_ONLY_NOT_FOUND', name: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND') },
+];
+
+const badgeMap = {
+  BROKEN_IMPORT_PROCESS: { color: 'red', text: t('integrations.imports.brokenRecords.codes.BROKEN_IMPORT_PROCESS') },
+  MISSING_DATA: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.MISSING_DATA') },
+  NO_MAPPED_PRODUCT_TYPE: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE') },
+  PRODUCT_TYPE_MISMATCH: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH') },
+  UPDATE_ONLY_NOT_FOUND: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND') },
+};
+
+const limit = 10;
+
+const fetchRecords = async (pagination: any = {}) => {
+  loading.value = true;
+  const variables: any = {
+    first: pagination.before ? undefined : limit,
+    last: pagination.before ? limit : undefined,
+    after: pagination.after || undefined,
+    before: pagination.before || undefined,
+    filter: {
+      importProcess: props.importId,
+      excludeUnknownIssues: true,
+      ...(codeFilter.value ? { code: codeFilter.value } : {}),
+    },
+  };
+  const { data } = await apolloClient.query({
+    query: amazonImportBrokenRecordsQuery,
+    variables,
+    fetchPolicy: 'network-only',
+  });
+  records.value = data.amazonImportBrokenRecords.edges.map((e: any) => e.node);
+  pageInfo.value = data.amazonImportBrokenRecords.pageInfo;
+  loading.value = false;
+};
+
+watch(codeFilter, () => fetchRecords());
+
+onMounted(() => fetchRecords());
+
+const openModal = (record: any) => {
+  modalRecord.value = record;
+  showModal.value = true;
+};
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+};
+
+const onPageChange = ({ query }) => {
+  fetchRecords(query);
+};
+</script>
+
+<template>
+  <div>
+    <div class="mb-4 w-72">
+      <Selector
+        v-model="codeFilter"
+        :options="codeOptions"
+        :label="t('shared.labels.code')"
+        :clearable="true"
+      />
+    </div>
+    <div v-if="!loading">
+      <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+        <thead>
+          <tr>
+            <th class="p-2 text-left">{{ t('shared.labels.createdAt') }}</th>
+            <th class="p-2 text-left">{{ t('shared.labels.code') }}</th>
+            <th class="p-2 text-left">{{ t('shared.labels.message') }}</th>
+            <th class="p-2 text-left">{{ t('shared.labels.actions') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <tr v-for="record in records" :key="record.id" class="border-b">
+            <td class="p-2">{{ formatDate(record.createdAt) }}</td>
+            <td class="p-2">
+              <Badge :color="badgeMap[record.record.code]?.color" :text="badgeMap[record.record.code]?.text || record.record.code" />
+            </td>
+            <td class="p-2">{{ record.record.message }}</td>
+            <td class="p-2">
+              <Button type="button" class="btn btn-primary" @click="openModal(record)">
+                {{ t('shared.button.details') }}
+              </Button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="mt-4">
+        <Pagination :page-info="pageInfo" :change-query-params="false" @query-changed="onPageChange" />
+      </div>
+    </div>
+    <DiscreteLoader v-else :loading="true" />
+
+    <Modal v-model="showModal" @closed="showModal = false">
+      <Card>
+        <Tabs :tabs="[
+          { name: 'data', label: t('shared.labels.data'), alwaysRender: true },
+          { name: 'context', label: t('shared.labels.context'), alwaysRender: true },
+          ...(modalRecord?.record.error ? [{ name: 'error', label: t('shared.labels.error'), alwaysRender: true }] : []),
+        ]">
+          <template #data>
+            <pre class="p-4 whitespace-pre-wrap">{{ JSON.stringify(modalRecord?.record.data, null, 2) }}</pre>
+          </template>
+          <template #context>
+            <pre class="p-4 whitespace-pre-wrap">{{ JSON.stringify(modalRecord?.record.context, null, 2) }}</pre>
+          </template>
+          <template v-if="modalRecord?.record.error" #error>
+            <pre class="p-4 whitespace-pre-wrap">{{ modalRecord?.record.error }}</pre>
+          </template>
+        </Tabs>
+      </Card>
+    </Modal>
+  </div>
+</template>

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -24,6 +24,8 @@
       "manual": "Manuell",
       "generate": "Generieren",
       "code": "Code",
+      "data": "Daten",
+      "context": "Kontext",
       "noIssues": "Keine Probleme",
       "active": "Active",
       "inactive": "Inactive"
@@ -138,6 +140,17 @@
     "show": {
       "tabs": {
         "reports": "Berichte"
+      }
+    },
+    "imports": {
+      "brokenRecords": {
+        "codes": {
+          "BROKEN_IMPORT_PROCESS": "Broken import process",
+          "MISSING_DATA": "Missing data",
+          "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
+          "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+        }
       }
     }
   },

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -416,6 +416,9 @@
       "remoteCode": "Remote Code",
       "pending": "Pending Processing",
       "progress": "Progress",
+      "code": "Code",
+      "data": "Data",
+      "context": "Context",
       "new": "New",
       "beta": "BETA",
       "url": "URL",
@@ -2793,6 +2796,15 @@
         "schemaDescription": "Initial setup required to enable product imports.",
         "productsDescription": "Imports actual product data from Amazon.",
         "schemaRequired": "Please complete the schema import first."
+      },
+      "brokenRecords": {
+        "codes": {
+          "BROKEN_IMPORT_PROCESS": "Broken import process",
+          "MISSING_DATA": "Missing data",
+          "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
+          "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+        }
       },
       "create": {
         "success": "Create import process success",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -24,6 +24,8 @@
       "manual": "Manuel",
       "generate": "Générer",
       "code": "Code",
+      "data": "Données",
+      "context": "Contexte",
       "noIssues": "Aucun problème",
       "active": "Active",
       "inactive": "Inactive"
@@ -138,6 +140,17 @@
     "show": {
       "tabs": {
         "reports": "Rapports"
+      }
+    },
+    "imports": {
+      "brokenRecords": {
+        "codes": {
+          "BROKEN_IMPORT_PROCESS": "Broken import process",
+          "MISSING_DATA": "Missing data",
+          "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
+          "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+        }
       }
     }
   },

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -208,6 +208,9 @@
       "notes": "Notities",
       "currency": "Valuta's",
       "date": "Datum",
+      "code": "Code",
+      "data": "Data",
+      "context": "Context",
       "firstName": "Voornaam",
       "lastName": "Achternaam",
       "email": "E-mail",
@@ -1932,6 +1935,17 @@
       },
       "tabs": {
         "reports": "Rapporten"
+      }
+    },
+    "imports": {
+      "brokenRecords": {
+        "codes": {
+          "BROKEN_IMPORT_PROCESS": "Broken import process",
+          "MISSING_DATA": "Missing data",
+          "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
+          "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+        }
       }
     }
   }

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -677,6 +677,45 @@ export const getSalesChannelImportQuery = gql`
       totalRecords
       processedRecords
       errorTraceback
+      salesChannel {
+        integrationPtr {
+          id
+        }
+      }
+    }
+  }
+`;
+
+export const amazonImportBrokenRecordsQuery = gql`
+  query AmazonImportBrokenRecords(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $filter: AmazonImportBrokenRecordFilter
+  ) {
+    amazonImportBrokenRecords(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      filters: $filter
+    ) {
+      edges {
+        node {
+          id
+          createdAt
+          record
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- add breadcrumbs and better spacing to import show page
- list Amazon broken records with filter, pagination, and details modal
- expose broken record query and translations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8cb091bc4832e94320339cb4d212b

## Summary by Sourcery

Improve the import details view by adding breadcrumbs, refining layout, exposing the integration ID in the import query, and introducing a new component to list and inspect Amazon broken records with filtering, pagination, and a detail modal

New Features:
- List Amazon broken records with filtering, pagination, and a detail modal

Enhancements:
- Add breadcrumbs navigation and improved spacing to the import details page
- Expose integration ID in the sales channel import GraphQL query

Documentation:
- Add locale translations for Amazon broken record codes