### PR TITLE
Use env var for API preconnect

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="preconnect" href="%VITE_APP_API_GRAPHQL_URL%">
+    <link rel="preconnect" href="https://static.hotjar.com">
     <link rel="icon" href="/icons/favicon.ico">
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png"/>
     <link rel="manifest" href="/icons/manifest.json" />


### PR DESCRIPTION
## Summary
- preconnect to API using Vite environment variable

## Testing
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_68b97fcc4a08832e8c03bb3c2597813a

## Summary by Sourcery

Add preconnect resource hints for the API endpoint and Hotjar domain in index.html to improve initial connection performance

Enhancements:
- Preconnect to API endpoint using the VITE_APP_API_GRAPHQL_URL environment variable
- Preconnect to static.hotjar.com