### PR TITLE
Add webhook integration badge

### DIFF
--- a/src/core/integrations/integrations/configs.ts
+++ b/src/core/integrations/integrations/configs.ts
@@ -28,10 +28,11 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
 });
 
 export const listingIntegrationTypeBadgeMap = (t: Function) => ({
-  [IntegrationTypes.Magento]: { text: 'Magento', color: 'red' },
-  [IntegrationTypes.Shopify]: { text: 'Shopify', color: 'green' },
-  [IntegrationTypes.Woocommerce]: { text: 'Woocommerce', color: 'blue' },
-  [IntegrationTypes.Amazon]: { text: 'Amazon', color: 'yellow' }
+  [IntegrationTypes.Magento]: { text: t('integrations.integrationTypes.magento'), color: 'red' },
+  [IntegrationTypes.Shopify]: { text: t('integrations.integrationTypes.shopify'), color: 'green' },
+  [IntegrationTypes.Woocommerce]: { text: t('integrations.integrationTypes.woocommerce'), color: 'blue' },
+  [IntegrationTypes.Amazon]: { text: t('integrations.integrationTypes.amazon'), color: 'yellow' },
+  [IntegrationTypes.Webhook]: { text: t('integrations.integrationTypes.webhook'), color: 'indigo' }
 });
 
 export const listingConfigConstructor = (t: Function): ListingConfig => ({

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -137,6 +137,13 @@
     }
   },
   "integrations": {
+    "integrationTypes": {
+      "magento": "Magento",
+      "shopify": "Shopify",
+      "woocommerce": "Woocommerce",
+      "amazon": "Amazon",
+      "webhook": "Webhook"
+    },
     "show": {
       "tabs": {
         "reports": "Berichte"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2310,6 +2310,13 @@
   },
   "integrations": {
     "title": "Integrations",
+    "integrationTypes": {
+      "magento": "Magento",
+      "shopify": "Shopify",
+      "woocommerce": "Woocommerce",
+      "amazon": "Amazon",
+      "webhook": "Webhook"
+    },
     "show": {
       "title": "Integration",
       "tabs": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -137,6 +137,13 @@
     }
   },
   "integrations": {
+    "integrationTypes": {
+      "magento": "Magento",
+      "shopify": "Shopify",
+      "woocommerce": "Woocommerce",
+      "amazon": "Amazon",
+      "webhook": "Webhook"
+    },
     "show": {
       "tabs": {
         "reports": "Rapports"

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1951,6 +1951,13 @@
   }
 ,
   "integrations": {
+    "integrationTypes": {
+      "magento": "Magento",
+      "shopify": "Shopify",
+      "woocommerce": "Woocommerce",
+      "amazon": "Amazon",
+      "webhook": "Webhook"
+    },
     "salesChannel": {
       "labels": {
         "assignedToSalesChannelView": "Toegewezen aan winkel",


### PR DESCRIPTION
## Summary
- show Webhook integration with a colored badge in integration listings
- translate integration type labels across locales

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8d4d12f00832ebd19eff63b082125