### PR TITLE
feat(router): load routes dynamically

### DIFF
--- a/src/shared/modules/router/index.ts
+++ b/src/shared/modules/router/index.ts
@@ -1,16 +1,18 @@
 import * as VueRouter from 'vue-router';
 
-import { routes as dashboardRoutes } from '../../../core/dashboard/routes';
-import { routes as authRoutes } from '../../../core/auth/routes';
-import { routes as profileRoutes } from '../../../core/profile/routes';
-import { routes as contactsRoutes } from '../../../core/contacts/routes';
-import { routes as salesRoutes } from '../../../core/sales/routes';
-import { routes as inventoryRoutes } from '../../../core/inventory/routes';
-import { routes as productsRoutes } from '../../../core/products/routes';
-import { routes as integrationsRoutes } from '../../../core/integrations/routes';
-import { routes as settingsRoutes } from '../../../core/settings/routes';
-import { routes as mediaRoutes } from '../../../core/media/routes';
-import { routes as propertiesRoutes } from '../../../core/properties/routes';
+const routeModules = [
+  () => import('../../../core/dashboard/routes'),
+  () => import('../../../core/auth/routes'),
+  () => import('../../../core/profile/routes'),
+  () => import('../../../core/contacts/routes'),
+  () => import('../../../core/sales/routes'),
+  () => import('../../../core/inventory/routes'),
+  () => import('../../../core/products/routes'),
+  () => import('../../../core/integrations/routes'),
+  () => import('../../../core/settings/routes'),
+  () => import('../../../core/media/routes'),
+  () => import('../../../core/properties/routes'),
+];
 import { PUBLIC_ROUTES } from '../../utils/constants'
 import {detectAuth, isAuthenticated, hasCompany, isActive, removeAuth, isFinishedOnboarding, getOnboardingStatus, setPageLoader} from '../auth';
 import { Toast } from '../toast';
@@ -18,7 +20,21 @@ import { useAppStore } from '../../plugins/store';
 
 let router: VueRouter.Router;
 
-export function buildRouter() {
+export async function buildRouter() {
+  const [
+    { routes: dashboardRoutes },
+    { routes: authRoutes },
+    { routes: profileRoutes },
+    { routes: contactsRoutes },
+    { routes: salesRoutes },
+    { routes: inventoryRoutes },
+    { routes: productsRoutes },
+    { routes: integrationsRoutes },
+    { routes: settingsRoutes },
+    { routes: mediaRoutes },
+    { routes: propertiesRoutes },
+  ] = await Promise.all(routeModules.map((load) => load()));
+
   router = VueRouter.createRouter({
     history: VueRouter.createWebHistory(),
     routes: [

--- a/src/shared/plugins/router.ts
+++ b/src/shared/plugins/router.ts
@@ -2,7 +2,7 @@ import { Plugin } from 'vue';
 import { buildRouter } from '../modules/router';
 
 export default {
-  install(app) {
-    app.use(buildRouter());
+  async install(app) {
+    app.use(await buildRouter());
   },
 } as Plugin;


### PR DESCRIPTION
## Summary
- load core route modules with dynamic imports
- await router creation during plugin install

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b97fc8625c832e86c3f89c188af397

## Summary by Sourcery

Implement dynamic route loading and defer router installation until after asynchronous initialization

New Features:
- Switch buildRouter to an async function that dynamically imports core route modules via Promise.all
- Update the plugin install method to await buildRouter before applying the router to the app