### PR TITLE
Ignore webhook integrations in content sales channel selection

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -67,7 +67,9 @@ const cleanedData = (rawData) => {
 const loadSalesChannels = async () => {
   try {
     const { data } = await apolloClient.query({ query: integrationsQuery, fetchPolicy: 'cache-first' });
-    salesChannels.value = data?.integrations.edges.map((e: any) => e.node) || [];
+    salesChannels.value = data?.integrations.edges
+      .map((e: any) => e.node)
+      .filter((c: any) => c.type !== IntegrationTypes.Webhook) || [];
   } catch (e) {
     console.error('Failed to load sales channels', e);
   }


### PR DESCRIPTION
## Summary
- filter out webhook integrations when listing sales channels for product content

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9d4344304832ebd93a2c756d01aa4

## Summary by Sourcery

Bug Fixes:
- Exclude webhook integrations when loading sales channels for product content