### PR TITLE
refactor: optimize apollo fetch policies

### DIFF
--- a/src/core/auth/register/containers/register-company-form/RegisterCompanyForm.vue
+++ b/src/core/auth/register/containers/register-company-form/RegisterCompanyForm.vue
@@ -73,7 +73,7 @@ useEnterKeyboardListener(onSubmit);
     <div class="mb-2">
       <Label class="font-semibold text-md">{{ t('auth.register.company.labels.country') }}</Label>
       <div class="mt-2">
-        <ApolloQuery :query="countriesQuery">
+        <ApolloQuery :query="countriesQuery" fetch-policy="cache-and-network">
           <template v-slot="{ result: { data } }">
               <Selector v-if="data" v-model="form.country" :options="data.countries" labelBy="name" valueBy="code" :placeholder="t('auth.register.company.placeholders.selector.country')" filterable />
           </template>
@@ -84,7 +84,7 @@ useEnterKeyboardListener(onSubmit);
     <div>
     <Label class="font-semibold text-md">{{ t('auth.register.company.labels.language') }}</Label>
     <div class="mt-1">
-      <ApolloQuery :query="languagesQuery">
+      <ApolloQuery :query="languagesQuery" fetch-policy="cache-and-network">
         <template v-slot="{ result: { data } }">
             <Selector v-if="data" v-model="form.language" :options="data.languages" labelBy="name" valueBy="code" :placeholder="t('auth.register.company.placeholders.selector.language')" filterable />
             <div class="mt-1 text-sm leading-6 text-gray-400">

--- a/src/core/integrations/integrations/integrations-shopify-entry/ShopifyEntryController.vue
+++ b/src/core/integrations/integrations/integrations-shopify-entry/ShopifyEntryController.vue
@@ -37,7 +37,7 @@ const createShopifySalesChannel = async (queryParams: Record<string, any>, hostn
       },
       first: 1,
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
 
   const existing = data?.shopifyChannels?.edges?.[0]?.node;
