### PR TITLE
refactor: trim product query fields

### DIFF
--- a/src/core/dashboard/dashboard/containers/onboarding-cards/OnboardingCards.vue
+++ b/src/core/dashboard/dashboard/containers/onboarding-cards/OnboardingCards.vue
@@ -2,7 +2,7 @@
 import { defineEmits, defineProps, onMounted, ref, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { OnboardingCard } from './../onboarding-card';
-import { productsQuery } from "../../../../../shared/api/queries/products.js";
+import { productsQuerySelector } from "../../../../../shared/api/queries/products.js";
 import { membersQuery } from "../../../../../shared/api/queries/me.js";
 import { Card } from "../../../../../shared/components/atoms/card";
 import {VOnboardingWrapper, useVOnboarding, StepEntity} from 'v-onboarding';
@@ -57,7 +57,7 @@ const fetchProductType = async () => {
 
 const fetchLastCreatedProduct = async () => {
   const { data } = await apolloClient.query({
-    query: productsQuery,
+    query: productsQuerySelector,
     variables: {
       filter: { excludeDemoData: true, type: { exact: ProductType.Simple } },
       order: { createdAt: OrderType.DESC },
@@ -117,7 +117,7 @@ const cards = computed((): OnboardingCardObject[] => [
     key: 'product',
     title: t('dashboard.onboarding.cards.product.title'),
     path: 'products.products.create',
-    query: productsQuery,
+    query: productsQuerySelector,
     variables: productsFilter,
     dependencies: ['createProductType']
   },

--- a/src/core/sales/orders/configs.ts
+++ b/src/core/sales/orders/configs.ts
@@ -9,7 +9,7 @@ import {currenciesQuery} from "../../../shared/api/queries/currencies.js";
 import {orderSubscription} from "../../../shared/api/subscriptions/salesOrders.js";
 import {currencyOnTheFlyConfig} from "../../settings/currencies/configs";
 import { createOrderItemsMutation, updateOrderItemMutation, deleteOrderItemsMutation } from "../../../shared/api/mutations/salesOrders.js";
-import { productsQuery } from "../../../shared/api/queries/products.js";
+import { productsQuerySelector } from "../../../shared/api/queries/products.js";
 
 export const getStatusOptions = (t) => [
   { name: t('sales.orders.labels.status.choices.draft'), code: OrderStatus.DRAFT },
@@ -297,7 +297,7 @@ export const baseFormConfigConstructor = (
           label: t('shared.labels.product'),
           labelBy: 'name',
           valueBy: 'id',
-          query: productsQuery,
+          query: productsQuerySelector,
           dataKey: 'products',
           isEdge: true,
           multiple: false,

--- a/src/core/sales/orders/order-show/containers/items/configs.ts
+++ b/src/core/sales/orders/order-show/containers/items/configs.ts
@@ -4,7 +4,7 @@ import { SearchConfig } from "../../../../../../shared/components/organisms/gene
 import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { deleteOrderItemMutation} from "../../../../../../shared/api/mutations/salesOrders.js";
 import { orderItemsQuery } from "../../../../../../shared/api/queries/salesOrders.js";
-import { productsQuery } from "../../../../../../shared/api/queries/products.js";
+import { productsQuerySelector } from "../../../../../../shared/api/queries/products.js";
 
 export const baseFormConfigConstructor = (
   t: Function,
@@ -33,7 +33,7 @@ export const baseFormConfigConstructor = (
       label:  t('shared.labels.product'),
       labelBy: 'name',
       valueBy: 'id',
-      query: productsQuery,
+      query: productsQuerySelector,
       queryVariables: productsId.length > 0
       ? {
           filter: {

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -7,11 +7,8 @@ query Products($first: Int, $last: Int, $after: String, $before: String, $order:
       edges {
         node {
           id
-          sku
           name
           active
-          type
-          proxyId
           thumbnailUrl
           inspectorStatus
         }
@@ -59,7 +56,6 @@ query Products($first: Int, $last: Int, $after: String, $before: String, $order:
           name
           active
           type
-          proxyId
           thumbnailUrl
           percentageInspectorStatus {
             percentage
@@ -69,13 +65,7 @@ query Products($first: Int, $last: Int, $after: String, $before: String, $order:
               completed
             }
           }
-          vatRate {
-            id
-            name
-            rate
-          }
-          allowBackorder
-        
+
         }
         cursor
       }


### PR DESCRIPTION
## Summary
- reduce product GraphQL queries to only needed fields
- use minimal product selectors in order and onboarding flows

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b99335a8ac832eb6bf7ecc44fd212b

## Summary by Sourcery

Trim product GraphQL queries to only fetch required fields and update onboarding cards and order-related configurations to use the new minimal productsQuerySelector.

Enhancements:
- Simplify product GraphQL queries by removing unneeded fields (sku, type, proxyId, vatRate, allowBackorder)
- Introduce a productsQuerySelector with minimal fields and migrate onboarding and order flows to use it instead of productsQuery