### PR TITLE
Fix translation value initialization after pagination

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/value-input/ValueInput.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/value-input/ValueInput.vue
@@ -326,7 +326,11 @@ const removePropertyValue = async () => {
     }
 }
 
-watch(props.value.translation, setTranslatedValues)
+watch(
+  () => props.value.translation,
+  setTranslatedValues,
+  { deep: true, immediate: true }
+)
 
 const hasValue = (val: ProductPropertyValue): boolean => {
   const propType = val.property.type;


### PR DESCRIPTION
## Summary
- ensure property translation inputs populate correctly by watching translation data immediately

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9f1ae158c832e855894a03a95b74b

## Summary by Sourcery

Bug Fixes:
- Ensure property translation inputs populate correctly by using a deep and immediate watcher on translation values