### PR TITLE
feat: add duplicate check loader with skip

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -312,5 +312,16 @@
         }
       }
     }
+  },
+  "properties": {
+    "duplicateModal": {
+      "title": "Properties with Similar Names Found",
+      "content": "We've found properties with similar names listed below. If none of them match what you're trying to create, you can continue and add your new property.",
+      "checkingTitle": "Checking for duplicates",
+      "steps": {
+        "step1": "Preparing duplicate check",
+        "step2": "Searching for duplicates"
+      }
+    }
   }
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2183,7 +2183,12 @@
     },
     "duplicateModal": {
       "title": "Properties with Similar Names Found",
-      "content": "We've found properties with similar names listed below. If none of them match what you're trying to create, you can continue and add your new property."
+      "content": "We've found properties with similar names listed below. If none of them match what you're trying to create, you can continue and add your new property.",
+      "checkingTitle": "Checking for duplicates",
+      "steps": {
+        "step1": "Preparing duplicate check",
+        "step2": "Searching for duplicates"
+      }
     },
     "values": {
       "title": "Select Values",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -312,5 +312,16 @@
         }
       }
     }
+  },
+  "properties": {
+    "duplicateModal": {
+      "title": "Properties with Similar Names Found",
+      "content": "We've found properties with similar names listed below. If none of them match what you're trying to create, you can continue and add your new property.",
+      "checkingTitle": "Checking for duplicates",
+      "steps": {
+        "step1": "Preparing duplicate check",
+        "step2": "Searching for duplicates"
+      }
+    }
   }
 }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1817,7 +1817,12 @@
     },
     "duplicateModal": {
       "title": "Eigenschappen met gelijkaardige naam gevonden",
-      "content": "Selecteer een bestaande eigenschap of maak toch een nieuwe aan."
+      "content": "Selecteer een bestaande eigenschap of maak toch een nieuwe aan.",
+      "checkingTitle": "Checking for duplicates",
+      "steps": {
+        "step1": "Preparing duplicate check",
+        "step2": "Searching for duplicates"
+      }
     },
     "values": {
       "title": "Selectie Waardes",

--- a/src/shared/components/molecules/duplicate-modal/DuplicateModal.vue
+++ b/src/shared/components/molecules/duplicate-modal/DuplicateModal.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, watch, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { Modal } from '../../../../shared/components/atoms/modal';
 import { Card } from '../../../../shared/components/atoms/card';
 import { Button } from '../../../../shared/components/atoms/button';
-import {Link} from "../../atoms/link";
+import { Link } from '../../atoms/link';
+import { Icon } from '../../atoms/icon';
 
 interface DuplicateItem {
   label: string;
@@ -17,9 +18,15 @@ const props = withDefaults(defineProps<{
   title: string;
   content?: string;
   items?: DuplicateItem[];
+  loading?: boolean;
+  modalTitle?: string;
+  steps?: string[];
 }>(), {
   content: '',
   items: () => [],
+  loading: false,
+  modalTitle: '',
+  steps: () => [],
 });
 
 const emit = defineEmits<{
@@ -30,9 +37,43 @@ const emit = defineEmits<{
 const router = useRouter();
 const { t } = useI18n();
 const localShowModal = ref(props.modelValue);
+const simulatedProgress = ref(0);
+let progressInterval: ReturnType<typeof setInterval> | null = null;
 
 watch(() => props.modelValue, (val) => {
   localShowModal.value = val;
+});
+
+const startSimulatedProgress = () => {
+  simulatedProgress.value = 0;
+  progressInterval = setInterval(() => {
+    if (simulatedProgress.value < props.steps.length) {
+      simulatedProgress.value += 1;
+    } else {
+      clearInterval(progressInterval!);
+      progressInterval = null;
+    }
+  }, 1000);
+};
+
+const stopSimulatedProgress = () => {
+  if (progressInterval) {
+    clearInterval(progressInterval);
+    progressInterval = null;
+  }
+};
+
+watch(() => props.loading, (val) => {
+  if (val) {
+    startSimulatedProgress();
+  } else {
+    stopSimulatedProgress();
+    simulatedProgress.value = 0;
+  }
+});
+
+onUnmounted(() => {
+  stopSimulatedProgress();
 });
 
 const close = () => {
@@ -51,19 +92,44 @@ const createAnyway = () => {
 <template>
   <Modal v-model="localShowModal" @closed="close">
     <Card class="modal-content w-1/3">
-      <h1 class="text-xl font-semibold text-center mb-4">{{ title }}</h1>
-      <p v-if="content" class="mb-4">{{ content }}</p>
-      <ul v-if="items.length" class="list-disc pl-5 mb-4">
-        <li v-for="(item, index) in items" :key="index">
-          <Link :path="item.urlParam" target="_blank">
-            {{ item.label }}
-          </Link>
-        </li>
-      </ul>
-      <div class="flex justify-end gap-4 mt-4">
-        <Button class="btn btn-primary" @click="createAnyway">{{ t('shared.button.createAnyway') }}</Button>
-        <Button class="btn btn-outline-dark" @click="close">{{ t('shared.button.abort') }}</Button>
-      </div>
+      <template v-if="props.loading">
+        <h3 class="text-lg text-center font-bold mb-2">{{ t(props.modalTitle) }}</h3>
+        <hr />
+        <ul class="mt-2">
+          <li
+            v-for="(step, index) in props.steps"
+            :key="index"
+            class="flex items-center mb-1 py-2 px-4"
+          >
+            <template v-if="simulatedProgress > index">
+              <Icon name="check-circle" class="text-green-600 w-5 h-5 mr-2" />
+              <span class="text-green-600">{{ step }}</span>
+            </template>
+            <template v-else>
+              <Icon name="circle" class="text-gray-400 w-5 h-5 mr-2" />
+              <span class="text-gray-400">{{ step }}</span>
+            </template>
+          </li>
+        </ul>
+        <div class="flex justify-end gap-4 mt-4">
+          <Button class="btn btn-primary" @click="createAnyway">{{ t('shared.button.skip') }}</Button>
+        </div>
+      </template>
+      <template v-else>
+        <h1 class="text-xl font-semibold text-center mb-4">{{ title }}</h1>
+        <p v-if="content" class="mb-4">{{ content }}</p>
+        <ul v-if="items.length" class="list-disc pl-5 mb-4">
+          <li v-for="(item, index) in items" :key="index">
+            <Link :path="item.urlParam" target="_blank">
+              {{ item.label }}
+            </Link>
+          </li>
+        </ul>
+        <div class="flex justify-end gap-4 mt-4">
+          <Button class="btn btn-primary" @click="createAnyway">{{ t('shared.button.createAnyway') }}</Button>
+          <Button class="btn btn-outline-dark" @click="close">{{ t('shared.button.abort') }}</Button>
+        </div>
+      </template>
     </Card>
   </Modal>
 </template>


### PR DESCRIPTION
## Summary
- add step-based loader and skip option to duplicate check modal
- integrate loader flow into property and select value creation
- extend translations for duplicate check steps

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9de2bf100832e838563ca0fbc80ab

## Summary by Sourcery

Add a step-based loader with a skip button to the duplicate check modal and integrate this loader into the property and select-value creation workflows

New Features:
- Add step-by-step progress loader with skip option to the duplicate-check modal

Enhancements:
- Integrate the loader flow into property creation and property-select-value creation to display duplicate-check progress
- Extend translations to include duplicate check step labels and checking modal title