### PR TITLE
Use network-only fetchPolicy for translations

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -87,7 +87,7 @@ const setFormAndMutation = async (language, channel) => {
       const { data } = await apolloClient.query({
         query: getProductContentByLanguageAndDefaultQuery,
         variables: { languageCode: language, productId: props.product.id },
-        fetchPolicy: 'cache-first'
+        fetchPolicy: 'network-only'
       });
 
       if (data && data.productTranslations.edges.length === 1) {
@@ -120,7 +120,7 @@ const setFormAndMutation = async (language, channel) => {
           productId: props.product.id,
           salesChannelId: channel
         },
-        fetchPolicy: 'cache-first'
+        fetchPolicy: 'network-only'
       });
 
       if (data && data.productTranslations.edges.length === 1) {
@@ -147,7 +147,7 @@ const setFormAndMutation = async (language, channel) => {
       const { data: def } = await apolloClient.query({
         query: getProductContentByLanguageAndDefaultQuery,
         variables: { languageCode: language, productId: props.product.id },
-        fetchPolicy: 'cache-first'
+        fetchPolicy: 'network-only'
       });
       defaultPreviewContent.value = def?.productTranslations.edges[0]?.node || null;
     }

--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -60,7 +60,7 @@ const fetchPoints = async () => {
     const {data} = await apolloClient.query({
       query: productTranslationBulletPointsQuery,
       variables: {filter: {productTranslation: {id: {exact: props.translationId}}}},
-      fetchPolicy: 'cache-first',
+      fetchPolicy: 'network-only',
     });
     bulletPoints.value =
         data?.productTranslationBulletPoints.edges.map((e: any) => ({...e.node})) || [];

--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -161,10 +161,10 @@ const fetchProductTypeValue = async (productTypePropertyId) => {
 
 const setCurrentLanguage = async () => {
 
-  const {data} = await apolloClient.query({
-    query: translationLanguagesQuery,
-    fetchPolicy: 'cache-first'
-  });
+    const {data} = await apolloClient.query({
+      query: translationLanguagesQuery,
+      fetchPolicy: 'cache-first'
+    });
 
   if (data && data.translationLanguages && data.translationLanguages.defaultLanguage) {
     const defaultLanguage = data.translationLanguages.defaultLanguage;
@@ -338,21 +338,21 @@ const fetchFieldTranslation = async (value: ProductPropertyValue) => {
     return
   }
 
-  const {data} = await apolloClient.query({
-    query: productPropertyTextTranslationsQuery,
-    variables: {
-      filter:
-          {
-            productProperty:
-                {
-                  property: {id: {exact: value.property.id}},
-                  product: {id: {exact: props.product.id}}
-                },
-            language: {exact: language.value}
-          }
-    },
-    fetchPolicy: 'cache-first'
-  });
+    const {data} = await apolloClient.query({
+      query: productPropertyTextTranslationsQuery,
+      variables: {
+        filter:
+            {
+              productProperty:
+                  {
+                    property: {id: {exact: value.property.id}},
+                    product: {id: {exact: props.product.id}}
+                  },
+              language: {exact: language.value}
+            }
+      },
+      fetchPolicy: 'network-only'
+    });
 
   if (data && data.productPropertyTextTranslations && data.productPropertyTextTranslations.edges && data.productPropertyTextTranslations.edges.length == 1) {
     value.translation.id = data.productPropertyTextTranslations.edges[0].node.id;

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -398,16 +398,16 @@ const fetchVariationProperties = async (variationId: string) => {
     edges.map(async ({ node }: any) => {
       let translation = null
       if ([PropertyTypes.TEXT, PropertyTypes.DESCRIPTION].includes(node.property.type)) {
-        const { data: tData } = await apolloClient.query({
-          query: productPropertyTextTranslationsQuery,
-          variables: {
-            filter: {
-              productProperty: { id: { exact: node.id } },
-              language: { exact: language.value },
+          const { data: tData } = await apolloClient.query({
+            query: productPropertyTextTranslationsQuery,
+            variables: {
+              filter: {
+                productProperty: { id: { exact: node.id } },
+                language: { exact: language.value },
+              },
             },
-          },
-          fetchPolicy: 'cache-first',
-        })
+            fetchPolicy: 'network-only',
+          })
         const tNode = tData?.productPropertyTextTranslations?.edges?.[0]?.node
         translation = tNode ? { ...tNode } : { language: language.value }
       }
@@ -446,10 +446,10 @@ watch(language, async () => {
 })
 
 const fetchDefaultLanguage = async () => {
-  const { data } = await apolloClient.query({
-    query: translationLanguagesQuery,
-    fetchPolicy: 'cache-first',
-  })
+    const { data } = await apolloClient.query({
+      query: translationLanguagesQuery,
+      fetchPolicy: 'cache-first',
+    })
   language.value = data?.translationLanguages?.defaultLanguage?.code || null
 }
 

--- a/src/shared/components/organisms/translated-fields/TranslatedFields.vue
+++ b/src/shared/components/organisms/translated-fields/TranslatedFields.vue
@@ -109,7 +109,7 @@ const setValues = async () => {
   const {data: translationData} = await apolloClient.query({
     query: props.query,
     variables: props.variables,
-    fetchPolicy: 'cache-first'
+    fetchPolicy: 'network-only'
   });
 
   if (translationData && translationData[props.queryKey]) {


### PR DESCRIPTION
## Summary
- avoid stale data by fetching translation content with `network-only`
- keep translation language lookups cached to reduce unnecessary network requests

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9c6c2b014832ebe0e81de58b10356