### PR TITLE
Default to translations tab when editing select values

### DIFF
--- a/src/core/properties/property-select-values/configs.ts
+++ b/src/core/properties/property-select-values/configs.ts
@@ -287,7 +287,7 @@ export const showConfigConstructor = (t: Function, id): ShowConfig => ({
     subscriptionKey: 'propertySelectValue',
     subscriptionVariables: {pk: id},
     backUrl: {name: 'properties.values.list'},
-    editUrl: {name: 'properties.values.edit', params: {id: id}},
+    editUrl: {name: 'properties.values.edit', params: {id: id}, query: {tab: 'translations'}},
     deleteMutation: deletePropertySelectValueMutation,
     deleteVariables: {id: id},
     deleteUrl: {name: 'properties.values.list'},


### PR DESCRIPTION
## Summary
- ensure property select value show page opens the edit screen on the translations tab

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9d1ae76d4832eb312c37b09821e7e

## Summary by Sourcery

Enhancements:
- Open the translations tab by default on the edit screen for property select values