### PR TITLE
refactor: use general listing for amazon broken records

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/AmazonImportBrokenRecordsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/AmazonImportBrokenRecordsListing.vue
@@ -1,142 +1,54 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { Selector } from '../../../../../../../../../shared/components/atoms/selector';
-import { Badge } from '../../../../../../../../../shared/components/atoms/badge';
+import { GeneralListing } from '../../../../../../../../../shared/components/organisms/general-listing';
 import { Button } from '../../../../../../../../../shared/components/atoms/button';
-import { Card } from '../../../../../../../../../shared/components/atoms/card';
-import { DiscreteLoader } from '../../../../../../../../../shared/components/atoms/discrete-loader';
-import { Pagination } from '../../../../../../../../../shared/components/molecules/pagination';
-import { Tabs } from '../../../../../../../../../shared/components/molecules/tabs';
+import { Icon } from '../../../../../../../../../shared/components/atoms/icon';
 import { Modal } from '../../../../../../../../../shared/components/atoms/modal';
-import apolloClient from '../../../../../../../../../../apollo-client';
-import { amazonImportBrokenRecordsQuery } from '../../../../../../../../../shared/api/queries/salesChannels.js';
+import { Card } from '../../../../../../../../../shared/components/atoms/card';
+import { Tabs } from '../../../../../../../../../shared/components/molecules/tabs';
+import { searchConfigConstructor, listingConfigConstructor, listingQuery, listingQueryKey } from './configs';
 
 const props = defineProps<{ importId: string }>();
 const { t } = useI18n();
 
-const codeFilter = ref<string | undefined>();
-const records = ref<any[]>([]);
-const pageInfo = ref({ endCursor: '', startCursor: '', hasNextPage: false, hasPreviousPage: false });
-const loading = ref(false);
+const searchConfig = searchConfigConstructor(t);
+const listingConfig = listingConfigConstructor(t);
+
 const showModal = ref(false);
 const modalRecord = ref<any | null>(null);
