### PR TITLE
Fix translation population in product property pagination

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -335,47 +335,52 @@ const handleRemove = (id) => {
 const fetchFieldTranslation = async (value: ProductPropertyValue) => {
 
   if (language.value == null) {
-    return
+    return null;
   }
 
-    const {data} = await apolloClient.query({
-      query: productPropertyTextTranslationsQuery,
-      variables: {
-        filter:
-            {
-              productProperty:
-                  {
-                    property: {id: {exact: value.property.id}},
-                    product: {id: {exact: props.product.id}}
-                  },
-              language: {exact: language.value}
-            }
-      },
-      fetchPolicy: 'network-only'
-    });
+  const {data} = await apolloClient.query({
+    query: productPropertyTextTranslationsQuery,
+    variables: {
+      filter: {
+        productProperty: {
+          property: {id: {exact: value.property.id}},
+          product: {id: {exact: props.product.id}}
+        },
+        language: {exact: language.value}
+      }
+    },
+    fetchPolicy: 'network-only'
+  });
 
   if (data && data.productPropertyTextTranslations && data.productPropertyTextTranslations.edges && data.productPropertyTextTranslations.edges.length == 1) {
-    value.translation.id = data.productPropertyTextTranslations.edges[0].node.id;
-    value.translation.valueText = data.productPropertyTextTranslations.edges[0].node.valueText;
-    value.translation.valueDescription = data.productPropertyTextTranslations.edges[0].node.valueDescription;
+    const node = data.productPropertyTextTranslations.edges[0].node;
+    return {
+      id: node.id,
+      valueText: node.valueText,
+      valueDescription: node.valueDescription,
+    };
   }
 
-  return null;
+  return {
+    id: undefined,
+    valueText: undefined,
+    valueDescription: undefined,
+  };
 };
 
 const populateTranslatableFields = async () => {
 
   if (language.value == null) {
-    return
+    return;
   }
 
   for (const value of values.value) {
     if ([PropertyTypes.TEXT, PropertyTypes.DESCRIPTION].includes(value.property.type)) {
-      value.translation.id = undefined;
-      value.translation.valueDescription = undefined;
-      value.translation.valueText = undefined;
-      await fetchFieldTranslation(value);
-      value.translation.language = language.value;
+      const translation = await fetchFieldTranslation(value);
+      value.translation = {
+        ...translation,
+        language: language.value,
+      };
     }
   }
 }


### PR DESCRIPTION
## Summary
- ensure property text translations are reloaded by returning translation data from `fetchFieldTranslation`
- replace translation object when populating text fields so `ValueInput` reacts to updates

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9d2435250832ea9d82f57baaca7e4

## Summary by Sourcery

Refactor translation fetching and assignment in product property pagination to ensure translations are reloaded and UI components react to updates.

Bug Fixes:
- Return translation data from fetchFieldTranslation and replace value.translation in populateTranslatableFields to ensure ValueInput reacts to updates

Enhancements:
- Refactor fetchFieldTranslation to return a structured translation object with id, valueText, and valueDescription
- Update populateTranslatableFields to assign the translation object atomically instead of mutating individual fields