### PR TITLE
Remove unused webhook fields and cap timeout

### DIFF
--- a/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/WebhookChannelInfoStep.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/integration-specific-step/webhook/WebhookChannelInfoStep.vue
@@ -34,11 +34,6 @@ const modeChoices = [
   { id: 'delta', text: t('integrations.webhook.choices.mode.delta') },
 ];
 
-const retentionChoices = [
-  { id: '3m', text: t('integrations.webhook.choices.retentionPolicy.3m') },
-  { id: '6m', text: t('integrations.webhook.choices.retentionPolicy.6m') },
-  { id: '12m', text: t('integrations.webhook.choices.retentionPolicy.12m') },
-];
 </script>
 
 <template>
@@ -123,27 +118,6 @@ const retentionChoices = [
             <Flex vertical class="gap-2">
               <FlexCell>
                 <Label class="font-semibold block text-sm leading-6 text-gray-900">
-                  {{ t('integrations.labels.userAgent') }}
-                </Label>
-              </FlexCell>
-              <FlexCell>
-                <TextInput
-                  class="w-96"
-                  v-model="channelInfo.userAgent"
-                  :placeholder="t('integrations.placeholders.userAgent')"
-                />
-              </FlexCell>
-            </Flex>
-            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
-              <p>{{ t('integrations.webhook.helpText.userAgent') }}</p>
-            </div>
-          </FlexCell>
-        </Flex>
-        <Flex class="mt-4 gap-4" center>
-          <FlexCell center>
-            <Flex vertical class="gap-2">
-              <FlexCell>
-                <Label class="font-semibold block text-sm leading-6 text-gray-900">
                   {{ t('integrations.labels.timeoutMs') }}
                 </Label>
               </FlexCell>
@@ -152,6 +126,7 @@ const retentionChoices = [
                   class="w-96"
                   v-model="channelInfo.timeoutMs"
                   :number="true"
+                  :max-number="10000"
                   :placeholder="t('integrations.placeholders.timeoutMs')"
                 />
               </FlexCell>
@@ -183,31 +158,6 @@ const retentionChoices = [
             </Flex>
             <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
               <p>{{ t('integrations.webhook.helpText.mode') }}</p>
-            </div>
-          </FlexCell>
-        </Flex>
-        <Flex class="mt-4 gap-4" center>
-          <FlexCell center>
-            <Flex vertical class="gap-2">
-              <FlexCell>
-                <Label class="font-semibold block text-sm leading-6 text-gray-900">
-                  {{ t('integrations.labels.retentionPolicy') }}
-                </Label>
-              </FlexCell>
-              <FlexCell>
-                <Selector
-                  class="w-96"
-                  v-model="channelInfo.retentionPolicy"
-                  :options="retentionChoices"
-                  value-by="id"
-                  label-by="text"
-                  :placeholder="t('integrations.placeholders.retentionPolicy')"
-                  :removable="false"
-                />
-              </FlexCell>
-            </Flex>
-            <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
-              <p>{{ t('integrations.webhook.helpText.retentionPolicy') }}</p>
             </div>
           </FlexCell>
         </Flex>

--- a/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
@@ -27,10 +27,8 @@ interface EditWebhookForm {
   version: string;
   url: string;
   secret: string;
-  userAgent: string;
   timeoutMs: number;
   mode: string;
-  retentionPolicy: string;
 }
 
 const props = defineProps<{ data: EditWebhookForm }>();
@@ -84,11 +82,6 @@ const modeChoices = [
   { id: 'delta', text: t('integrations.webhook.choices.mode.delta') },
 ];
 
-const retentionChoices = [
-  { id: '3m', text: t('integrations.webhook.choices.retentionPolicy.3m') },
-  { id: '6m', text: t('integrations.webhook.choices.retentionPolicy.6m') },
-  { id: '12m', text: t('integrations.webhook.choices.retentionPolicy.12m') },
-];
 
 watch(
   () => props.data,
@@ -212,15 +205,6 @@ const regenerateSecret = async () => {
           <p>{{ t('integrations.webhook.helpText.version') }}</p>
         </div>
       </div>
-      <div class="md:col-span-6 col-span-12">
-        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
-          {{ t('integrations.labels.userAgent') }}
-        </Label>
-        <TextInput v-model="formData.userAgent" :placeholder="t('integrations.placeholders.userAgent')" class="w-full" />
-        <div class="mt-1 text-sm leading-6 text-gray-400">
-          <p>{{ t('integrations.webhook.helpText.userAgent') }}</p>
-        </div>
-      </div>
     </div>
 
     <div class="grid grid-cols-12 gap-4">
@@ -228,7 +212,7 @@ const regenerateSecret = async () => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.timeoutMs') }}
         </Label>
-        <TextInput v-model="formData.timeoutMs" :number="true" :placeholder="t('integrations.placeholders.timeoutMs')" class="w-full" />
+        <TextInput v-model="formData.timeoutMs" :number="true" :max-number="10000" :placeholder="t('integrations.placeholders.timeoutMs')" class="w-full" />
         <div class="mt-1 text-sm leading-6 text-gray-400">
           <p>{{ t('integrations.webhook.helpText.timeoutMs') }}</p>
         </div>
@@ -255,25 +239,6 @@ const regenerateSecret = async () => {
     </div>
 
     <div class="grid grid-cols-12 gap-4">
-      <div class="md:col-span-6 col-span-12">
-        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
-          {{ t('integrations.labels.retentionPolicy') }}
-        </Label>
-        <div>
-          <Selector
-            v-model="formData.retentionPolicy"
-            :options="retentionChoices"
-            value-by="id"
-            label-by="text"
-            :placeholder="t('integrations.placeholders.retentionPolicy')"
-            :removable="false"
-            class="w-full"
-          />
-        </div>
-        <div class="mt-1 text-sm leading-6 text-gray-400">
-          <p>{{ t('integrations.webhook.helpText.retentionPolicy') }}</p>
-        </div>
-      </div>
       <div class="md:col-span-6 col-span-12">
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.secret') }}

--- a/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/monitor/WebhookMonitor.vue
@@ -207,7 +207,7 @@ const generateHeaders = async () => {
   const rawBody = JSON.stringify(selectedEvent.value.outbox.payload);
   const timestamp = Math.floor(Date.now() / 1000);
   const base = await buildHeaders(
-    integration.value.userAgent || '',
+    t('integrations.placeholders.userAgent'),
     selectedEvent.value.outbox.topic,
     selectedEvent.value.outbox.action,
     integration.value.version || '',

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -109,12 +109,10 @@ export interface WebhookChannelInfo extends SpecificChannelInfo {
   version: string;
   url: string;
   secret: string;
-  userAgent: string;
   timeoutMs: number;
   mode: string;
   extraHeaders: Record<string, any>;
   config: Record<string, any>;
-  retentionPolicy: string;
 }
 
 
@@ -165,12 +163,10 @@ export function getWebhookDefaultFields(): WebhookChannelInfo {
     version: '2025-08-01',
     url: '',
     secret: '',
-    userAgent: 'OneSila-Webhook/1.0',
     timeoutMs: 10000,
     mode: '',
     extraHeaders: {},
     config: {},
-    retentionPolicy: ''
   };
 }
 

--- a/src/shared/api/mutations/webhooks.js
+++ b/src/shared/api/mutations/webhooks.js
@@ -10,12 +10,10 @@ export const createWebhookIntegrationMutation = gql`
       version
       url
       secret
-      userAgent
       timeoutMs
       mode
       extraHeaders
       config
-      retentionPolicy
       requestsPerMinute
       maxRetries
     }
@@ -32,12 +30,10 @@ export const createWebhookIntegrationsMutation = gql`
       version
       url
       secret
-      userAgent
       timeoutMs
       mode
       extraHeaders
       config
-      retentionPolicy
       requestsPerMinute
       maxRetries
     }
@@ -54,12 +50,10 @@ export const updateWebhookIntegrationMutation = gql`
       version
       url
       secret
-      userAgent
       timeoutMs
       mode
       extraHeaders
       config
-      retentionPolicy
       requestsPerMinute
       maxRetries
     }
@@ -77,12 +71,10 @@ export const regenerateWebhookIntegrationSecretMutation = gql`
         version
         url
         secret
-        userAgent
         timeoutMs
         mode
         extraHeaders
         config
-        retentionPolicy
         requestsPerMinute
         maxRetries
       }

--- a/src/shared/api/queries/webhooks.js
+++ b/src/shared/api/queries/webhooks.js
@@ -12,12 +12,10 @@ export const webhookIntegrationsQuery = gql`
           version
           url
           secret
-          userAgent
           timeoutMs
           mode
           extraHeaders
           config
-          retentionPolicy
           requestsPerMinute
           maxRetries
         }
@@ -44,12 +42,10 @@ export const getWebhookIntegrationQuery = gql`
       version
       url
       secret
-      userAgent
       timeoutMs
       mode
       extraHeaders
       config
-      retentionPolicy
       requestsPerMinute
       maxRetries
     }


### PR DESCRIPTION
## Summary
- Drop user agent and retention policy from webhook show views
- Cap webhook timeout input at 10 seconds in edit form
- Remove userAgent and retentionPolicy from webhook queries and mutations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9d6e32a1c832eabd909b68405507e

## Summary by Sourcery

Remove unused webhook fields (userAgent, retentionPolicy) across UI, API, and types, and enforce a 10-second cap on timeout input

Enhancements:
- Cap webhook timeout input at 10 seconds in create and edit forms

Chores:
- Remove userAgent and retentionPolicy fields from webhook UI components
- Remove userAgent and retentionPolicy from GraphQL queries and mutations
- Remove userAgent and retentionPolicy from internal WebhookChannelInfo types and defaults