### PR TITLE
Add selector queries for common field lookups

### DIFF
--- a/src/core/contacts/people/configs.ts
+++ b/src/core/contacts/people/configs.ts
@@ -3,7 +3,7 @@ import { FieldType } from '../../../shared/utils/constants.js'
 import { SearchConfig } from "../../../shared/components/organisms/general-search/searchConfig";
 import { ListingConfig } from "../../../shared/components/organisms/general-listing/listingConfig";
 import { ShowConfig, ShowField } from '../../../shared/components/organisms/general-show/showConfig';
-import {companiesQuery, companyAddressesQuery, peopleQuery} from "../../../shared/api/queries/contacts.js"
+import {companiesQuerySelector, companyAddressesQuery, peopleQuery} from "../../../shared/api/queries/contacts.js"
 import { createCompanyMutation, deletePersonMutation } from "../../../shared/api/mutations/contacts.js";
 import { customerLanguagesQuery } from "../../../shared/api/queries/languages.js";
 import { baseFormConfigConstructor as baseCompanyConfigConstructor } from '../companies/configs'
@@ -48,7 +48,7 @@ const getCompanyField = (companyId, t): FormField => {
       label: t('contacts.people.labels.company'),
       labelBy: 'name',
       valueBy: 'id',
-      query: companiesQuery,
+        query: companiesQuerySelector,
       dataKey: 'companies',
       isEdge: true,
       multiple: false,
@@ -135,7 +135,7 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
   filters: [
     {
       type: FieldType.Query,
-      query: companiesQuery,
+        query: companiesQuerySelector,
       label: t('contacts.people.labels.company'),
       name: 'company',
       labelBy: "name",

--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/shopify/ShopifyChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/shopify/ShopifyChannelInfoStep.vue
@@ -8,7 +8,7 @@ import { Icon } from "../../../../../../../shared/components/atoms/icon";
 import { Button } from "../../../../../../../shared/components/atoms/button";
 import { useRouter} from "vue-router";
 import { FieldType, PropertyTypes } from "../../../../../../../shared/utils/constants";
-import { propertiesQuery } from "../../../../../../../shared/api/queries/properties";
+import { propertiesQuerySelector } from "../../../../../../../shared/api/queries/properties";
 import { QueryFormField } from "../../../../../../../shared/components/organisms/general-form/formConfig";
 import {
   FieldQuery
@@ -34,7 +34,7 @@ const propertyField = computed(() => ({
     label: t('properties.properties.show.title'),
     labelBy: 'name',
     valueBy: 'id',
-    query: propertiesQuery,
+    query: propertiesQuerySelector,
     queryVariables: { filter: {'type': {'exact': PropertyTypes.SELECT }, 'isProductType': {'exact': false }} },
     dataKey: 'properties',
     isEdge: true,

--- a/src/core/integrations/integrations/integrations-show/containers/currencies/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/currencies/configs.ts
@@ -2,7 +2,7 @@ import { FieldType } from "../../../../../../shared/utils/constants";
 import {getRemoteCurrencyQuery, remoteCurrenciesQuery} from "../../../../../../shared/api/queries/salesChannels.js";
 import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
 import {FormConfig, FormType} from '../../../../../../shared/components/organisms/general-form/formConfig';
-import {currenciesQuery} from "../../../../../../shared/api/queries/currencies.js";
+import {currenciesQuerySelector} from "../../../../../../shared/api/queries/currencies.js";
 import {currencyOnTheFlyConfig} from "../../../../../settings/currencies/configs";
 import {updateRemoteCurrencyMutation} from "../../../../../../shared/api/mutations/salesChannels.js";
 import {SearchConfig} from "../../../../../../shared/components/organisms/general-search/searchConfig";
@@ -39,7 +39,7 @@ export const currencyEditFormConfigConstructor = (
       label: t("shared.labels.currency"),
       labelBy: "isoCode",
       valueBy: "id",
-      query: currenciesQuery,
+      query: currenciesQuerySelector,
       dataKey: "currencies",
       isEdge: true,
       multiple: false,

--- a/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/default-unit-configurators/containers/amazon-unit-configurators/configs.ts
@@ -1,5 +1,5 @@
 import { FieldType } from "../../../../../../../../shared/utils/constants";
-import { amazonDefaultUnitConfiguratorsQuery, salesChannelViewsQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
+import { amazonDefaultUnitConfiguratorsQuery, salesChannelViewsQuerySelector } from "../../../../../../../../shared/api/queries/salesChannels.js";
 import { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { SearchConfig } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
 
@@ -14,7 +14,7 @@ export const amazonDefaultUnitConfiguratorsSearchConfigConstructor = (t: Functio
       label: t('integrations.show.propertySelectValues.labels.marketplace'),
       labelBy: 'name',
       valueBy: 'id',
-      query: salesChannelViewsQuery,
+      query: salesChannelViewsQuerySelector,
       dataKey: 'salesChannelViews',
       filterable: true,
       isEdge: true,

--- a/src/core/integrations/integrations/integrations-show/containers/general/shopify-general-tab/ShopifyGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/shopify-general-tab/ShopifyGeneralInfoTab.vue
@@ -19,7 +19,7 @@ import { processGraphQLErrors } from "../../../../../../../shared/utils";
 import { cleanShopHostname } from "../../../../configs";
 import apolloClient from "../../../../../../../../apollo-client";
 import {FieldType, PropertyTypes} from "../../../../../../../shared/utils/constants";
-import {propertiesQuery} from "../../../../../../../shared/api/queries/properties";
+import {propertiesQuerySelector} from "../../../../../../../shared/api/queries/properties";
 import {QueryFormField} from "../../../../../../../shared/components/organisms/general-form/formConfig";
 import {
   FieldQuery
@@ -140,7 +140,7 @@ const propertyField = computed(() => ({
     label: t('properties.properties.show.title'),
     labelBy: 'name',
     valueBy: 'id',
-    query: propertiesQuery,
+    query: propertiesQuerySelector,
     queryVariables: { filter: {'type': {'exact': PropertyTypes.SELECT }, 'isProductType': {'exact': false }} },
     dataKey: 'properties',
     isEdge: true,

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/general/languages-and-currencies/LanguagesAndCurrenciesStep.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/general/languages-and-currencies/LanguagesAndCurrenciesStep.vue
@@ -3,7 +3,7 @@ import { onMounted, ref, defineProps, computed, defineExpose, watch } from "vue"
 import { useI18n } from "vue-i18n";
 import { remoteLanguagesQuery, remoteCurrenciesQuery } from "../../../../../../../../../../../shared/api/queries/salesChannels.js";
 import {companyLanguagesQuery} from "../../../../../../../../../../../shared/api/queries/languages.js";
-import {currenciesQuery} from "../../../../../../../../../../../shared/api/queries/currencies.js";
+import {currenciesQuerySelector} from "../../../../../../../../../../../shared/api/queries/currencies.js";
 
 import {FieldType} from "../../../../../../../../../../../shared/utils/constants";
 import apolloClient from "../../../../../../../../../../../../apollo-client";
@@ -46,7 +46,7 @@ const currencyField = computed(() => ({
       label: t("shared.labels.currency"),
       labelBy: "isoCode",
       valueBy: "id",
-      query: currenciesQuery,
+      query: currenciesQuerySelector,
       dataKey: "currencies",
       isEdge: true,
       multiple: false,

--- a/src/core/integrations/integrations/integrations-show/containers/price-lists/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/price-lists/configs.ts
@@ -2,7 +2,7 @@ import { FieldType } from "../../../../../../shared/utils/constants";
 import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { SearchConfig } from "../../../../../../shared/components/organisms/general-search/searchConfig";
 import { FormConfig, FormType } from "../../../../../../shared/components/organisms/general-form/formConfig";
-import { salesPriceListsQuery } from "../../../../../../shared/api/queries/salesPrices.js";
+import { salesPriceListsQuerySelector } from "../../../../../../shared/api/queries/salesPrices.js";
 import { salesChannelIntegrationPricelistsQuery } from "../../../../../../shared/api/queries/salesChannels.js";
 import {
   createSalesChannelIntegrationPricelistMutation,
@@ -39,7 +39,7 @@ export const priceListCreateFormConfigConstructor = (
       labelBy: 'name',
       valueBy: 'id',
       formMapIdentifier: 'id',
-      query: salesPriceListsQuery,
+      query: salesPriceListsQuerySelector,
       dataKey: 'salesPriceLists',
       isEdge: true,
       multiple: false,

--- a/src/core/integrations/integrations/integrations-show/containers/products/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/products/configs.ts
@@ -1,5 +1,5 @@
 import { FieldType } from "../../../../../../shared/utils/constants";
-import { salesChannelViewAssignsQuery, salesChannelViewsQuery } from "../../../../../../shared/api/queries/salesChannels.js";
+import { salesChannelViewAssignsQuery, salesChannelViewsQuerySelector } from "../../../../../../shared/api/queries/salesChannels.js";
 import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { SearchConfig } from "../../../../../../shared/components/organisms/general-search/searchConfig";
 import { deleteSalesChannelViewAssignMutation } from "../../../../../../shared/api/mutations/salesChannels.js";
@@ -21,7 +21,7 @@ export const productsSearchConfigConstructor = (t: Function, salesChannelId: str
       label: t('integrations.show.products.labels.store'),
       labelBy: 'name',
       valueBy: 'id',
-      query: salesChannelViewsQuery,
+      query: salesChannelViewsQuerySelector,
       dataKey: 'salesChannelViews',
       isEdge: true,
       multiple: true,
@@ -39,7 +39,7 @@ export const productsSearchConfigConstructor = (t: Function, salesChannelId: str
       label: t('integrations.show.products.labels.excludeStores'),
       labelBy: 'name',
       valueBy: 'id',
-      query: salesChannelViewsQuery,
+      query: salesChannelViewsQuerySelector,
       dataKey: 'salesChannelViews',
       isEdge: true,
       multiple: false,

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/configs.ts
@@ -1,6 +1,6 @@
 import {FieldType, getPropertyTypeOptions} from "../../../../../../../../shared/utils/constants";
 import { amazonPropertiesQuery, getAmazonPropertyQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
-import { propertiesQuery } from "../../../../../../../../shared/api/queries/properties.js";
+import { propertiesQuerySelector } from "../../../../../../../../shared/api/queries/properties.js";
 import { updateAmazonPropertyMutation } from "../../../../../../../../shared/api/mutations/salesChannels.js";
 import { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { FormConfig, FormType } from '../../../../../../../../shared/components/organisms/general-form/formConfig';
@@ -61,7 +61,7 @@ export const amazonPropertiesSearchConfigConstructor = (t: Function): SearchConf
       label: t('properties.properties.title'),
       labelBy: 'name',
       valueBy: 'id',
-      query: propertiesQuery,
+      query: propertiesQuerySelector,
       dataKey: 'properties',
       filterable: true,
       isEdge: true,

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue
@@ -7,7 +7,7 @@ import { Breadcrumbs } from "../../../../../../../../../shared/components/molecu
 import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
 import { amazonPropertyEditFormConfigConstructor } from "../configs";
 import { FieldType } from "../../../../../../../../../shared/utils/constants";
-import { propertiesQuery } from "../../../../../../../../../shared/api/queries/properties.js";
+import { propertiesQuerySelector } from "../../../../../../../../../shared/api/queries/properties.js";
 import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
 import { Label } from "../../../../../../../../../shared/components/atoms/label";
@@ -119,7 +119,7 @@ const handleSetData = (data: any) => {
     help: t('integrations.show.properties.help.property'),
     labelBy: 'name',
     valueBy: 'id',
-    query: propertiesQuery,
+    query: propertiesQuerySelector,
     queryVariables: { filter: { type: { exact: propertyType } } },
     dataKey: 'properties',
     isEdge: true,

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/BulkAmazonPropertySelectValueAssigner.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/BulkAmazonPropertySelectValueAssigner.vue
@@ -5,7 +5,7 @@ import { Icon } from '../../../../../../../../shared/components/atoms/icon';
 import { Label } from '../../../../../../../../shared/components/atoms/label';
 import { FieldQuery } from '../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query';
 import { Button } from '../../../../../../../../shared/components/atoms/button';
-import { propertiesQuery, propertySelectValuesQuerySimpleSelector } from '../../../../../../../../shared/api/queries/properties';
+import { propertiesQuerySelector, propertySelectValuesQuerySimpleSelector } from '../../../../../../../../shared/api/queries/properties';
 import apolloClient from '../../../../../../../../../apollo-client';
 import {FieldType, PropertyTypes} from '../../../../../../../../shared/utils/constants';
 import { QueryFormField } from '../../../../../../../../shared/components/organisms/general-form/formConfig';
@@ -31,7 +31,7 @@ const propertyField = {
   label: t('properties.properties.show.title'),
   labelBy: 'name',
   valueBy: 'id',
-  query: propertiesQuery,
+  query: propertiesQuerySelector,
   queryVariables: { filter: { isProductType: { exact: false }, type: {exact: PropertyTypes.SELECT} } },
   dataKey: 'properties',
   isEdge: true,
@@ -46,7 +46,7 @@ watch(selectedProperty, async (newPropId) => {
   if (!newPropId) return;
 
   const { data } = await apolloClient.query({
-    query: propertiesQuery,
+    query: propertiesQuerySelector,
     variables: { filter: { id: { exact: newPropId } } },
   });
 

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
@@ -4,7 +4,7 @@ import {
   getAmazonPropertySelectValueQuery,
   amazonPropertiesQuery,
   amazonChannelsQuery,
-  salesChannelViewsQuery
+  salesChannelViewsQuerySelector
 } from "../../../../../../../../shared/api/queries/salesChannels.js";
 import { propertySelectValuesQuery } from "../../../../../../../../shared/api/queries/properties.js";
 import { selectValueOnTheFlyConfig } from "../../../../../../../properties/property-select-values/configs";
@@ -62,7 +62,7 @@ export const amazonPropertySelectValuesSearchConfigConstructor = (t: Function, s
       label: t('integrations.show.propertySelectValues.labels.marketplace'),
       labelBy: 'name',
       valueBy: 'id',
-      query: salesChannelViewsQuery,
+      query: salesChannelViewsQuerySelector,
       dataKey: 'salesChannelViews',
       filterable: true,
       isEdge: true,

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/ImportedAmazonProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/ImportedAmazonProductType.vue
@@ -7,7 +7,7 @@ import GeneralTemplate from "../../../../../../../../../shared/templates/General
 import {TextInput} from "../../../../../../../../../shared/components/atoms/input-text";
 import {Button} from "../../../../../../../../../shared/components/atoms/button";
 import {FieldQuery} from "../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
-import {salesChannelViewsQuery} from "../../../../../../../../../shared/api/queries/salesChannels.js";
+import {salesChannelViewsQuerySelector} from "../../../../../../../../../shared/api/queries/salesChannels.js";
 import {suggestAmazonProductTypeMutation, updateAmazonProductTypeMutation} from "../../../../../../../../../shared/api/mutations/salesChannels.js";
 import {listingQuery} from '../configs';
 import {Link} from "../../../../../../../../../shared/components/atoms/link";
@@ -45,7 +45,7 @@ const marketplaceField: QueryFormField = {
   label: t('integrations.show.propertySelectValues.labels.marketplace'),
   labelBy: 'name',
   valueBy: 'id',
-  query: salesChannelViewsQuery,
+  query: salesChannelViewsQuerySelector,
   dataKey: 'salesChannelViews',
   isEdge: true,
   multiple: false,

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/RemotelyMappedAmazonProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/amazon-product-types/containers/RemotelyMappedAmazonProductType.vue
@@ -10,7 +10,7 @@ import {amazonProductTypeEditFormConfigConstructor, listingQuery} from "../confi
 import apolloClient from "../../../../../../../../../../apollo-client";
 import {
   productPropertiesRulesQuery,
-  propertiesQuery
+  propertiesQuerySelector
 } from "../../../../../../../../../shared/api/queries/properties.js";
 import {Link} from "../../../../../../../../../shared/components/atoms/link";
 import {Button} from "../../../../../../../../../shared/components/atoms/button";
@@ -102,7 +102,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
 
 const fetchProductType = async () => {
   const {data} = await apolloClient.query({
-    query: propertiesQuery,
+    query: propertiesQuerySelector,
     variables: {filter: {isProductType: {exact: true}}}
   })
 

--- a/src/core/inventory/inventory/configs.ts
+++ b/src/core/inventory/inventory/configs.ts
@@ -3,7 +3,7 @@ import {FieldType, INVENTORY_MOVEMENTS_MODEL_CODES, ProductType} from '../../../
 import { SearchConfig } from "../../../shared/components/organisms/general-search/searchConfig";
 import {ListingConfig} from "../../../shared/components/organisms/general-listing/listingConfig";
 import { inventoriesQuery, inventoryLocationsQuery } from "../../../shared/api/queries/inventory.js"
-import {productsQuery} from "../../../shared/api/queries/products.js"
+import {productsQuerySelector} from "../../../shared/api/queries/products.js"
 import {createInventoryLocationMutation, deleteInventoryMutation} from "../../../shared/api/mutations/inventory.js";
 import {ShowConfig, ShowField} from "../../../shared/components/organisms/general-show/showConfig";
 import {baseFormConfigConstructor as baseStocklocationConfigConstructor } from '../inventory-location/configs'
@@ -39,7 +39,7 @@ export const getProductField = (productId, t): FormField => {
         label:  t('shared.labels.product'),
         labelBy: 'name',
         valueBy: 'id',
-        query: productsQuery,
+        query: productsQuerySelector,
         queryVariables: {"filter": {"id": {"exact": productId}}},
         dataKey: 'products',
         isEdge: true,
@@ -55,7 +55,7 @@ export const getProductField = (productId, t): FormField => {
         label:  t('shared.labels.product'),
         labelBy: 'name',
         valueBy: 'id',
-        query: productsQuery,
+        query: productsQuerySelector,
         dataKey: 'products',
         isEdge: true,
         multiple: false,

--- a/src/core/products/ean-codes/configs.ts
+++ b/src/core/products/ean-codes/configs.ts
@@ -4,7 +4,7 @@ import { SearchConfig } from "../../../shared/components/organisms/general-searc
 import {ListingConfig} from "../../../shared/components/organisms/general-listing/listingConfig";
 import {ShowField} from "../../../shared/components/organisms/general-show/showConfig";
 import { eanCodesQuery } from "../../../shared/api/queries/eanCodes.js"
-import { productsQuery } from "../../../shared/api/queries/products.js"
+import { productsQuerySelector } from "../../../shared/api/queries/products.js"
 import {
     deleteEanCodeMutation,
     deleteEanCodesMutation,
@@ -66,7 +66,7 @@ export const baseFormConfigConstructor = (
         label:  t('shared.labels.product'),
         labelBy: 'name',
         valueBy: 'id',
-        query: productsQuery,
+        query: productsQuerySelector,
         dataKey: 'products',
         isEdge: true,
         multiple: false,

--- a/src/core/products/hs-codes/configs.ts
+++ b/src/core/products/hs-codes/configs.ts
@@ -4,7 +4,7 @@ import { SearchConfig } from "../../../shared/components/organisms/general-searc
 import { ListingConfig } from "../../../shared/components/organisms/general-listing/listingConfig";
 import { ShowConfig } from "../../../shared/components/organisms/general-show/showConfig";
 import { hsCodesQuery } from "../../../shared/api/queries/hsCodes.js"
-import { productsQuery } from "../../../shared/api/queries/products.js"
+import { productsQuerySelector } from "../../../shared/api/queries/products.js"
 import { deleteHsCodeMutation } from "../../../shared/api/mutations/hsCodes.js";
 import { hsCodeSubscription } from "../../../shared/api/subscriptions/hsCodes.js";
 
@@ -39,7 +39,7 @@ const getProductField = (productId, t, type): FormField | null => {
         label:  t('shared.labels.product'),
         labelBy: 'name',
         valueBy: 'id',
-        query: productsQuery,
+        query: productsQuerySelector,
         dataKey: 'products',
         isEdge: true,
         multiple: true,

--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -9,12 +9,12 @@ import { FieldType, InspectorStatus, InspectorStatusType, ProductType, Url } fro
 import { OrderType, SearchConfig, SearchFilter } from "../../../shared/components/organisms/general-search/searchConfig";
 import { ListingConfig } from "../../../shared/components/organisms/general-listing/listingConfig";
 import { productsQuery } from "../../../shared/api/queries/products.js"
-import { vatRatesQuery } from "../../../shared/api/queries/vatRates.js";
+import { vatRatesQuerySelector } from "../../../shared/api/queries/vatRates.js";
 import { createVatRateMutation } from "../../../shared/api/mutations/vatRates.js";
 import { baseFormConfigConstructor as baseVatRateConfigConstructor } from '../../settings/vat-rates/configs'
 import { Badge, Icon } from "../../../shared/components/organisms/general-show/showConfig";
 import { propertySelectValuesQuerySelector } from "../../../shared/api/queries/properties.js";
-import { amazonChannelsQuerySelector, salesChannelViewsQuery } from "../../../shared/api/queries/salesChannels.js";
+import { amazonChannelsQuerySelector, salesChannelViewsQuerySelector } from "../../../shared/api/queries/salesChannels.js";
 import { deleteProductsMutation } from "../../../shared/api/mutations/products.js";
 
 export const vatRateOnTheFlyConfig = (t: Function):CreateOnTheFly => ({
@@ -130,7 +130,7 @@ export const getVatRateField = (t): QueryFormField => {
       label: t('products.products.labels.vatRate'),
       labelBy: 'name',
       valueBy: 'id',
-      query: vatRatesQuery,
+        query: vatRatesQuerySelector,
       dataKey: 'vatRates',
       isEdge: true,
       multiple: false,
@@ -162,7 +162,7 @@ const getFields = (type, t): FormField[] => {
       label: t('products.products.labels.vatRate'),
       labelBy: 'name',
       valueBy: 'id',
-      query: vatRatesQuery,
+        query: vatRatesQuerySelector,
       dataKey: 'vatRates',
       isEdge: true,
       multiple: false,
@@ -206,7 +206,7 @@ export const searchConfigConstructor = (t: Function, hasAmazon: boolean = false)
      {
       type: FieldType.Query,
       name: 'vatRate',
-      query: vatRatesQuery,
+        query: vatRatesQuerySelector,
       label: t('products.products.labels.vatRate'),
       labelBy: "name",
       valueBy: "id",
@@ -233,7 +233,7 @@ export const searchConfigConstructor = (t: Function, hasAmazon: boolean = false)
     {
       type: FieldType.Query,
       name: 'assignedToSalesChannelViewId',
-      query: salesChannelViewsQuery,
+      query: salesChannelViewsQuerySelector,
       label: t('integrations.salesChannel.labels.assignedToSalesChannelView'),
       labelBy: 'name',
       valueBy: 'id',
@@ -246,7 +246,7 @@ export const searchConfigConstructor = (t: Function, hasAmazon: boolean = false)
     {
       type: FieldType.Query,
       name: 'notAssignedToSalesChannelViewId',
-      query: salesChannelViewsQuery,
+      query: salesChannelViewsQuerySelector,
       label: t('integrations.salesChannel.labels.notAssignedToSalesChannelView'),
       labelBy: 'name',
       valueBy: 'id',

--- a/src/core/products/products/product-create/containers/alias-options-step/AliasOptionsStep.vue
+++ b/src/core/products/products/product-create/containers/alias-options-step/AliasOptionsStep.vue
@@ -6,7 +6,7 @@ import { FieldType, ProductType } from "../../../../../../shared/utils/constants
 import { Label } from "../../../../../../shared/components/atoms/label";
 import { Toggle } from "../../../../../../shared/components/atoms/toggle";
 import { FieldQuery } from "../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
-import { productsQuery } from "../../../../../../shared/api/queries/products.js";
+import { productsQuerySelector } from "../../../../../../shared/api/queries/products.js";
 import { QueryFormField } from "../../../../../../shared/components/organisms/general-form/formConfig";
 
 const props = defineProps<{ form: FormType, preselectedParentId?: string | null, disableParentSelector?: boolean }>();
@@ -18,7 +18,7 @@ const aliasParentProductField = computed<QueryFormField>(() => ({
   label: t('products.products.create.wizard.stepAlias.labels.aliasParent'),
   labelBy: 'name',
   valueBy: 'id',
-  query: productsQuery,
+  query: productsQuerySelector,
   dataKey: 'products',
   isEdge: true,
   multiple: false,

--- a/src/core/products/products/product-create/containers/general-info-step/GeneralInfoStep.vue
+++ b/src/core/products/products/product-create/containers/general-info-step/GeneralInfoStep.vue
@@ -7,7 +7,7 @@ import {PrimaryButton} from "../../../../../../shared/components/atoms/button-pr
 import {FieldType, ProductType} from "../../../../../../shared/utils/constants";
 import {Label} from "../../../../../../shared/components/atoms/label";
 import {FieldQuery} from "../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
-import { propertiesQuery, propertySelectValuesQuery } from "../../../../../../shared/api/queries/properties.js";
+import { propertiesQuerySelector, propertySelectValuesQuery } from "../../../../../../shared/api/queries/properties.js";
 import apolloClient from "../../../../../../../apollo-client";
 import {Selector} from "../../../../../../shared/components/atoms/selector";
 import {QueryFormField} from "../../../../../../shared/components/organisms/general-form/formConfig";
@@ -27,7 +27,7 @@ const isGenerateDisabled = computed(() => {
 const fetchProductType = async () => {
 
     const {data} = await apolloClient.query({
-      query: propertiesQuery,
+      query: propertiesQuerySelector,
       variables: {filter: {isProductType: { exact: true } }}
     })
 

--- a/src/core/products/products/product-show/containers/tabs/general/ProductEditView.vue
+++ b/src/core/products/products/product-show/containers/tabs/general/ProductEditView.vue
@@ -12,7 +12,7 @@ import { Product, vatRateOnTheFlyConfig} from "../../../../configs";
 import { Toast} from "../../../../../../../shared/modules/toast";
 import {FieldValue} from "../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-value";
 import {PrimaryButton} from "../../../../../../../shared/components/atoms/button-primary";
-import {vatRatesQuery} from "../../../../../../../shared/api/queries/vatRates.js";
+import {vatRatesQuerySelector} from "../../../../../../../shared/api/queries/vatRates.js";
 import {FieldQuery} from "../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
 import {FieldCheckbox} from "../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-checkbox";
 import {SecondaryButton} from "../../../../../../../shared/components/atoms/button-secondary";
@@ -56,7 +56,7 @@ const fields = {
     label: t('products.products.labels.vatRate'),
     labelBy: 'name',
     valueBy: 'id',
-    query: vatRatesQuery,
+    query: vatRatesQuerySelector,
     dataKey: 'vatRates',
     isEdge: true,
     multiple: false,

--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -8,7 +8,7 @@ import {
   getPropertySelectValueQuery,
   productPropertiesQuery,
   productPropertiesRulesQuery, productPropertyTextTranslationsQuery,
-  propertiesQuery
+  propertiesQuerySelector
 } from "../../../../../../../shared/api/queries/properties.js";
 import {ConfigTypes, ProductType, PropertyTypes} from "../../../../../../../shared/utils/constants";
 import {ValueInput} from "./value-input";
@@ -256,7 +256,7 @@ const setInitialValues = async (propertiesIds) => {
 const fetchRequiredProductType = async () => {
 
   const {data} = await apolloClient.query({
-    query: propertiesQuery,
+    query: propertiesQuerySelector,
     variables: {filter: {isProductType: {exact: true}}},
     fetchPolicy: 'cache-first'
   })

--- a/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
+++ b/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
@@ -10,7 +10,7 @@ import { salesPricesQuery } from "../../../../../../../shared/api/queries/salesP
 import { TextInput } from "../../../../../../../shared/components/atoms/input-text";
 import { createSalesPriceMutation, updateSalesPriceMutation } from "../../../../../../../shared/api/mutations/salesPrices.js";
 import { Toast } from "../../../../../../../shared/modules/toast";
-import { currenciesQuery } from "../../../../../../../shared/api/queries/currencies.js";
+import { currenciesQuerySelector } from "../../../../../../../shared/api/queries/currencies.js";
 import {TextInputPrepend} from "../../../../../../../shared/components/atoms/input-text-prepend";
 
 const { t } = useI18n();
@@ -30,7 +30,7 @@ const defaultCurrency = ref({ id: '', isoCode: '', symbol: '' });
 
 const getDefaultCurrency = async () => {
   const { data } = await apolloClient.query({
-    query: currenciesQuery,
+    query: currenciesQuerySelector,
     variables: { filter: { isDefaultCurrency: { exact: true } } },
   });
 

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variation-create/CreateForm.vue
@@ -5,7 +5,7 @@ import debounce from 'lodash.debounce';
 import { Product } from "../../../../../../configs";
 import { useI18n } from "vue-i18n";
 import { ProductType, variationTypes } from "../../../../../../../../../shared/utils/constants";
-import { productsQuery } from "../../../../../../../../../shared/api/queries/products.js";
+import { productsQuerySelector } from "../../../../../../../../../shared/api/queries/products.js";
 import { TextInput } from "../../../../../../../../../shared/components/atoms/input-text";
 import { Selector } from "../../../../../../../../../shared/components/atoms/selector";
 import { VariationForm } from "./VariationCreate.vue";
@@ -51,7 +51,7 @@ const fetchData = async () => {
   }
 
   const { data } = await apolloClient.query({
-    query: productsQuery,
+    query: productsQuerySelector,
     variables: { filter },
     fetchPolicy: 'cache-first',
   });

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -20,7 +20,7 @@ import { Selector } from "../../../../../../../../../shared/components/atoms/sel
 import type { QueryFormField } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
 import { Pagination } from "../../../../../../../../../shared/components/molecules/pagination";
 import apolloClient from '../../../../../../../../../../apollo-client'
-import { propertiesQuery, productPropertiesQuery, productPropertiesRulesQuery, productPropertyTextTranslationsQuery, propertySelectValuesQuerySimpleSelector } from '../../../../../../../../../shared/api/queries/properties.js'
+import { propertiesQuerySelector, productPropertiesQuery, productPropertiesRulesQuery, productPropertyTextTranslationsQuery, propertySelectValuesQuerySimpleSelector } from '../../../../../../../../../shared/api/queries/properties.js'
 import { translationLanguagesQuery } from '../../../../../../../../../shared/api/queries/languages.js'
 import { bulkCreateProductPropertiesMutation, bulkUpdateProductPropertiesMutation, deleteProductPropertiesMutation } from '../../../../../../../../../shared/api/mutations/properties.js'
 import { Toast } from "../../../../../../../../../shared/modules/toast";
@@ -327,7 +327,7 @@ const queryKey = computed(() =>
 
 const fetchProperties = async () => {
   const { data: typeData } = await apolloClient.query({
-    query: propertiesQuery,
+    query: propertiesQuerySelector,
     variables: { filter: { isProductType: { exact: true } } },
     fetchPolicy: 'cache-first',
   })

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/assign-create/WebsiteAssignCreate.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/assign-create/WebsiteAssignCreate.vue
@@ -2,7 +2,7 @@
 import {onMounted, ref, Ref, watch} from 'vue';
 import { useI18n } from "vue-i18n";
 import { Product } from "../../../../../../configs";
-import { salesChannelViewsQuery } from "../../../../../../../../../shared/api/queries/salesChannels.js";
+import { salesChannelViewsQuerySelector } from "../../../../../../../../../shared/api/queries/salesChannels.js";
 import { createSalesChannelViewAssignMutation } from "../../../../../../../../../shared/api/mutations/salesChannels.js";
 import { Selector } from "../../../../../../../../../shared/components/atoms/selector";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
@@ -31,7 +31,7 @@ const loading = ref(false);
 const fetchViews = async () => {
   loading.value = true;
   const { data } = await apolloClient.query({
-    query: salesChannelViewsQuery,
+    query: salesChannelViewsQuerySelector,
     variables: { filter: { salesChannel: { active: {exact: true} }, NOT: { id: { inList: props.viewsIds } } } },
     fetchPolicy: 'cache-first'
   });

--- a/src/core/properties/product-properties-rule/product-properties-rule-list/ProductPropertiesRuleListController.vue
+++ b/src/core/properties/product-properties-rule/product-properties-rule-list/ProductPropertiesRuleListController.vue
@@ -8,7 +8,7 @@ import GeneralTemplate  from "../../../../shared/templates/GeneralTemplate.vue"
 import { GeneralListing } from "../../../../shared/components/organisms/general-listing";
 import { searchConfigConstructor, listingConfigConstructor, listingQueryKey, listingQuery } from '../configs'
 import apolloClient from "../../../../../apollo-client";
-import {propertiesQuery} from "../../../../shared/api/queries/properties.js";
+import {propertiesQuerySelector} from "../../../../shared/api/queries/properties.js";
 import { onMounted, ref} from "vue";
 
 const { t } = useI18n();
@@ -19,7 +19,7 @@ const listingConfig = listingConfigConstructor(t, true);
 
 const fetchProductType = async () => {
     const {data} = await apolloClient.query({
-      query: propertiesQuery,
+      query: propertiesQuerySelector,
       variables: {filter: {isProductType: { exact: true } }}
     })
 

--- a/src/core/properties/property-select-values/configs.ts
+++ b/src/core/properties/property-select-values/configs.ts
@@ -9,7 +9,7 @@ import {SearchConfig} from "../../../shared/components/organisms/general-search/
 import {ListingConfig} from "../../../shared/components/organisms/general-listing/listingConfig";
 import {
     getPropertySelectValueQuery,
-    propertiesQuery,
+    propertiesQuerySelector,
     propertySelectValuesQuery
 } from "../../../shared/api/queries/properties.js";
 import {
@@ -161,7 +161,7 @@ export const editFormConfigConstructor = (
             label: t('properties.properties.show.title'),
             labelBy: 'name',
             valueBy: 'id',
-            query: propertiesQuery,
+            query: propertiesQuerySelector,
             queryVariables: {filter: {'type': {'exact': PropertyTypes.SELECT}}},
             dataKey: 'properties',
             isEdge: true,
@@ -194,7 +194,7 @@ const getPropertyField = (t, propertyId, type): FormField => {
             label: t('properties.properties.show.title'),
             labelBy: 'name',
             valueBy: 'id',
-            query: propertiesQuery,
+            query: propertiesQuerySelector,
             queryVariables: {filter: {'type': {'inList': [PropertyTypes.SELECT, PropertyTypes.MULTISELECT]}}},
             dataKey: 'properties',
             isEdge: true,
@@ -216,7 +216,7 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
             label: t('properties.properties.show.title'),
             labelBy: 'name',
             valueBy: 'id',
-            query: propertiesQuery,
+            query: propertiesQuerySelector,
             queryVariables: {filter: {'type': {'inList': [PropertyTypes.SELECT, PropertyTypes.MULTISELECT]}}},
             dataKey: 'properties',
             filterable: true,

--- a/src/core/sales/orders/configs.ts
+++ b/src/core/sales/orders/configs.ts
@@ -4,7 +4,7 @@ import {OrderType, SearchConfig} from "../../../shared/components/organisms/gene
 import {ListingConfig} from "../../../shared/components/organisms/general-listing/listingConfig";
 import {NestedTextField, ShowConfig, ShowField} from "../../../shared/components/organisms/general-show/showConfig";
 import {orderItemsQuery, ordersQuery} from "../../../shared/api/queries/salesOrders.js"
-import {companiesQuery, companyInvoiceAddressesQuery, companyShippingAddressesQuery} from "../../../shared/api/queries/contacts.js";
+import {companiesQuerySelector, companyInvoiceAddressesQuery, companyShippingAddressesQuery} from "../../../shared/api/queries/contacts.js";
 import {currenciesQuery} from "../../../shared/api/queries/currencies.js";
 import {orderSubscription} from "../../../shared/api/subscriptions/salesOrders.js";
 import {currencyOnTheFlyConfig} from "../../settings/currencies/configs";
@@ -129,7 +129,7 @@ const getCustomerField = (customerId, source, t): FormField => {
       label: t('contacts.people.labels.customer'),
       labelBy: 'name',
       valueBy: 'id',
-      query: companiesQuery,
+        query: companiesQuerySelector,
       queryVariables: { filter: { 'isInternalCompany': { exact: false } }},
       dataKey: 'companies',
       isEdge: true,
@@ -206,7 +206,7 @@ export const baseFormConfigConstructor = (
       label: t('contacts.companies.labels.internalCompany'),
       labelBy: 'name',
       valueBy: 'id',
-      query: companiesQuery,
+        query: companiesQuerySelector,
       queryVariables: { filter: { 'isInternalCompany': { exact: true} }},
       dataKey: 'companies',
       isEdge: true,
@@ -364,7 +364,7 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
       label: t('contacts.people.labels.customer'),
       labelBy: 'name',
       valueBy: 'id',
-      query: companiesQuery,
+        query: companiesQuerySelector,
       queryVariables: { filter: { 'isInternalCompany': { exact: false } }},
       dataKey: 'companies',
       filterable: true,

--- a/src/core/sales/price-lists/configs.ts
+++ b/src/core/sales/price-lists/configs.ts
@@ -3,8 +3,8 @@ import { FieldType } from '../../../shared/utils/constants.js'
 import { SearchConfig } from "../../../shared/components/organisms/general-search/searchConfig";
 import {ListingConfig} from "../../../shared/components/organisms/general-listing/listingConfig";
 import { salesPriceListsQuery } from "../../../shared/api/queries/salesPrices.js"
-import {companiesQuery} from "../../../shared/api/queries/contacts.js";
-import { currenciesQuery } from "../../../shared/api/queries/currencies.js";
+import {companiesQuerySelector} from "../../../shared/api/queries/contacts.js";
+import { currenciesQuerySelector } from "../../../shared/api/queries/currencies.js";
 import {ShowConfig} from "../../../shared/components/organisms/general-show/showConfig";
 import {salesPriceListSubscription} from "../../../shared/api/subscriptions/salesPrices.js";
 import {
@@ -49,7 +49,7 @@ const getCustomerField = (customerId, t, type): FormField | null => {
         label: t('sales.customers.title'),
         labelBy: 'name',
         valueBy: 'id',
-        query: companiesQuery,
+        query: companiesQuerySelector,
         queryVariables: { filter: { 'isInternalCompany': { exact: false } }},
         dataKey: 'companies',
         isEdge: true,
@@ -85,7 +85,7 @@ export const getFields = (customerId, t, type, showPcnt: boolean = true): FormFi
       label: t('shared.labels.currency'),
       labelBy: 'isoCode',
       valueBy: 'id',
-      query: currenciesQuery,
+      query: currenciesQuerySelector,
       dataKey: 'currencies',
       isEdge: true,
       multiple: false,
@@ -213,7 +213,7 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
     },
     {
       type: FieldType.Query,
-      query: currenciesQuery,
+      query: currenciesQuerySelector,
       dataKey: 'currencies',
       name: 'currency',
       label: t('shared.labels.currency'),

--- a/src/core/sales/price-lists/price-list-show/containers/items/configs.ts
+++ b/src/core/sales/price-lists/price-list-show/containers/items/configs.ts
@@ -4,7 +4,7 @@ import { SearchConfig } from "../../../../../../shared/components/organisms/gene
 import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { deleteSalesPriceListItemMutation} from "../../../../../../shared/api/mutations/salesPrices.js";
 import { salesPriceListItemsQuery } from "../../../../../../shared/api/queries/salesPrices.js";
-import { productsQuery } from "../../../../../../shared/api/queries/products.js";
+import { productsQuerySelector } from "../../../../../../shared/api/queries/products.js";
 
 export const baseFormConfigConstructor = (
   t: Function,
@@ -28,7 +28,7 @@ export const baseFormConfigConstructor = (
       label: t('shared.labels.product'),
       labelBy: 'name',
       valueBy: 'id',
-      query: productsQuery,
+      query: productsQuerySelector,
       dataKey: 'products',
       queryVariables:
         productsId.length > 0

--- a/src/core/settings/currencies/configs.ts
+++ b/src/core/settings/currencies/configs.ts
@@ -2,7 +2,7 @@ import {CreateOnTheFly, FormConfig, FormField, FormType} from '../../../shared/c
 import { FieldType } from '../../../shared/utils/constants.js'
 import { SearchConfig } from "../../../shared/components/organisms/general-search/searchConfig";
 import { ListingConfig } from "../../../shared/components/organisms/general-listing/listingConfig";
-import {currenciesQuery, publicCurrenciesQuery} from "../../../shared/api/queries/currencies.js"
+import {currenciesQuery, currenciesQuerySelector, publicCurrenciesQuery} from "../../../shared/api/queries/currencies.js"
 import {createCurrencyMutation, deleteCurrencyMutation} from "../../../shared/api/mutations/currencies.js";
 
 export const getCurrencyFields = (t, isEdit: boolean = false): FormField[] => {
@@ -76,7 +76,7 @@ export const getNonDefaultFields = (t): FormField[] => {
       label:  t('settings.currencies.labels.inheritsFrom'),
       labelBy: 'name',
       valueBy: 'id',
-      query: currenciesQuery,
+      query: currenciesQuerySelector,
       dataKey: 'currencies',
       isEdge: true,
       multiple: false,

--- a/src/core/settings/internal-companies/configs.ts
+++ b/src/core/settings/internal-companies/configs.ts
@@ -8,7 +8,7 @@ import { deleteCompanyMutation } from "../../../shared/api/mutations/contacts.js
 import { getCompanySubscription } from "../../../shared/api/subscriptions/contacts.js";
 import { customerLanguagesQuery } from "../../../shared/api/queries/languages.js";
 import {currencyOnTheFlyConfig} from "../currencies/configs";
-import {currenciesQuery} from "../../../shared/api/queries/currencies.js";
+import {currenciesQuerySelector} from "../../../shared/api/queries/currencies.js";
 
 export const baseFormConfigConstructor = (
   t: Function,
@@ -64,7 +64,7 @@ export const baseFormConfigConstructor = (
       label: t('shared.labels.currency'),
       labelBy: 'isoCode',
       valueBy: 'id',
-      query: currenciesQuery,
+      query: currenciesQuerySelector,
       dataKey: 'currencies',
       isEdge: true,
       multiple: false,

--- a/src/shared/api/queries/contacts.js
+++ b/src/shared/api/queries/contacts.js
@@ -29,6 +29,27 @@ query Companies($first: Int, $last: Int, $after: String, $before: String, $order
 }
 `;
 
+export const companiesQuerySelector = gql`
+query Companies($first: Int, $last: Int, $after: String, $before: String, $order: CompanyOrder, $filter: CompanyFilter) {
+  companies(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+    edges {
+      node {
+        id
+        name
+      }
+      cursor
+    }
+    totalCount
+    pageInfo {
+      endCursor
+      startCursor
+      hasNextPage
+      hasPreviousPage
+    }
+  }
+}
+`;
+
 export const getCompanyQuery = gql`
 query getCompany ($id: GlobalID!) {
   company(id: $id) {

--- a/src/shared/api/queries/currencies.js
+++ b/src/shared/api/queries/currencies.js
@@ -29,6 +29,27 @@ export const currenciesQuery = gql`
         hasNextPage
         hasPreviousPage
       }
+  }
+}
+`;
+
+export const currenciesQuerySelector = gql`
+  query Currencies($first: Int, $last: Int, $after: String, $before: String, $order: CurrencyOrder, $filter: CurrencyFilter) {
+    currencies(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          isoCode
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
     }
   }
 `;

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -28,6 +28,27 @@ query Products($first: Int, $last: Int, $after: String, $before: String, $order:
   }
 `;
 
+export const productsQuerySelector = gql`
+query Products($first: Int, $last: Int, $after: String, $before: String, $order: ProductOrder, $filter: ProductFilter) {
+    products(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          name
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 export const productsQuery = gql`  
 query Products($first: Int, $last: Int, $after: String, $before: String, $order: ProductOrder, $filter: ProductFilter) {
     products(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {

--- a/src/shared/api/queries/properties.js
+++ b/src/shared/api/queries/properties.js
@@ -25,6 +25,27 @@ query Properties($first: Int, $last: Int, $after: String, $before: String, $orde
         hasNextPage
         hasPreviousPage
       }
+  }
+}
+`;
+
+export const propertiesQuerySelector = gql`
+query Properties($first: Int, $last: Int, $after: String, $before: String, $order: PropertyOrder, $filter: PropertyFilter) {
+    properties(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          name
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
     }
   }
 `;

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -482,6 +482,27 @@ export const salesChannelViewsQuery = gql`
   }
 `;
 
+export const salesChannelViewsQuerySelector = gql`
+  query SalesChannelViews($first: Int, $last: Int, $after: String, $before: String, $order: SalesChannelViewOrder, $filter: SalesChannelViewFilter) {
+    salesChannelViews(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          name
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 export const getSalesChannelViewQuery = gql`
   query getSalesChannelView($id: GlobalID!) {
     salesChannelView(id: $id) {

--- a/src/shared/api/queries/salesPrices.js
+++ b/src/shared/api/queries/salesPrices.js
@@ -88,6 +88,27 @@ export const salesPriceListsQuery = gql`
         hasNextPage
         hasPreviousPage
       }
+  }
+  }
+`;
+
+export const salesPriceListsQuerySelector = gql`
+  query SalesPriceLists($first: Int, $last: Int, $after: String, $before: String, $order: SalesPriceListOrder, $filter: SalesPriceListFilter) {
+    salesPriceLists(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          name
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
     }
   }
 `;

--- a/src/shared/api/queries/vatRates.js
+++ b/src/shared/api/queries/vatRates.js
@@ -22,6 +22,27 @@ export const vatRatesQuery = gql`
   }
 `;
 
+export const vatRatesQuerySelector = gql`
+  query VatRates($first: Int, $last: Int, $after: String, $before: String, $order: VatRateOrder, $filter: VatRateFilter) {
+    vatRates(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          name
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 export const getVatRateQuery = gql`
   query getVatRate($id: GlobalID!) {
     vatRate(id: $id) {

--- a/src/shared/components/organisms/bulk=product-property-assigner/BulkProductPropertyAssigner.vue
+++ b/src/shared/components/organisms/bulk=product-property-assigner/BulkProductPropertyAssigner.vue
@@ -9,7 +9,7 @@ import {TextEditor} from '../../atoms/input-text-editor';
 import {Toggle} from '../../atoms/toggle';
 import {DateInput} from '../../atoms/input-date';
 import {format} from 'date-fns';
-import {propertiesQuery, propertySelectValuesQuerySimpleSelector} from '../../../api/queries/properties';
+import {propertiesQuery, propertiesQuerySelector, propertySelectValuesQuerySimpleSelector} from '../../../api/queries/properties';
 import {translationLanguagesQuery} from '../../../api/queries/languages';
 import apolloClient from "../../../../../apollo-client";
 import {FieldType, PropertyTypes} from "../../../utils/constants";
@@ -43,7 +43,7 @@ const propertyField = computed(() => ({
   label: t('properties.properties.show.title'),
   labelBy: 'name',
   valueBy: 'id',
-  query: propertiesQuery,
+  query: propertiesQuerySelector,
   queryVariables: {filter: {isProductType: {exact: false}}},
   dataKey: 'properties',
   isEdge: true,

--- a/src/shared/components/organisms/product-properties-configurator/ProductPropertiesConfigurator.vue
+++ b/src/shared/components/organisms/product-properties-configurator/ProductPropertiesConfigurator.vue
@@ -7,7 +7,7 @@ import {TextInput} from '../../atoms/input-text';
 import {Pagination} from '../../molecules/pagination';
 import debounce from 'lodash.debounce';
 import apolloClient from '../../../../../apollo-client';
-import {getPropertySelectValueQuery, propertiesQuery} from '../../../api/queries/properties.js';
+import {getPropertySelectValueQuery, propertiesQuerySelector} from '../../../api/queries/properties.js';
 import {AddPropertyModal} from "./containers/add-property-modal";
 import {Badge} from "../../atoms/badge";
 import {getPropertyTypeBadgeMap} from "../../../../core/properties/properties/configs";
@@ -76,7 +76,7 @@ const fetchData = async () => {
   };
 
   const {data} = await apolloClient.query({
-    query: propertiesQuery,
+    query: propertiesQuerySelector,
     variables: variables,
     fetchPolicy: 'cache-first'
   });


### PR DESCRIPTION
## Summary
- add selector variants for product, property, currency, sales channel view, and price list queries
- update forms and filters to use minimal selector queries for faster lookups

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b980cfc11c832ebd267c8fee8e25f2