### PR TITLE
feat: add Apollo cache type policies

### DIFF
--- a/apollo-client.ts
+++ b/apollo-client.ts
@@ -63,18 +63,25 @@ const splitLink = split(
 
 const combinedLink = ApolloLink.from([errorLink, splitLink]);
 
-const mergeById = (existing: any[] = [], incoming: any[], { readField }: any) => {
-  const merged = [...existing];
-  incoming.forEach((item) => {
-    const id = readField('id', item);
-    const index = merged.findIndex((i) => readField('id', i) === id);
+const mergeEdgesById = (
+  existing: { edges: any[] } = { edges: [] },
+  incoming: { edges: any[] },
+  { readField }: any,
+) => {
+  const merged = existing.edges ? [...existing.edges] : [];
+  incoming.edges.forEach((edge) => {
+    const id = readField('id', edge.node);
+    const index = merged.findIndex((e) => readField('id', e.node) === id);
     if (index > -1) {
-      merged[index] = item;
+      merged[index] = edge;
     } else {
-      merged.push(item);
+      merged.push(edge);
     }
   });
-  return merged;
+  return {
+    ...incoming,
+    edges: merged,
+  };
 };
 
 const cache = new InMemoryCache({
@@ -83,19 +90,19 @@ const cache = new InMemoryCache({
       fields: {
         propertySelectValues: {
           keyArgs: false,
-          merge: mergeById,
+          merge: mergeEdgesById,
         },
         properties: {
           keyArgs: false,
-          merge: mergeById,
+          merge: mergeEdgesById,
         },
         products: {
           keyArgs: false,
-          merge: mergeById,
+          merge: mergeEdgesById,
         },
         medias: {
           keyArgs: false,
-          merge: mergeById,
+          merge: mergeEdgesById,
         },
       },
     },

--- a/apollo-client.ts
+++ b/apollo-client.ts
@@ -63,7 +63,57 @@ const splitLink = split(
 
 const combinedLink = ApolloLink.from([errorLink, splitLink]);
 
-const cache =  new InMemoryCache();
+const mergeById = (existing: any[] = [], incoming: any[], { readField }: any) => {
+  const merged = [...existing];
+  incoming.forEach((item) => {
+    const id = readField('id', item);
+    const index = merged.findIndex((i) => readField('id', i) === id);
+    if (index > -1) {
+      merged[index] = item;
+    } else {
+      merged.push(item);
+    }
+  });
+  return merged;
+};
+
+const cache = new InMemoryCache({
+  typePolicies: {
+    Query: {
+      fields: {
+        propertySelectValues: {
+          keyArgs: false,
+          merge: mergeById,
+        },
+        properties: {
+          keyArgs: false,
+          merge: mergeById,
+        },
+        products: {
+          keyArgs: false,
+          merge: mergeById,
+        },
+        medias: {
+          keyArgs: false,
+          merge: mergeById,
+        },
+      },
+    },
+    PropertySelectValue: {
+      keyFields: ['id'],
+    },
+    Property: {
+      keyFields: ['id'],
+    },
+    Product: {
+      keyFields: ['id'],
+    },
+    Media: {
+      keyFields: ['id'],
+    },
+  },
+});
+
 const apolloClient = new ApolloClient({
   link: combinedLink,
   cache,


### PR DESCRIPTION
## Summary
- merge property, media, product, and select value lists into Apollo cache by ID
- define keyFields for Property, Product, Media, and PropertySelectValue types

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b97fc4d6b8832eb555f2480901c91d