### PR TITLE
Align webhook fields on same rows

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/webhook-general-tab/WebhookGeneralInfoTab.vue
@@ -205,9 +205,6 @@ const regenerateSecret = async () => {
           <p>{{ t('integrations.webhook.helpText.version') }}</p>
         </div>
       </div>
-    </div>
-
-    <div class="grid grid-cols-12 gap-4">
       <div class="md:col-span-6 col-span-12">
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.timeoutMs') }}
@@ -217,6 +214,9 @@ const regenerateSecret = async () => {
           <p>{{ t('integrations.webhook.helpText.timeoutMs') }}</p>
         </div>
       </div>
+    </div>
+
+    <div class="grid grid-cols-12 gap-4">
       <div class="md:col-span-6 col-span-12">
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.mode') }}
@@ -236,9 +236,6 @@ const regenerateSecret = async () => {
           <p>{{ t('integrations.webhook.helpText.mode') }}</p>
         </div>
       </div>
-    </div>
-
-    <div class="grid grid-cols-12 gap-4">
       <div class="md:col-span-6 col-span-12">
         <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
           {{ t('integrations.labels.secret') }}


### PR DESCRIPTION
## Summary
- Place timeout next to version in webhook general settings
- Place secret field alongside mode in webhook general settings

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9db28dd1c832ea22ca11b413c776e

## Summary by Sourcery

Align the layout of webhook general settings fields by placing timeout next to version and secret next to mode in the same grid rows

Enhancements:
- Group timeout field next to version in the webhook general settings grid
- Group secret field alongside mode in the webhook general settings grid