-
-const codeOptions = [
-  { id: 'BROKEN_IMPORT_PROCESS', name: t('integrations.imports.brokenRecords.codes.BROKEN_IMPORT_PROCESS') },
-  { id: 'MISSING_DATA', name: t('integrations.imports.brokenRecords.codes.MISSING_DATA') },
-  { id: 'NO_MAPPED_PRODUCT_TYPE', name: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE') },
-  { id: 'PRODUCT_TYPE_MISMATCH', name: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH') },
-  { id: 'UPDATE_ONLY_NOT_FOUND', name: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND') },
-];
-
-const badgeMap = {
-  BROKEN_IMPORT_PROCESS: { color: 'red', text: t('integrations.imports.brokenRecords.codes.BROKEN_IMPORT_PROCESS') },
-  MISSING_DATA: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.MISSING_DATA') },
-  NO_MAPPED_PRODUCT_TYPE: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE') },
-  PRODUCT_TYPE_MISMATCH: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH') },
-  UPDATE_ONLY_NOT_FOUND: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND') },
-};
-
-const limit = 10;
-
-const fetchRecords = async (pagination: any = {}) => {
-  loading.value = true;
-  const variables: any = {
-    first: pagination.before ? undefined : limit,
-    last: pagination.before ? limit : undefined,
-    after: pagination.after || undefined,
-    before: pagination.before || undefined,
-    filter: {
-      importProcess: props.importId,
-      excludeUnknownIssues: true,
-      ...(codeFilter.value ? { code: codeFilter.value } : {}),
-    },
-  };
-  const { data } = await apolloClient.query({
-    query: amazonImportBrokenRecordsQuery,
-    variables,
-    fetchPolicy: 'network-only',
-  });
-  records.value = data.amazonImportBrokenRecords.edges.map((e: any) => e.node);
-  pageInfo.value = data.amazonImportBrokenRecords.pageInfo;
-  loading.value = false;
-};
-
-watch(codeFilter, () => fetchRecords());
-
-onMounted(() => fetchRecords());
 
 const openModal = (record: any) => {
   modalRecord.value = record;
   showModal.value = true;
 };
-
-const formatDate = (dateString: string) => {
-  const date = new Date(dateString);
-  return new Intl.DateTimeFormat('en-GB', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).format(date);
-};
-
-const onPageChange = ({ query }) => {
-  fetchRecords(query);
-};
 </script>
 
 <template>
   <div>
-    <div class="mb-4 w-72">
-      <Selector
-        v-model="codeFilter"
-        :options="codeOptions"
-        :label="t('shared.labels.code')"
-        :clearable="true"
-      />
-    </div>
-    <div v-if="!loading">
-      <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
-        <thead>
-          <tr>
-            <th class="p-2 text-left">{{ t('shared.labels.createdAt') }}</th>
-            <th class="p-2 text-left">{{ t('shared.labels.code') }}</th>
-            <th class="p-2 text-left">{{ t('shared.labels.message') }}</th>
-            <th class="p-2 text-left">{{ t('shared.labels.actions') }}</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-gray-200 bg-white">
-          <tr v-for="record in records" :key="record.id" class="border-b">
-            <td class="p-2">{{ formatDate(record.createdAt) }}</td>
-            <td class="p-2">
-              <Badge :color="badgeMap[record.record.code]?.color" :text="badgeMap[record.record.code]?.text || record.record.code" />
-            </td>
-            <td class="p-2">{{ record.record.message }}</td>
-            <td class="p-2">
-              <Button type="button" class="btn btn-primary" @click="openModal(record)">
-                {{ t('shared.button.details') }}
-              </Button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <div class="mt-4">
-        <Pagination :page-info="pageInfo" :change-query-params="false" @query-changed="onPageChange" />
-      </div>
-    </div>
-    <DiscreteLoader v-else :loading="true" />
+    <GeneralListing
+      :search-config="searchConfig"
+      :config="listingConfig"
+      :query="listingQuery"
+      :query-key="listingQueryKey"
+      :fixed-filter-variables="{ importProcess: { id: { exact: importId } }, excludeUnknownIssues: true }"
+    >
+      <template #additionalButtons="{ item }">
+        <Button type="button" @click="openModal(item.node)">
+          <Icon name="eye" size="lg" class="text-gray-500" />
+        </Button>
+      </template>
+    </GeneralListing>
 
     <Modal v-model="showModal" @closed="showModal = false">
       <Card>
-        <Tabs :tabs="[
-          { name: 'data', label: t('shared.labels.data'), alwaysRender: true },
-          { name: 'context', label: t('shared.labels.context'), alwaysRender: true },
-          ...(modalRecord?.record.error ? [{ name: 'error', label: t('shared.labels.error'), alwaysRender: true }] : []),
-        ]">
+        <Tabs
+          :tabs="[
+            { name: 'data', label: t('shared.labels.data'), alwaysRender: true },
+            { name: 'context', label: t('shared.labels.context'), alwaysRender: true },
+            ...(modalRecord?.record.error ? [{ name: 'error', label: t('shared.labels.error'), alwaysRender: true }] : []),
+          ]"
+        >
           <template #data>
             <pre class="p-4 whitespace-pre-wrap">{{ JSON.stringify(modalRecord?.record.data, null, 2) }}</pre>
           </template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/configs.ts
@@ -1,0 +1,55 @@
+import { FieldType } from "../../../../../../../../../shared/utils/constants";
+import { amazonImportBrokenRecordsQuery } from "../../../../../../../../../shared/api/queries/salesChannels.js";
+import { ListingConfig } from "../../../../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { SearchConfig } from "../../../../../../../../../shared/components/organisms/general-search/searchConfig";
+
+const getCodeBadgeMap = (t: Function) => ({
+  BROKEN_IMPORT_PROCESS: { color: 'red', text: t('integrations.imports.brokenRecords.codes.BROKEN_IMPORT_PROCESS') },
+  MISSING_DATA: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.MISSING_DATA') },
+  NO_MAPPED_PRODUCT_TYPE: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE') },
+  PRODUCT_TYPE_MISMATCH: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH') },
+  UPDATE_ONLY_NOT_FOUND: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND') },
+});
+
+export const searchConfigConstructor = (t: Function): SearchConfig => ({
+  search: false,
+  filters: [
+    {
+      type: FieldType.Choice,
+      name: 'code',
+      label: t('shared.labels.code'),
+      options: [
+        { label: t('integrations.imports.brokenRecords.codes.BROKEN_IMPORT_PROCESS'), value: 'BROKEN_IMPORT_PROCESS' },
+        { label: t('integrations.imports.brokenRecords.codes.MISSING_DATA'), value: 'MISSING_DATA' },
+        { label: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE'), value: 'NO_MAPPED_PRODUCT_TYPE' },
+        { label: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH'), value: 'PRODUCT_TYPE_MISMATCH' },
+        { label: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND'), value: 'UPDATE_ONLY_NOT_FOUND' },
+      ],
+      labelBy: 'label',
+      valueBy: 'value',
+    },
+  ],
+  orders: [],
+});
+
+export const listingConfigConstructor = (t: Function): ListingConfig => ({
+  headers: [
+    t('shared.labels.createdAt'),
+    t('shared.labels.code'),
+    t('shared.labels.message'),
+  ],
+  fields: [
+    { name: 'createdAt', type: FieldType.Date },
+    { name: 'record.code', type: FieldType.Badge, badgeMap: getCodeBadgeMap(t), accessor: (node) => node.record.code },
+    { name: 'record.message', type: FieldType.Text, accessor: (node) => node.record.message },
+  ],
+  identifierKey: 'id',
+  addActions: true,
+  addEdit: false,
+  addShow: false,
+  addDelete: false,
+  addPagination: true,
+});
+
+export const listingQuery = amazonImportBrokenRecordsQuery;
+export const listingQueryKey = 'amazonImportBrokenRecords';


### PR DESCRIPTION
## Summary
- refactor AmazonImportBrokenRecordsListing to use GeneralListing and modal
- add config with code filter and query for Amazon import broken records

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b8d1427ca8832e945ac04fc9fe7802

## Summary by Sourcery

Refactor the AmazonImportBrokenRecordsListing component to use the shared GeneralListing abstraction with search and listing configs, and externalize listing/search configuration into a separate configs file.

Enhancements:
- Replace manual data fetching, filtering, pagination, and table UI with the GeneralListing component
- Move search and listing configuration logic into a dedicated configs.ts file
- Simplify modal actions to integrate with the new GeneralListing item actions