### PR TITLE
feat: show loader while loading merge data

### DIFF
--- a/src/core/properties/property-select-values/property-select-values-list/PropertySelectValuesMerge.vue
+++ b/src/core/properties/property-select-values/property-select-values-list/PropertySelectValuesMerge.vue
@@ -6,6 +6,7 @@ import { Modal } from '../../../../shared/components/atoms/modal';
 import { Card } from '../../../../shared/components/atoms/card';
 import { Toggle } from '../../../../shared/components/atoms/toggle';
 import { Icon } from '../../../../shared/components/atoms/icon';
+import { LocalLoader } from '../../../../shared/components/atoms/local-loader';
 import apolloClient from '../../../../../apollo-client';
 import { propertySelectValuesQuery, productPropertiesCountQuery } from '../../../../shared/api/queries/properties.js';
 import { mergePropertySelectValueMutation } from '../../../../shared/api/mutations/properties.js';
@@ -19,42 +20,48 @@ const { t } = useI18n();
 const showModal = ref(false);
 const values = ref<{ id: string; value: string; count: number }[]>([]);
 const target = ref<string | null>(null);
+const loading = ref(false);
 
-const openModal = async () => {
-  await fetchValues();
+const openModal = () => {
   showModal.value = true;
+  void fetchValues();
 };
 
 const fetchValues = async () => {
-  const { data } = await apolloClient.query({
-    query: propertySelectValuesQuery,
-    variables: { filter: { id: { inList: props.selectedEntities } } },
-    fetchPolicy: 'cache-first',
-  });
-  const edges = data?.propertySelectValues?.edges || [];
-  const result = await Promise.all(
-    edges.map(async (edge: any) => {
-      const id = edge.node.id;
-      const { data: countData } = await apolloClient.query({
-        query: productPropertiesCountQuery,
-        variables: {
-          filter: {
-            valueSelect: { id: { exact: id } },
-            OR: { valueMultiSelect: { id: { exact: id } } },
+  loading.value = true;
+  try {
+    const { data } = await apolloClient.query({
+      query: propertySelectValuesQuery,
+      variables: { filter: { id: { inList: props.selectedEntities } } },
+      fetchPolicy: 'cache-first',
+    });
+    const edges = data?.propertySelectValues?.edges || [];
+    const result = await Promise.all(
+      edges.map(async (edge: any) => {
+        const id = edge.node.id;
+        const { data: countData } = await apolloClient.query({
+          query: productPropertiesCountQuery,
+          variables: {
+            filter: {
+              valueSelect: { id: { exact: id } },
+              OR: { valueMultiSelect: { id: { exact: id } } },
+            },
           },
-        },
-        fetchPolicy: 'cache-first',
-      });
-      return {
-        id,
-        value: edge.node.value,
-        count: countData?.productProperties?.totalCount || 0,
-      };
-    })
-  );
-  values.value = result;
-  if (result.length > 0) {
-    target.value = result.reduce((max, item) => (item.count > max.count ? item : max), result[0]).id;
+          fetchPolicy: 'cache-first',
+        });
+        return {
+          id,
+          value: edge.node.value,
+          count: countData?.productProperties?.totalCount || 0,
+        };
+      })
+    );
+    values.value = result;
+    if (result.length > 0) {
+      target.value = result.reduce((max, item) => (item.count > max.count ? item : max), result[0]).id;
+    }
+  } finally {
+    loading.value = false;
   }
 };
 
@@ -95,26 +102,29 @@ const mergeValues = async () => {
 
   <Modal v-model="showModal" @closed="showModal = false">
     <Card class="modal-content w-2/3">
-      <h3 class="text-xl font-semibold mb-4">{{ t('properties.values.merge.title') }}</h3>
-      <p class="mb-4">{{ t('properties.values.merge.description') }}</p>
-      <hr class="my-4">
-      <div v-for="val in values" :key="val.id" class="flex items-center justify-between py-2">
-        <div>
-          <div>{{ val.value }}</div>
-          <div class="text-sm text-gray-500">{{ t('properties.values.merge.counter', { count: val.count }) }}</div>
+      <LocalLoader :loading="loading" />
+      <template v-if="!loading">
+        <h3 class="text-xl font-semibold mb-4">{{ t('properties.values.merge.title') }}</h3>
+        <p class="mb-4">{{ t('properties.values.merge.description') }}</p>
+        <hr class="my-4">
+        <div v-for="val in values" :key="val.id" class="flex items-center justify-between py-2">
+          <div>
+            <div>{{ val.value }}</div>
+            <div class="text-sm text-gray-500">{{ t('properties.values.merge.counter', { count: val.count }) }}</div>
+          </div>
+          <Toggle
+            :model-value="target === val.id"
+            @update:model-value="() => onToggle(val.id)"
+          />
         </div>
-        <Toggle
-          :model-value="target === val.id"
-          @update:model-value="() => onToggle(val.id)"
-        />
-      </div>
-      <p class="text-sm text-red-600 mt-4">{{ t('properties.values.merge.warning') }}</p>
-      <div class="flex justify-end gap-4 mt-4">
-        <Button class="btn btn-outline-dark" @click="showModal = false">{{ t('shared.button.cancel') }}</Button>
-        <Button type="button" class="btn btn-primary" @click="mergeValues">
-          {{ t('properties.values.merge.confirm') }}
-        </Button>
-      </div>
+        <p class="text-sm text-red-600 mt-4">{{ t('properties.values.merge.warning') }}</p>
+        <div class="flex justify-end gap-4 mt-4">
+          <Button class="btn btn-outline-dark" @click="showModal = false">{{ t('shared.button.cancel') }}</Button>
+          <Button type="button" class="btn btn-primary" @click="mergeValues">
+            {{ t('properties.values.merge.confirm') }}
+          </Button>
+        </div>
+      </template>
     </Card>
   </Modal>
 </template>

--- a/src/core/properties/property-select-values/property-select-values-show/PropertySelectValueMerge.vue
+++ b/src/core/properties/property-select-values/property-select-values-show/PropertySelectValueMerge.vue
@@ -6,6 +6,7 @@ import { Modal } from '../../../../shared/components/atoms/modal';
 import { Selector } from '../../../../shared/components/atoms/selector';
 import { Card } from '../../../../shared/components/atoms/card';
 import { Icon } from '../../../../shared/components/atoms/icon';
+import { LocalLoader } from '../../../../shared/components/atoms/local-loader';
 import apolloClient from '../../../../../apollo-client';
 import { propertySelectValuesQuerySimpleSelector, productPropertiesCountQuery } from '../../../../shared/api/queries/properties.js';
 import { mergePropertySelectValueMutation } from '../../../../shared/api/mutations/properties.js';
@@ -21,6 +22,7 @@ const selectedOption = ref<string | null>(null);
 const options = ref<{ label: string; value: string }[]>([]);
 const sources = ref<{ id: string; label: string; count: number }[]>([]);
 const currentCount = ref(0);
+const loading = ref(false);
 
 const fetchCount = async (id: string) => {
   const { data } = await apolloClient.query({
@@ -36,12 +38,21 @@ const fetchCount = async (id: string) => {
   return data?.productProperties?.totalCount || 0;
 };
 
-const openModal = async () => {
-  await fetchOptions();
-  currentCount.value = await fetchCount(props.id);
+const openModal = () => {
+  showModal.value = true;
   selectedOption.value = null;
   sources.value = [];
-  showModal.value = true;
+  void loadData();
+};
+
+const loadData = async () => {
+  loading.value = true;
+  try {
+    await fetchOptions();
+    currentCount.value = await fetchCount(props.id);
+  } finally {
+    loading.value = false;
+  }
 };
 
 const fetchOptions = async (searchValue: string | null = null) => {
@@ -112,40 +123,43 @@ const mergeValues = async () => {
 
     <Modal v-model="showModal" @closed="showModal = false">
       <Card class="modal-content w-2/3">
-        <h3 class="text-xl font-semibold mb-4">{{ t('properties.values.merge.title') }}</h3>
-        <p>{{ t('properties.values.merge.detailDescription', { value: props.currentLabel }) }}</p>
-        <p class="mb-4 text-sm text-gray-500">{{ t('properties.values.merge.current', { value: props.currentLabel, count: currentCount }) }}</p>
-        <hr class="my-4" />
-        <div class="flex items-center gap-2 mb-4">
-          <Selector
-            v-model="selectedOption"
-            :options="options"
-            label-by="label"
-            value-by="value"
-            class="flex-1"
-            @searched="fetchOptions"
-            :placeholder="t('properties.values.merge.selectSource')"
-          />
-          <Button class="btn btn-secondary" :disabled="!selectedOption" @click="addSource">
-            {{ t('shared.button.add') }}
-          </Button>
-        </div>
-        <div v-for="src in sources" :key="src.id" class="flex items-center justify-between mb-2">
-          <div>
-            <div>{{ src.label }}</div>
-            <div class="text-sm text-gray-500">{{ t('properties.values.merge.counter', { count: src.count }) }}</div>
+        <LocalLoader :loading="loading" />
+        <template v-if="!loading">
+          <h3 class="text-xl font-semibold mb-4">{{ t('properties.values.merge.title') }}</h3>
+          <p>{{ t('properties.values.merge.detailDescription', { value: props.currentLabel }) }}</p>
+          <p class="mb-4 text-sm text-gray-500">{{ t('properties.values.merge.current', { value: props.currentLabel, count: currentCount }) }}</p>
+          <hr class="my-4" />
+          <div class="flex items-center gap-2 mb-4">
+            <Selector
+              v-model="selectedOption"
+              :options="options"
+              label-by="label"
+              value-by="value"
+              class="flex-1"
+              @searched="fetchOptions"
+              :placeholder="t('properties.values.merge.selectSource')"
+            />
+            <Button class="btn btn-secondary" :disabled="!selectedOption" @click="addSource">
+              {{ t('shared.button.add') }}
+            </Button>
           </div>
-          <Button class="btn btn-outline-danger" @click="removeSource(src.id)">
-            <Icon name="trash" size="sm" />
-          </Button>
-        </div>
-        <p class="text-sm text-red-600 mt-4">{{ t('properties.values.merge.warning') }}</p>
-        <div class="flex justify-end gap-4 mt-4">
-          <Button class="btn btn-outline-dark" @click="showModal = false">{{ t('shared.button.cancel') }}</Button>
-          <Button type="button" class="btn btn-primary" @click="mergeValues">
-            {{ t('properties.values.merge.confirm') }}
-          </Button>
-        </div>
+          <div v-for="src in sources" :key="src.id" class="flex items-center justify-between mb-2">
+            <div>
+              <div>{{ src.label }}</div>
+              <div class="text-sm text-gray-500">{{ t('properties.values.merge.counter', { count: src.count }) }}</div>
+            </div>
+            <Button class="btn btn-outline-danger" @click="removeSource(src.id)">
+              <Icon name="trash" size="sm" />
+            </Button>
+          </div>
+          <p class="text-sm text-red-600 mt-4">{{ t('properties.values.merge.warning') }}</p>
+          <div class="flex justify-end gap-4 mt-4">
+            <Button class="btn btn-outline-dark" @click="showModal = false">{{ t('shared.button.cancel') }}</Button>
+            <Button type="button" class="btn btn-primary" @click="mergeValues">
+              {{ t('properties.values.merge.confirm') }}
+            </Button>
+          </div>
+        </template>
       </Card>
     </Modal>
   </div>


### PR DESCRIPTION
## Summary
- show loader when opening merge dialog from property select value list
- show loader when opening merge dialog from property select value detail

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9d4b164c8832eb6040f264cc38f89

## Summary by Sourcery

Display a loader while fetching merge data in property select value merge dialogs and restructure the modal opening logic to manage loading state.

New Features:
- Show a loading spinner when opening the merge dialog for property select values in both list and detail views

Enhancements:
- Introduce a reactive loading state and a LocalLoader component to manage async data fetches in merge dialogs
- Refactor openModal handlers to decouple modal display from data loading and wrap dialog content in conditional templates