### PR TITLE
feat: add keyboard shortcuts to select value creation

### DIFF
--- a/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
+++ b/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
@@ -19,6 +19,7 @@ import { CancelButton } from "../../../../shared/components/atoms/button-cancel"
 import { DuplicateModal } from "../../../../shared/components/molecules/duplicate-modal";
 import { Toast } from "../../../../shared/modules/toast";
 import { processGraphQLErrors } from "../../../../shared/utils";
+import { useEnterKeyboardListener, useShiftBackspaceKeyboardListener, useShiftEnterKeyboardListener } from "../../../../shared/modules/keyboard";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -213,6 +214,13 @@ const cancel = () => {
     router.push(formConfig.value.submitUrl);
   }
 };
+
+const saveAndContinue = () => checkDuplicatesAndCreate(true);
+const save = () => checkDuplicatesAndCreate(false);
+
+useShiftEnterKeyboardListener(saveAndContinue);
+useEnterKeyboardListener(save);
+useShiftBackspaceKeyboardListener(cancel);
 
 </script>
 


### PR DESCRIPTION
## Summary
- allow property select value creation with keyboard

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9d476ec7c832ea7a7141ed6d6c20b

## Summary by Sourcery

Add keyboard shortcuts to the property-select-value creation controller

New Features:
- Allow Enter to save a new select value
- Allow Shift+Enter to save and continue creating values
- Allow Shift+Backspace to cancel the creation flow