### PR TITLE
feat: add skeleton loaders for main views

### DIFF
--- a/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
+++ b/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
@@ -7,6 +7,7 @@ import { FormConfig, HiddenFormField} from '../../formConfig';
 import { FieldType } from "../../../../../utils/constants";
 import {SubmitButtons} from "../submit-buttons";
 import { Toast } from "../../../../../modules/toast";
+import FormSkeleton from "../form-skeleton/FormSkeleton.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -104,11 +105,9 @@ watch(() => props.fieldsToClear, (fields) => {
       </template>
       <ApolloQuery v-else :query="config.query" :variables="config.queryVariables" class="grid max-w grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-6">
         <template v-slot="{ result: { loading, error, data } }">
-          <template v-if="data && !loading && initialFormUpdate(data)">
+          <FormSkeleton v-if="loading" />
+          <template v-else-if="data && initialFormUpdate(data)">
             <FormLayout :config="config" :form="form" :errors="errors"/>
-          </template>
-          <template>
-            <span class="animate-spin border-2 border-black dark:border-white !border-l-transparent rounded-full w-5 h-5 inline-flex"></span>
           </template>
         </template>
       </ApolloQuery>

--- a/src/shared/components/organisms/general-form/containers/form-skeleton/FormSkeleton.vue
+++ b/src/shared/components/organisms/general-form/containers/form-skeleton/FormSkeleton.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="animate-pulse space-y-4 p-4">
+    <div v-for="i in 4" :key="i" class="h-6 bg-gray-200 rounded"></div>
+  </div>
+</template>

--- a/src/shared/components/organisms/general-listing/GeneralListing.vue
+++ b/src/shared/components/organisms/general-listing/GeneralListing.vue
@@ -17,6 +17,7 @@ import apolloClient from "../../../../../apollo-client";
 import { Toast } from "../../../modules/toast";
 import Swal from 'sweetalert2';
 import { SweetAlertOptions } from 'sweetalert2';
+import GeneralListingSkeleton from "./GeneralListingSkeleton.vue";
 
 const { t } = useI18n();
 
@@ -301,7 +302,8 @@ defineExpose({
                               after: pagination.after }">
         <template v-slot="{ result: { loading, error, data }, query }">
 
-          <div v-if="data" class="mt-5 p-0 border-0 "
+          <GeneralListingSkeleton v-if="loading" />
+          <div v-else-if="data" class="mt-5 p-0 border-0 "
                :class="config.isMainPage ? 'card bg-white rounded-xl panel' : ''">
             <div class="flex flex-wrap gap-2 mb-4 p-4">
               <div

--- a/src/shared/components/organisms/general-listing/GeneralListingSkeleton.vue
+++ b/src/shared/components/organisms/general-listing/GeneralListingSkeleton.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="p-4 animate-pulse space-y-3">
+    <div class="h-6 bg-gray-200 rounded w-1/3"></div>
+    <div class="space-y-2">
+      <div v-for="i in 5" :key="i" class="h-4 bg-gray-200 rounded"></div>
+    </div>
+  </div>
+</template>
+

--- a/src/shared/components/organisms/general-show/GeneralShow.vue
+++ b/src/shared/components/organisms/general-show/GeneralShow.vue
@@ -9,6 +9,7 @@ import {Icon} from "../../atoms/icon";
 import {Label} from "../../atoms/label";
 import {FieldArray} from "./containers/field-array";
 import {FieldType} from "../../../utils/constants";
+import ShowSkeleton from "./ShowSkeleton.vue";
 
 const router = useRouter();
 const props = defineProps<{ config: ShowConfig;}>();
@@ -34,7 +35,8 @@ const updateData = (newData) => {
 <template>
   <ApolloSubscription :subscription="config.subscription" :variables="config.subscriptionVariables">
     <template v-slot:default="{ loading, error, result }">
-      <template v-if="!loading && result && updateData(result)">
+      <ShowSkeleton v-if="loading" />
+      <template v-else-if="result && updateData(result)">
         <div :class="computedStyle">
           <div class="overflow-hidden" :class="gridClass">
             <div v-if="config.title || config.description" class="px-4 py-6 sm:px-6">

--- a/src/shared/components/organisms/general-show/ShowSkeleton.vue
+++ b/src/shared/components/organisms/general-show/ShowSkeleton.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="p-4 animate-pulse space-y-4">
+    <div class="h-6 bg-gray-200 rounded w-1/3"></div>
+    <div class="space-y-2">
+      <div v-for="i in 3" :key="i" class="h-4 bg-gray-200 rounded"></div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add lightweight skeleton component for general listing
- show skeletons in listing, form, and show views while Apollo data loads

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (no output produced)


------
https://chatgpt.com/codex/tasks/task_e_68b975fa62f0832eb4431be01947322d

## Summary by Sourcery

Add skeleton loader components to replace spinner loaders in form, listing, and show views during Apollo data loading

New Features:
- Introduce FormSkeleton, GeneralListingSkeleton, and ShowSkeleton components
- Render skeleton placeholders in general-form, general-listing, and general-show containers while data is loading