### PR TITLE
Refine fetch policies for live webhook features

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/AmazonDefaultUnitConfigurators.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/AmazonDefaultUnitConfigurators.vue
@@ -26,7 +26,7 @@ const fetchFirstUnmapped = async () => {
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
   const edges = data?.amazonDefaultUnitConfigurators?.edges || [];
   canStartMapping.value = edges.length > 0;

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/containers/IntegrationsAmazonDefaultUnitConfiguratorEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/containers/IntegrationsAmazonDefaultUnitConfiguratorEditController.vue
@@ -84,7 +84,7 @@ onMounted(async () => {
   const { data } = await apolloClient.query({
     query: getAmazonDefaultUnitConfiguratorQuery,
     variables: { id: configuratorId.value },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
 
   const cfg = data?.amazonDefaultUnitConfigurator;
@@ -136,7 +136,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
 
   const edges = data?.amazonDefaultUnitConfigurators?.edges || [];

--- a/src/core/integrations/integrations/integrations-show/containers/monitor/useLiveMonitor.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/useLiveMonitor.ts
@@ -62,14 +62,14 @@ export function useLiveMonitor(options: Options = {}) {
           lte: timeRange.value.to,
         };
       }
-      const { data } = await apolloClient.query({
+      const { data } = await apolloClient.watchQuery({
         query: webhookDeliveriesQuery,
-        fetchPolicy: 'cache-first',
+        fetchPolicy: 'cache-and-network',
         variables: {
           filter,
           ...pagination,
         },
-      });
+      }).result();
       const edges = data?.webhookDeliveries?.edges || [];
       pageInfo.value = data?.webhookDeliveries?.pageInfo || null;
       const nodes = edges.map((e: any) => e.node);
@@ -104,11 +104,11 @@ export function useLiveMonitor(options: Options = {}) {
           lte: timeRange.value.to,
         };
       }
-      const { data } = await apolloClient.query({
+      const { data } = await apolloClient.watchQuery({
         query: webhookDeliveryStatsQuery,
-        fetchPolicy: 'cache-first',
+        fetchPolicy: 'cache-and-network',
         variables: { filter },
-      });
+      }).result();
       stats.value = data?.webhookDeliveryStats || null;
     } catch (e) {
       stats.value = null;

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/AmazonProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/AmazonProperties.vue
@@ -25,7 +25,7 @@ const fetchFirstUnmapped = async () => {
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
   const edges = data?.amazonProperties?.edges || [];
   canStartMapping.value = edges.length > 0;

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -46,7 +46,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
 
   const edges = data?.amazonProperties?.edges || [];

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonPropertySelectValues.vue
@@ -28,7 +28,7 @@ const fetchFirstUnmapped = async () => {
       },
       order: { marketplace: { isDefault: 'DESC' } },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
   const edges = data?.amazonPropertySelectValues?.edges || [];
   canStartMapping.value = edges.length > 0;

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -254,7 +254,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
       },
       order: { marketplace: { isDefault: 'DESC' } },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
 
 

--- a/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/reports/WebhookReports.vue
@@ -75,17 +75,17 @@ const fetchStats = async () => {
       }
     });
     const variables = { filter };
-    const { data } = await apolloClient.query({
+    const { data } = await apolloClient.watchQuery({
       query: webhookReportsKpiQuery,
-      fetchPolicy: 'cache-first',
+      fetchPolicy: 'cache-and-network',
       variables,
-    });
+    }).result();
     stats.value = data?.webhookReportsKpi || null;
-    const { data: seriesResp } = await apolloClient.query({
+    const { data: seriesResp } = await apolloClient.watchQuery({
       query: webhookReportsSeriesQuery,
-      fetchPolicy: 'cache-first',
+      fetchPolicy: 'cache-and-network',
       variables,
-    });
+    }).result();
     seriesData.value = seriesResp?.webhookReportsSeries || null;
   } catch {
     stats.value = null;

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/AmazonProductTypes.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/AmazonProductTypes.vue
@@ -29,7 +29,7 @@ const fetchFirstUnmapped = async () => {
         mappedLocally:  false ,
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
   const edges = data?.amazonProductTypes?.edges || [];
   canStartMapping.value = edges.length > 0;

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/ImportedAmazonProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/ImportedAmazonProductType.vue
@@ -139,7 +139,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
   const edges = data?.amazonProductTypes?.edges || [];
   let nextId: string | null = null;

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/RemotelyMappedAmazonProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/RemotelyMappedAmazonProductType.vue
@@ -86,7 +86,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
         mappedLocally: false,
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   });
   const edges = data?.amazonProductTypes?.edges || [];
   let nextId: string | null = null;


### PR DESCRIPTION
## Summary
- switch useLiveMonitor to watchQuery with `cache-and-network`
- adjust WebhookReports to watchQuery with `cache-and-network`
- use `network-only` for `fetchFirstUnmapped` and `fetchNextUnmapped` helpers

## Testing
- `npm test` *(fails: npm missing)*
- `apt-get install -y nodejs npm` *(attempted to install Node to run tests; long install aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b97a1f03f4832e93ce53c96d93b504