### PR TITLE
fix: reset query results when clearing text

### DIFF
--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -99,18 +99,20 @@ async function ensureSelectedValuesArePresent() {
 async function fetchData(searchValue: string | null | undefined = null, ensureSelected: boolean = false) {
   try {
     loading.value = true;
-    // Start with existing query variables or initialize if not set
-    const variables = { ...props.field.queryVariables };
+    // Start with existing query variables without mutating props
+    const variables: any = {
+      ...props.field.queryVariables,
+      filter: {
+        ...(props.field.queryVariables?.filter ?? {}),
+      },
+    };
 
-    // Initialize filter object if it doesn't exist
+    // Handle live updates and search values
     if (isLiveUpdate.value) {
-      if (!variables.filter) {
-        variables.filter = {};
-      }
-
-      // Add or update the search value in the filter object
-      if (searchValue !== null && searchValue !== undefined) {
+      if (searchValue) {
         variables.filter.search = searchValue;
+      } else {
+        delete variables.filter.search;
       }
     }
 

--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
@@ -50,14 +50,17 @@ const selectedValue = ref(
 );
 
 const fetchData = async (searchValue: string | null = null) => {
-  const variables = { ...props.filter.queryVariables } as any;
+  const variables: any = {
+    ...props.filter.queryVariables,
+    filter: {
+      ...(props.filter.queryVariables?.filter ?? {}),
+    },
+  };
 
-  if (!variables.filter) {
-    variables.filter = {};
-  }
-
-  if (searchValue !== null && searchValue !== undefined) {
+  if (searchValue) {
     variables.filter.search = searchValue;
+  } else {
+    delete variables.filter.search;
   }
 
   try {


### PR DESCRIPTION
## Summary
- avoid mutating query variables in FieldQuery and FilterQuery
- remove stale search filter when input is cleared

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9ea9722cc832e805c344b566bf4cf

## Summary by Sourcery

Ensure query filters are safely cloned before modification and remove stale search parameters when the search field is cleared to correctly reset query results.

Bug Fixes:
- Reset query results when clearing search input by deleting stale filter.search

Enhancements:
- Clone queryVariables and nested filter object to avoid mutating props in FieldQuery and FilterQuery