### PR TITLE
feat: add search limit and debounce

### DIFF
--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -16,8 +16,8 @@ const props = defineProps<{
 }>();
 
 const limit = computed(() => props.field.limit ?? 20);
-
-const MIN_SEARCH_LENGTH = 3;
+const DEFAULT_MIN_SEARCH_LENGTH = 3;
+const minSearchLength = computed(() => props.field.minSearchLength ?? DEFAULT_MIN_SEARCH_LENGTH);
 
 onMounted(() => {
   fetchData(null, true);
@@ -234,7 +234,7 @@ const handleInput = debounce(async (searchValue: string) => {
     return;
   }
 
-  if (searchValue.length >= MIN_SEARCH_LENGTH) {
+  if (searchValue.length >= minSearchLength.value) {
     fetchData(searchValue);
   } else if (!searchValue.length) {
     fetchData();

--- a/src/shared/components/organisms/general-form/formConfig.ts
+++ b/src/shared/components/organisms/general-form/formConfig.ts
@@ -166,6 +166,7 @@ export interface QueryFormField extends BaseFormField {
   filterable?: boolean;
   removable?: boolean;
   limit?: number;
+  minSearchLength?: number;
   autocompleteIfOneResult?: boolean;
   isLiveUpdate?: boolean;
   createOnFlyConfig?: CreateOnTheFly;

--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
@@ -39,6 +39,8 @@ const storeLabel = ({ id, label }: { id: any; label: string }) => {
 
 const props = defineProps<{ filter: QueryFilter }>();
 const limit = computed(() => props.filter.limit ?? 20);
+const DEFAULT_MIN_SEARCH_LENGTH = 3;
+const minSearchLength = computed(() => props.filter.minSearchLength ?? DEFAULT_MIN_SEARCH_LENGTH);
 const emit = defineEmits(['update-value']);
 const route = useRoute();
 const cleanedData: Ref<any[]> = ref([]);
@@ -107,10 +109,8 @@ watch([selectedValue, cleanedData], () => {
 
 watch(() => props.filter.queryVariables, () => fetchData(), { deep: true });
 
-const MIN_SEARCH_LENGTH = 3;
-
 const handleInput = debounce(async (searchValue: string) => {
-  if (searchValue.length >= MIN_SEARCH_LENGTH) {
+  if (searchValue.length >= minSearchLength.value) {
     fetchData(searchValue);
   } else if (!searchValue.length) {
     fetchData();

--- a/src/shared/components/organisms/general-search/searchConfig.ts
+++ b/src/shared/components/organisms/general-search/searchConfig.ts
@@ -68,6 +68,7 @@ export interface QueryFilter extends BaseFilter {
   filterable?: boolean;
   removable?: boolean;
   limit?: number;
+  minSearchLength?: number;
 }
 
 


### PR DESCRIPTION
## Summary
- add `limit` prop with default 20 to FieldQuery and FilterQuery
- debounce search requests until three characters are entered

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b97329d398832eb6649c7cb73b21f9