### PR TITLE
Allow skipping duplicate check to proceed with property creation

### DIFF
--- a/src/core/properties/properties/properties-create/PropertiesCreateController.vue
+++ b/src/core/properties/properties/properties-create/PropertiesCreateController.vue
@@ -38,6 +38,7 @@ const showDuplicateModal = ref(false);
 const duplicateItems = ref<{ label: string; urlParam: any }[]>([]);
 const checkingDuplicates = ref(false);
 const skippedCheck = ref(false);
+let duplicateCheckController: AbortController | null = null;
 const duplicateSteps = computed(() => [
   t('properties.duplicateModal.steps.step1'),
   t('properties.duplicateModal.steps.step2'),
@@ -168,34 +169,42 @@ const createProperty = async () => {
   }
 };
 
-const handleFinish = async () => {
-  try {
-    showDuplicateModal.value = true;
-    checkingDuplicates.value = true;
-    skippedCheck.value = false;
-    const { data } = await apolloClient.mutate({
+const handleFinish = () => {
+  showDuplicateModal.value = true;
+  checkingDuplicates.value = true;
+  skippedCheck.value = false;
+  duplicateCheckController = new AbortController();
+  apolloClient
+    .mutate({
       mutation: checkPropertyForDuplicatesMutation,
-      variables: { name: form.name }
+      variables: { name: form.name },
+      context: { fetchOptions: { signal: duplicateCheckController.signal } },
+    })
+    .then(({ data }) => {
+      if (skippedCheck.value) return;
+      checkingDuplicates.value = false;
+      if (data && data.checkPropertyForDuplicates && data.checkPropertyForDuplicates.duplicateFound) {
+        duplicateItems.value = data.checkPropertyForDuplicates.duplicates.map((p: any) => ({
+          label: p.name,
+          urlParam: { name: 'properties.properties.show', params: { id: p.id } }
+        }));
+        return;
+      }
+      showDuplicateModal.value = false;
+      createProperty();
+    })
+    .catch((err) => {
+      if ((err as any)?.name === 'AbortError') return;
+      const graphqlError = err as { graphQLErrors: Array<{ message: string }> };
+      onError(graphqlError);
     });
-    if (skippedCheck.value) return;
-    checkingDuplicates.value = false;
-    if (data && data.checkPropertyForDuplicates && data.checkPropertyForDuplicates.duplicateFound) {
-      duplicateItems.value = data.checkPropertyForDuplicates.duplicates.map((p: any) => ({
-        label: p.name,
-        urlParam: { name: 'properties.properties.show', params: { id: p.id } }
-      }));
-      return;
-    }
-    showDuplicateModal.value = false;
-    await createProperty();
-  } catch (err) {
-    const graphqlError = err as { graphQLErrors: Array<{ message: string }> };
-    onError(graphqlError);
-  }
-}
+};
 
 const createAnywayHandler = async () => {
   skippedCheck.value = true;
+  duplicateCheckController?.abort();
+  checkingDuplicates.value = false;
+  showDuplicateModal.value = false;
   await createProperty();
 };
 


### PR DESCRIPTION
## Summary
- run duplicate check without awaiting so skipping can immediately proceed with property creation
- apply same non-blocking duplicate check logic to property select value creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9e31349e8832ea91f4a5cfc2f55d6

## Summary by Sourcery

Convert duplicate detection in property and property-select-value creation flows to non-blocking operations using AbortController to enable immediate skip and proceed with creation.

Enhancements:
- Run duplicate-check GraphQL mutations without awaiting to allow users to skip ahead immediately.
- Introduce AbortController to cancel in-flight duplicate checks when skipping.
- Apply the same non-blocking duplicate-check logic to the property-select-value creation controller.