@@ -110,7 +110,7 @@ const getFakeUserCredentials = async (identifier?: string) => {
   const {data} = await apolloClient.query({
     query: generateUserCredentialsQuery,
     variables: {identifier},
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
 
   if (!data?.generateUserCredentials) {

--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -140,7 +140,7 @@ const fetchIntegrationData = async () => {
     const { data } = await apolloClient.query({
       query: getIntegrationQuery(),
       variables: { id: id.value },
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
     const rawData = data[getIntegrationQueryKey()];
 

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/AmazonDefaultUnitConfigurators.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/AmazonDefaultUnitConfigurators.vue
@@ -26,7 +26,7 @@ const fetchFirstUnmapped = async () => {
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const edges = data?.amazonDefaultUnitConfigurators?.edges || [];
   canStartMapping.value = edges.length > 0;

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/containers/IntegrationsAmazonDefaultUnitConfiguratorEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/containers/IntegrationsAmazonDefaultUnitConfiguratorEditController.vue
@@ -84,7 +84,7 @@ onMounted(async () => {
   const { data } = await apolloClient.query({
     query: getAmazonDefaultUnitConfiguratorQuery,
     variables: { id: configuratorId.value },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
 
   const cfg = data?.amazonDefaultUnitConfigurator;
@@ -136,7 +136,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
 
   const edges = data?.amazonDefaultUnitConfigurators?.edges || [];

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/general/languages-and-currencies/LanguagesAndCurrenciesStep.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/general/languages-and-currencies/LanguagesAndCurrenciesStep.vue
@@ -65,12 +65,12 @@ const fetchData = async () => {
       apolloClient.query({
         query: remoteLanguagesQuery,
         variables: { filter: { salesChannel: { id: { exact: props.salesChannelId } } } },
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-first',
       }),
       apolloClient.query({
         query: remoteCurrenciesQuery,
         variables: { filter: { salesChannel: { id: { exact: props.salesChannelId } } } },
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-first',
       }),
     ]);
 

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/magento/magento-importer/MagentoImporter.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/magento/magento-importer/MagentoImporter.vue
@@ -104,7 +104,7 @@ const fetchIntegrationData = async () => {
     const { data } = await apolloClient.query({
       query: getMagentoChannelQuery,
       variables: { id: props.integrationId },
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
     const { __typename, integrationPtr, saleschannelPtr,  ...cleanData } = data['magentoChannel'];
     integrationData.value = cleanData;
@@ -125,7 +125,7 @@ const fetchAttributesData = async () => {
     const { data } = await apolloClient.query({
       query: magentoRemoteAttributesQuery,
       variables: { salesChannelId: props.integrationId },
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
     });
     attributes.value = data.magentoRemoteAttributes;
   } catch (err) {
@@ -138,7 +138,7 @@ const fetchAttributeSetsData = async () => {
     const { data } = await apolloClient.query({
       query: magentoRemoteAttributeSetsQuery,
       variables: { salesChannelId: props.integrationId },
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
     });
     attributeSets.value = data.magentoRemoteAttributeSets;
   } catch (err) {

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/shopify/shopify-importer/ShopifyImporter.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/shopify/shopify-importer/ShopifyImporter.vue
@@ -69,7 +69,7 @@ const fetchIntegrationData = async () => {
     const { data } = await apolloClient.query({
       query: getShopifyChannelQuery,
       variables: { id: props.integrationId },
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
     const { __typename, integrationPtr, saleschannelPtr,  ...cleanData } = data['shopifyChannel'];
 

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/woocommerce/woocommerce-importer/WoocommerceImporter.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/woocommerce/woocommerce-importer/WoocommerceImporter.vue
@@ -69,7 +69,7 @@ const fetchIntegrationData = async () => {
     const { data } = await apolloClient.query({
       query: getWoocommerceChannelQuery,
       variables: { id: props.integrationId },
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
     const { __typename, integrationPtr, saleschannelPtr,  ...cleanData } = data['woocommerceChannel'];
 

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/ImportShowController.vue
@@ -29,7 +29,7 @@ const fetchImport = async () => {
     const { data } = await apolloClient.query({
       query: getSalesChannelImportQuery,
       variables: { id: id.value },
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
     result.value = data;
     integrationId.value = data.salesChannelImport.salesChannel.id;

--- a/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
@@ -318,7 +318,7 @@ onMounted(async () => {
   const { data } = await apolloClient.query({
     query: getWebhookIntegrationQuery,
     variables: { id: props.integrationId },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   rpm.value = data?.webhookIntegration?.requestsPerMinute || null;
   integration.value = data?.webhookIntegration || null;

--- a/src/core/integrations/integrations/integrations-show/containers/monitor/useLiveMonitor.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/useLiveMonitor.ts
@@ -64,7 +64,7 @@ export function useLiveMonitor(options: Options = {}) {
       }
       const { data } = await apolloClient.query({
         query: webhookDeliveriesQuery,
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-first',
         variables: {
           filter,
           ...pagination,
@@ -106,7 +106,7 @@ export function useLiveMonitor(options: Options = {}) {
       }
       const { data } = await apolloClient.query({
         query: webhookDeliveryStatsQuery,
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-first',
         variables: { filter },
       });
       stats.value = data?.webhookDeliveryStats || null;

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/AmazonProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/AmazonProperties.vue
@@ -25,7 +25,7 @@ const fetchFirstUnmapped = async () => {
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const edges = data?.amazonProperties?.edges || [];
   canStartMapping.value = edges.length > 0;

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -46,7 +46,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
 
   const edges = data?.amazonProperties?.edges || [];

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
@@ -28,7 +28,7 @@ const fetchFirstUnmapped = async () => {
       },
       order: { marketplace: { isDefault: 'DESC' } },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const edges = data?.amazonPropertySelectValues?.edges || [];
   canStartMapping.value = edges.length > 0;

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -162,7 +162,7 @@ onMounted(async () => {
   const { data } = await apolloClient.query({
     query: getAmazonPropertySelectValueQuery,
     variables: { id: valueId.value },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   const valueData = data?.amazonPropertySelectValue;
@@ -185,7 +185,7 @@ onMounted(async () => {
     const { data: propData } = await apolloClient.query({
       query: getAmazonPropertyQuery,
       variables: { id: amazonPropertyId.value },
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
     propertyMapped.value = propData?.amazonProperty?.mappedLocally ?? true;
     localPropertyId.value = propData?.amazonProperty?.localInstance?.id || null;
@@ -254,7 +254,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
       },
       order: { marketplace: { isDefault: 'DESC' } },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
 
 

--- a/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
@@ -77,13 +77,13 @@ const fetchStats = async () => {
     const variables = { filter };
     const { data } = await apolloClient.query({
       query: webhookReportsKpiQuery,
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
       variables,
     });
     stats.value = data?.webhookReportsKpi || null;
     const { data: seriesResp } = await apolloClient.query({
       query: webhookReportsSeriesQuery,
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
       variables,
     });
     seriesData.value = seriesResp?.webhookReportsSeries || null;

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/AmazonProductTypes.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/AmazonProductTypes.vue
@@ -29,7 +29,7 @@ const fetchFirstUnmapped = async () => {
         mappedLocally:  false ,
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const edges = data?.amazonProductTypes?.edges || [];
   canStartMapping.value = edges.length > 0;

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/ImportedAmazonProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/ImportedAmazonProductType.vue
@@ -139,7 +139,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const edges = data?.amazonProductTypes?.edges || [];
   let nextId: string | null = null;

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/IntegrationsAmazonProductTypeEditController.vue
@@ -15,7 +15,7 @@ onMounted(async () => {
   const {data} = await apolloClient.query({
     query: getAmazonProductTypeQuery,
     variables: {id: productTypeId},
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   productType.value = data?.amazonProductType || null;
   loading.value = false;

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/RemotelyMappedAmazonProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/RemotelyMappedAmazonProductType.vue
@@ -86,7 +86,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const edges = data?.amazonProductTypes?.edges || [];
   let nextId: string | null = null;

--- a/src/core/media/files/containers/FilesList.vue
+++ b/src/core/media/files/containers/FilesList.vue
@@ -142,7 +142,7 @@ const deleteAll = async (query) => {
     <div class="flex flex-col mt-2">
       <FilterManager :searchConfig="searchConfig">
         <template v-slot:variables="{ filterVariables, orderVariables, pagination }">
-          <ApolloQuery :query="listQuery"
+          <ApolloQuery :query="listQuery" fetch-policy="cache-and-network"
                        :variables="{
                          filter: {
                            ...filterVariables,

--- a/src/core/media/files/containers/MediaCard.vue
+++ b/src/core/media/files/containers/MediaCard.vue
@@ -38,7 +38,7 @@ const refetchIfNecessary = (query, data) => {
         </div>
         <div class="flex items-center gap-2">
           <span class="p-0.5 bg-gray-600 rounded-full"></span>
-            <ApolloQuery :query="cntQuery">
+            <ApolloQuery :query="cntQuery" fetch-policy="cache-and-network">
               <template v-slot="{ result: { data }, query }">
                 <p v-if="data && refetchIfNecessary(query, data)" class="text-sm">{{ data.medias.totalCount }} {{ t('media.media.labels.files') }}</p>
               </template>

--- a/src/core/products/products/product-create/ProductCreateController.vue
+++ b/src/core/products/products/product-create/ProductCreateController.vue
@@ -109,7 +109,7 @@ watch(
       const { data } = await apolloClient.query({
         query: getProductQuery,
         variables: { id: newVal },
-        fetchPolicy: 'network-only'
+        fetchPolicy: 'cache-first'
       });
 
       const product = data?.product;

--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -31,7 +31,7 @@ const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
     query: amazonProductsQuery,
     variables: { localInstance: props.product.id },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
 };

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -26,7 +26,7 @@ const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
     query: amazonProductsQuery,
     variables: { localInstance: props.product.id },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
 };

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -31,7 +31,7 @@ const fetchAmazonProducts = async () => {
   const { data } = await apolloClient.query({
     query: amazonProductsQuery,
     variables: { localInstance: props.product.id },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
 };

--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -52,7 +52,7 @@ const fetchViews = async () => {
   loading.value = true;
   const { data } = await apolloClient.query({
     query: amazonChannelViewsQuery,
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   views.value = data.amazonChannelViews?.edges?.map((edge: any) => edge.node) || [];
   loading.value = false;

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
@@ -80,7 +80,7 @@ const fetchNodes = async () => {
   const { data } = await apolloClient.query({
     query: amazonBrowseNodesQuery,
     variables: { filter },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   nodes.value = data?.amazonBrowseNodes?.edges?.map((e: any) => e.node) || [];
   loadingNodes.value = false;
@@ -106,7 +106,7 @@ const fetchSelected = async () => {
   const { data } = await apolloClient.query({
     query: amazonProductBrowseNodesQuery,
     variables: { filter },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const node = data?.amazonProductBrowseNodes?.edges?.[0]?.node;
   if (node) {
@@ -129,7 +129,7 @@ const fetchSelectedNodeDetails = async (remoteId: string) => {
   const { data } = await apolloClient.query({
     query: amazonBrowseNodesQuery,
     variables: { filter },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   selectedNodeDetails.value = data?.amazonBrowseNodes?.edges?.[0]?.node || null;
 };
@@ -156,7 +156,7 @@ const fetchRecommendedTypes = async () => {
         productTypeCode: { inList: codes },
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const map = new Map<string, { id: string }>(
     (data?.amazonProductTypes?.edges || []).map((e: any) => [

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonExternalProductIdSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonExternalProductIdSection.vue
@@ -66,7 +66,7 @@ const fetchExternalId = async () => {
         view: { id: { exact: props.view.id } },
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const node = data?.amazonExternalProductIds?.edges?.[0]?.node;
   externalId.value = node?.id || null;

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonGtinExemptionSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonGtinExemptionSection.vue
@@ -30,7 +30,7 @@ const fetchExemption = async () => {
     const { data } = await apolloClient.query({
       query: amazonGtinExemptionsQuery,
       variables: { productId: props.productId, viewId: props.viewId },
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
     });
     const node = data.amazonGtinExemptions?.edges?.[0]?.node;
     if (node) {

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonUnmappedValuesSection.vue
@@ -30,7 +30,7 @@ const fetchProperties = async () => {
   const { data } = await apolloClient.query({
     query: amazonProductPropertiesQuery,
     variables: { remoteProductId: props.remoteProductId },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   properties.value =
     data?.amazonProductProperties?.edges?.map((e: any) => e.node) || [];

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
@@ -39,7 +39,7 @@ const fetchOptions = async () => {
   const { data } = await apolloClient.query({
     query: amazonProductTypesQuery,
     variables: { filter: { localInstance: { id: { exact: productTypeRuleId.value } } } },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const node = data?.amazonProductTypes?.edges?.[0]?.node;
   const themes: string[] = node?.variationThemes || [];
@@ -61,7 +61,7 @@ const fetchCurrent = async () => {
         view: { id: { exact: props.view.id } },
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const node = data?.amazonVariationThemes?.edges?.[0]?.node;
   recordId.value = node?.id || null;

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -66,7 +66,7 @@ const cleanedData = (rawData) => {
 
 const loadSalesChannels = async () => {
   try {
-    const { data } = await apolloClient.query({ query: integrationsQuery, fetchPolicy: 'network-only' });
+    const { data } = await apolloClient.query({ query: integrationsQuery, fetchPolicy: 'cache-first' });
     salesChannels.value = data?.integrations.edges.map((e: any) => e.node) || [];
   } catch (e) {
     console.error('Failed to load sales channels', e);
@@ -87,7 +87,7 @@ const setFormAndMutation = async (language, channel) => {
       const { data } = await apolloClient.query({
         query: getProductContentByLanguageAndDefaultQuery,
         variables: { languageCode: language, productId: props.product.id },
-        fetchPolicy: 'network-only'
+        fetchPolicy: 'cache-first'
       });
 
       if (data && data.productTranslations.edges.length === 1) {
@@ -120,7 +120,7 @@ const setFormAndMutation = async (language, channel) => {
           productId: props.product.id,
           salesChannelId: channel
         },
-        fetchPolicy: 'network-only'
+        fetchPolicy: 'cache-first'
       });
 
       if (data && data.productTranslations.edges.length === 1) {
@@ -147,7 +147,7 @@ const setFormAndMutation = async (language, channel) => {
       const { data: def } = await apolloClient.query({
         query: getProductContentByLanguageAndDefaultQuery,
         variables: { languageCode: language, productId: props.product.id },
-        fetchPolicy: 'network-only'
+        fetchPolicy: 'cache-first'
       });
       defaultPreviewContent.value = def?.productTranslations.edges[0]?.node || null;
     }
@@ -292,7 +292,7 @@ const shortDescriptionToolbarOptions = [
       </ApolloMutation>
     </FlexCell>
     <FlexCell>
-      <ApolloQuery :query="translationLanguagesQuery">
+      <ApolloQuery :query="translationLanguagesQuery" fetch-policy="cache-and-network">
         <template v-slot="{ result: { data } }">
           <Selector v-if="data"
                     v-model="currentLanguage"

--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -60,7 +60,7 @@ const fetchPoints = async () => {
     const {data} = await apolloClient.query({
       query: productTranslationBulletPointsQuery,
       variables: {filter: {productTranslation: {id: {exact: props.translationId}}}},
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
     });
     bulletPoints.value =
         data?.productTranslationBulletPoints.edges.map((e: any) => ({...e.node})) || [];

--- a/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodesList.vue
@@ -54,7 +54,7 @@ const fetchCurrentEanCode = async () => {
   const {data} = await apolloClient.query({
     query: eanCodesQuery,
     variables: {filter: {product: {id: {exact: props.product.id}}}},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.eanCodes && data.eanCodes.edges.length > 0) {
@@ -73,7 +73,7 @@ const fetchAvailableEanCode = async () => {
   const {data} = await apolloClient.query({
     query: eanCodesQuery,
     variables: {filter: {internal: {exact: true}, alreadyUsed: {exact: false}}},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.eanCodes && data.eanCodes.edges.length > 0) {

--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
@@ -70,7 +70,7 @@ const fetchData = async () => {
   const { data } = await apolloClient.query({
     query: mediaProductThroughQuery,
     variables: { filter: { product: {id: {exact: props.product.id }} }},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data) {

--- a/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
@@ -38,7 +38,7 @@ const fetchConfigurableVariations = async () => {
       filter: { variation: { id: { exact: props.product.id } } },
       first: 100
     },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   const edges = data?.configurableVariations?.edges || [];
@@ -52,7 +52,7 @@ const fetchBundleVariations = async () => {
       filter: { variation: { id: { exact: props.product.id } } },
       first: 100
     },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   const edges = data?.bundleVariations?.edges || [];

--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -119,7 +119,7 @@ const fetchProductTypeValue = async (productTypePropertyId) => {
   const {data} = await apolloClient.query({
     query: productPropertiesQuery,
     variables: {filter: {property: {id: {exact: productTypePropertyId}}, product: {id: {exact: props.product.id}}}},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productProperties && data.productProperties.edges && data.productProperties.edges.length == 1) {
@@ -163,7 +163,7 @@ const setCurrentLanguage = async () => {
 
   const {data} = await apolloClient.query({
     query: translationLanguagesQuery,
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.translationLanguages && data.translationLanguages.defaultLanguage) {
@@ -178,7 +178,7 @@ const fetchPropertiesIds = async (productTypeValueId) => {
   const {data} = await apolloClient.query({
     query: productPropertiesRulesQuery,
     variables: {filter: {productType: {id: {exact: productTypeValueId}}}},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   })
 
   if (data && data.productPropertiesRules && data.productPropertiesRules.edges && data.productPropertiesRules.edges.length == 1) {
@@ -225,7 +225,7 @@ const setInitialValues = async (propertiesIds) => {
   const {data} = await apolloClient.query({
     query: productPropertiesQuery,
     variables: {filter: {property: {id: {inList: propertiesIds}}, product: {id: {exact: props.product.id}}}},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productProperties && data.productProperties.edges) {
@@ -258,7 +258,7 @@ const fetchRequiredProductType = async () => {
   const {data} = await apolloClient.query({
     query: propertiesQuery,
     variables: {filter: {isProductType: {exact: true}}},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   })
 
   if (data && data.properties && data.properties.edges && data.properties.edges.length == 1) {
@@ -351,7 +351,7 @@ const fetchFieldTranslation = async (value: ProductPropertyValue) => {
             language: {exact: language.value}
           }
     },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productPropertyTextTranslations && data.productPropertyTextTranslations.edges && data.productPropertyTextTranslations.edges.length == 1) {
@@ -482,7 +482,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
         </div>
       </FlexCell>
       <FlexCell v-if="language">
-        <ApolloQuery :query="translationLanguagesQuery">
+        <ApolloQuery :query="translationLanguagesQuery" fetch-policy="cache-and-network">
           <template v-slot="{ result: { data } }">
             <Selector v-if="data"
                       v-model="language"

--- a/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
+++ b/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
@@ -47,7 +47,7 @@ const loadPrices = async () => {
   const { data } = await apolloClient.query({
     query: salesPricesQuery,
     variables: { filter: { product: {id: { exact: props.product.id }} }, order: { currency: { isoCode: 'ASC' } } },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   prices.value = data.salesPrices.edges.map(edge => ({

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
@@ -53,7 +53,7 @@ const fetchData = async () => {
   const { data } = await apolloClient.query({
     query: productsQuery,
     variables: { filter },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
 
   if (data) {

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -329,7 +329,7 @@ const fetchProperties = async () => {
   const { data: typeData } = await apolloClient.query({
     query: propertiesQuery,
     variables: { filter: { isProductType: { exact: true } } },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   })
   if (!typeData?.properties?.edges?.length) return
   const typePropertyId = typeData.properties.edges[0].node.id
@@ -342,7 +342,7 @@ const fetchProperties = async () => {
         product: { id: { exact: parentId.value } },
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   })
   if (!valueData?.productProperties?.edges?.length) return
   const productTypeValueId = valueData.productProperties.edges[0].node.valueSelect?.id
@@ -351,7 +351,7 @@ const fetchProperties = async () => {
   const { data: ruleData } = await apolloClient.query({
     query: productPropertiesRulesQuery,
     variables: { filter: { productType: { id: { exact: productTypeValueId } } } },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   })
   if (!ruleData?.productPropertiesRules?.edges?.length) return
   const items = ruleData.productPropertiesRules.edges[0].node.items
@@ -390,7 +390,7 @@ const fetchVariationProperties = async (variationId: string) => {
   const { data } = await apolloClient.query({
     query: productPropertiesQuery,
     variables: { filter: { product: { id: { exact: variationId } } }, first: 100 },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   })
   const edges = data?.productProperties?.edges ?? []
   const propertyValues: Record<string, any> = {}
@@ -406,7 +406,7 @@ const fetchVariationProperties = async (variationId: string) => {
               language: { exact: language.value },
             },
           },
-          fetchPolicy: 'network-only',
+          fetchPolicy: 'cache-first',
         })
         const tNode = tData?.productPropertyTextTranslations?.edges?.[0]?.node
         translation = tNode ? { ...tNode } : { language: language.value }
@@ -424,7 +424,7 @@ const fetchVariations = async () => {
       filter: { parent: { id: { exact: parentId.value } } },
       ...fetchPaginationData.value,
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   })
   const edges = data?.[queryKey.value]?.edges ?? []
   pageInfo.value = data?.[queryKey.value]?.pageInfo ?? null
@@ -448,7 +448,7 @@ watch(language, async () => {
 const fetchDefaultLanguage = async () => {
   const { data } = await apolloClient.query({
     query: translationLanguagesQuery,
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   })
   language.value = data?.translationLanguages?.defaultLanguage?.code || null
 }
@@ -927,7 +927,7 @@ const startResize = (e: MouseEvent, key: string) => {
         </Button>
       </FlexCell>
       <FlexCell >
-        <ApolloQuery :query="translationLanguagesQuery">
+        <ApolloQuery :query="translationLanguagesQuery" fetch-policy="cache-and-network">
           <template v-slot="{ result: { data } }">
             <Selector
               v-if="data"

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
@@ -131,7 +131,7 @@ const handleQuantityChanged = debounce(async (event, id) => {
 <template>
   <FilterManager :searchConfig="searchConfig">
     <template v-slot:variables="{ filterVariables, orderVariables, pagination }">
-      <ApolloQuery :query="listQuery"
+      <ApolloQuery :query="listQuery" fetch-policy="cache-and-network"
                    :variables="{filter: {...filterVariables, 'parent': {'id': {'exact': parentId}}},
                                 order:orderVariables,
                                 first: pagination.first,

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/assign-create/WebsiteAssignCreate.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/assign-create/WebsiteAssignCreate.vue
@@ -33,7 +33,7 @@ const fetchViews = async () => {
   const { data } = await apolloClient.query({
     query: salesChannelViewsQuery,
     variables: { filter: { salesChannel: { active: {exact: true} }, NOT: { id: { inList: props.viewsIds } } } },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data) {

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/logs-info-modal/LogsInfoModal.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/logs-info-modal/LogsInfoModal.vue
@@ -61,7 +61,7 @@ const fetchLogs = async () => {
   const {data} = await apolloClient.query({
     query,
     variables: {filter: {remoteProduct: {id: {exact: props.id }}}},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   const logsData = props.integrationType === 'amazon' ? data?.amazonRemoteLogs : data?.remoteLogs;

--- a/src/core/profile/company/containers/company-profile-edit-form/CompanyProfileEditForm.vue
+++ b/src/core/profile/company/containers/company-profile-edit-form/CompanyProfileEditForm.vue
@@ -177,7 +177,7 @@ onMounted(async () => {
             {{ t('auth.register.company.placeholders.country') }}
             <span v-if="mandatory">*</span>
           </Label>
-          <ApolloQuery :query="countriesQuery">
+          <ApolloQuery :query="countriesQuery" fetch-policy="cache-and-network">
             <template v-slot="{ result: { data } }">
               <Selector
                 class="mt-2"

--- a/src/core/profile/user/containers/profile-edit/containers/profile-edit-form/ProfileEditForm.vue
+++ b/src/core/profile/user/containers/profile-edit/containers/profile-edit-form/ProfileEditForm.vue
@@ -125,7 +125,7 @@ const onUploaded = async (files: any[]) => {
           </div>
           <div>
             <Label>{{ t('profile.labels.timezone') }}</Label>
-            <ApolloQuery :query="timezonesQuery">
+            <ApolloQuery :query="timezonesQuery" fetch-policy="cache-and-network">
               <template v-slot="{ result: { data } }">
                 <Selector v-if="data" v-model="form.timezone" :options="data.timezones" :placeholder="t('auth.register.company.placeholders.selector.country')" filterable
                           labelBy="key" valueBy="key"/>

--- a/src/core/properties/product-properties-rule/product-properties-rule-create/ProductPropertiesRuleCreateController.vue
+++ b/src/core/properties/product-properties-rule/product-properties-rule-create/ProductPropertiesRuleCreateController.vue
@@ -99,7 +99,7 @@ const fetchProductType = async () => {
    const {data} = await apolloClient.query({
       query: getPropertySelectValueQuery,
       variables: { id: initialProductId.value },
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     })
 
     if (data && data.propertySelectValue) {

--- a/src/core/properties/product-properties-rule/product-properties-rule-edit/ProductPropertiesRuleEditController.vue
+++ b/src/core/properties/product-properties-rule/product-properties-rule-edit/ProductPropertiesRuleEditController.vue
@@ -79,7 +79,7 @@ const fetchData = async () => {
   const {data} = await apolloClient.query({
     query: getProductPropertiesRuleQuery,
     variables: {id: id.value.toString() },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   })
 
   if (data && data.productPropertiesRule) {

--- a/src/core/properties/product-properties-rule/product-properties-rule-show/containers/products-list/ProductsList.vue
+++ b/src/core/properties/product-properties-rule/product-properties-rule-show/containers/products-list/ProductsList.vue
@@ -21,7 +21,7 @@ const fetchFilterIds = async () => {
   const { data } = await apolloClient.query({
     query: productPropertiesQuery,
     variables: { filter: { valueSelect: { id: { exact: props.id }} }},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productProperties && data.productProperties.edges) {

--- a/src/core/properties/properties/properties-show/containers/products-list/ProductsList.vue
+++ b/src/core/properties/properties/properties-show/containers/products-list/ProductsList.vue
@@ -21,7 +21,7 @@ const fetchFilterIds = async () => {
   const { data } = await apolloClient.query({
     query: productPropertiesQuery,
     variables: { filter: { property: { id: { exact: props.id }} }},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productProperties && data.productProperties.edges) {

--- a/src/core/properties/properties/properties-show/containers/rules-list/RulesList.vue
+++ b/src/core/properties/properties/properties-show/containers/rules-list/RulesList.vue
@@ -22,7 +22,7 @@ const fetchFilterIds = async () => {
     const { data } = await apolloClient.query({
       query: productPropertiesRuleItemsQuery,
       variables: { filter: { property: { id: { exact: props.id }} }},
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
 
     if (data && data.productPropertiesRuleItems && data.productPropertiesRuleItems.edges) {

--- a/src/core/properties/property-select-values/property-select-values-list/PropertySelectValuesMerge.vue
+++ b/src/core/properties/property-select-values/property-select-values-list/PropertySelectValuesMerge.vue
@@ -29,7 +29,7 @@ const fetchValues = async () => {
   const { data } = await apolloClient.query({
     query: propertySelectValuesQuery,
     variables: { filter: { id: { inList: props.selectedEntities } } },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const edges = data?.propertySelectValues?.edges || [];
   const result = await Promise.all(
@@ -43,7 +43,7 @@ const fetchValues = async () => {
             OR: { valueMultiSelect: { id: { exact: id } } },
           },
         },
-        fetchPolicy: 'network-only',
+        fetchPolicy: 'cache-first',
       });
       return {
         id,

--- a/src/core/properties/property-select-values/property-select-values-show/PropertySelectValueMerge.vue
+++ b/src/core/properties/property-select-values/property-select-values-show/PropertySelectValueMerge.vue
@@ -31,7 +31,7 @@ const fetchCount = async (id: string) => {
         OR: { valueMultiSelect: { id: { exact: id } } },
       },
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   return data?.productProperties?.totalCount || 0;
 };
@@ -54,7 +54,7 @@ const fetchOptions = async (searchValue: string | null = null) => {
   const { data } = await apolloClient.query({
     query: propertySelectValuesQuerySimpleSelector,
     variables: variables,
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-first',
   });
   const fetched =
     data?.propertySelectValues?.edges?.map((e: any) => ({ label: e.node.value, value: e.node.id })) || [];

--- a/src/core/properties/property-select-values/property-select-values-show/containers/products-list/ProductsList.vue
+++ b/src/core/properties/property-select-values/property-select-values-show/containers/products-list/ProductsList.vue
@@ -24,7 +24,7 @@ const fetchFilterIds = async () => {
         valueSelect: { id: {exact: props.id} },
         OR: { valueMultiSelect: { id: {exact: props.id }} }
     }},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productProperties && data.productProperties.edges) {

--- a/src/core/properties/property-select-values/property-select-values-show/containers/rules-list/RulesList.vue
+++ b/src/core/properties/property-select-values/property-select-values-show/containers/rules-list/RulesList.vue
@@ -22,7 +22,7 @@ const fetchFilterIds = async () => {
   const { data } = await apolloClient.query({
     query: productPropertiesRulesQuery,
     variables: { filter: { productType: { id: { exact: props.id }} }},
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productPropertiesRules && data.productPropertiesRules.edges && data.productPropertiesRules.edges.length == 1) {

--- a/src/shared/components/organisms/bulk=product-property-assigner/BulkProductPropertyAssigner.vue
+++ b/src/shared/components/organisms/bulk=product-property-assigner/BulkProductPropertyAssigner.vue
@@ -297,7 +297,7 @@ const onAssignSubmit = async () => {
           <Label class="block font-semibold text-sm text-gray-700 mb-1">
             {{ t('shared.labels.language') }}
           </Label>
-          <ApolloQuery :query="translationLanguagesQuery">
+          <ApolloQuery :query="translationLanguagesQuery" fetch-policy="cache-and-network">
             <template v-slot="{ result: { data } }">
               <Selector v-if="data" v-model="language" :options="data.translationLanguages.languages" labelBy="name"
                         valueBy="code" filterable/>

--- a/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
+++ b/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
@@ -102,7 +102,7 @@ watch(() => props.fieldsToClear, (fields) => {
           <FormLayout v-if="initialFormUpdate(config.queryData)" :config="config" :form="form" :errors="errors" />
         </div>
       </template>
-      <ApolloQuery v-else :query="config.query" :variables="config.queryVariables" class="grid max-w grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-6">
+      <ApolloQuery v-else :query="config.query" :variables="config.queryVariables" fetch-policy="cache-and-network" class="grid max-w grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-6">
         <template v-slot="{ result: { loading, error, data } }">
           <template v-if="data && !loading && initialFormUpdate(data)">
             <FormLayout :config="config" :form="form" :errors="errors"/>

--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -82,7 +82,7 @@ async function ensureSelectedValuesArePresent() {
         [props.field.valueBy]: { inList: missingIds }
       }
     },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   const newItems = props.field.isEdge
@@ -114,7 +114,7 @@ async function fetchData(searchValue: string | null | undefined = null, ensureSe
     const { data } = await apolloClient.query({
       query: props.field.query as unknown as DocumentNode,
       variables: variables,
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
 
     processAndCleanData(data[props.field.dataKey]);

--- a/src/shared/components/organisms/general-listing/GeneralListing.vue
+++ b/src/shared/components/organisms/general-listing/GeneralListing.vue
@@ -292,7 +292,7 @@ defineExpose({
   <FilterManager :searchConfig="searchConfig">
 
     <template v-slot:variables="{ filterVariables, orderVariables, pagination }">
-      <ApolloQuery :query="query"
+      <ApolloQuery :query="query" fetch-policy="cache-and-network"
                    :variables="{filter: fixedFilterVariables !== null ? { ...filterVariables, ...fixedFilterVariables } : filterVariables,
                               order: fixedOrderVariables !== null ? { ...orderVariables, ...fixedOrderVariables } : orderVariables,
                               first: pagination.first,

--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
@@ -62,7 +62,7 @@ const fetchData = async (searchValue: string | null = null) => {
     const { data } = await apolloClient.query({
       query: props.filter.query as unknown as DocumentNode,
       variables: variables,
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     });
     if (data && data[props.filter.dataKey]) {
       cleanedData.value = cleanData(data[props.filter.dataKey]);

--- a/src/shared/components/organisms/product-properties-configurator/ProductPropertiesConfigurator.vue
+++ b/src/shared/components/organisms/product-properties-configurator/ProductPropertiesConfigurator.vue
@@ -78,7 +78,7 @@ const fetchData = async () => {
   const {data} = await apolloClient.query({
     query: propertiesQuery,
     variables: variables,
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.properties) {
@@ -270,7 +270,7 @@ const handleProductTypeUpdated = async (newVal) => {
     const {data} = await apolloClient.query({
       query: getPropertySelectValueQuery,
       variables: {id: newVal},
-      fetchPolicy: 'network-only'
+      fetchPolicy: 'cache-first'
     })
 
     if (data && data.propertySelectValue) {

--- a/src/shared/components/organisms/product-properties-configurator/containers/product-type-field/ProductTypeField.vue
+++ b/src/shared/components/organisms/product-properties-configurator/containers/product-type-field/ProductTypeField.vue
@@ -37,7 +37,7 @@ const setField = async () => {
   let ids: string[] = []
   const {data} = await apolloClient.query({
     query: productPropertiesRulesQuery,
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productPropertiesRules && data.productPropertiesRules.edges.length > 0) {

--- a/src/shared/components/organisms/translated-fields/TranslatedFields.vue
+++ b/src/shared/components/organisms/translated-fields/TranslatedFields.vue
@@ -86,7 +86,7 @@ const setValues = async () => {
 
   const {data} = await apolloClient.query({
     query: translationLanguagesQuery,
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data?.translationLanguages?.languages?.length) {
@@ -109,7 +109,7 @@ const setValues = async () => {
   const {data: translationData} = await apolloClient.query({
     query: props.query,
     variables: props.variables,
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (translationData && translationData[props.queryKey]) {

--- a/src/shared/components/organisms/variations-adder/VariationsAdder.vue
+++ b/src/shared/components/organisms/variations-adder/VariationsAdder.vue
@@ -89,7 +89,7 @@ const fetchData = async () => {
   const { data } = await apolloClient.query({
     query: minimalProductsQuery,
     variables: variables,
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.products) {

--- a/src/shared/components/organisms/variations-generator/VariationsGenerator.vue
+++ b/src/shared/components/organisms/variations-generator/VariationsGenerator.vue
@@ -36,7 +36,7 @@ const fetchValues = async (propertyId: string) => {
   const { data } = await apolloClient.query({
     query: propertySelectValuesQuery,
     variables: { filter: { property: { id: { exact: propertyId } } } },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.propertySelectValues) {
@@ -59,7 +59,7 @@ const fetchData = async () => {
   const { data } = await apolloClient.query({
     query: productPropertiesRulesQuery,
     variables: { filter: { productType: { id: { exact: props.productTypeId } } } },
-    fetchPolicy: 'network-only'
+    fetchPolicy: 'cache-first'
   });
 
   if (data && data.productPropertiesRules && data.productPropertiesRules.edges.length > 0) {


### PR DESCRIPTION
## Summary
- default queries to `cache-first` instead of `network-only`
- use `fetch-policy="cache-and-network"` on `<ApolloQuery>` components
- watch dashboard card queries with `cache-and-network`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b96fd3321c832eb5a3d1a34518d3fb

## Summary by Sourcery

Update Apollo Client usage to optimize caching and data reactivity by changing default fetch policies and leveraging subscriptions.

Enhancements:
- Change default fetchPolicy to "cache-first" for apolloClient.query calls across the app
- Convert many data fetches in dashboard general, orders, and Amazon sections to watchQuery with "cache-and-network" for real-time updates
- Update <ApolloQuery> components to include fetch-policy="cache-and-network" for consistent cache+network behavior
- Introduce a makeQuery helper in DashboardSectionAmazon to streamline watchQuery subscription logic