### PR TITLE
Fetch missing filter labels on listing pages

### DIFF
--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
@@ -10,7 +10,7 @@ import apolloClient from "../../../../../../../../../apollo-client";
 import {DocumentNode} from "graphql";
 
 const STORAGE_KEY = 'filterLabelMap';
-const MAX_AGE = 24 * 60 * 60 * 1000;
+const MAX_AGE = 7 * 24 * 60 * 60 * 1000;
 
 const pruneOldEntries = (map: Record<string, { label: string; timestamp: number }>) => {
   const now = Date.now();


### PR DESCRIPTION
## Summary
- fetch missing filter labels from API when not cached
- extend filter label cache duration to 7 days

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b981b6671c832e86ac61fd8ad84966