### PR TITLE
fix: ensure external links open correctly

### DIFF
--- a/src/shared/components/atoms/link/Link.vue
+++ b/src/shared/components/atoms/link/Link.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
-const props = defineProps<{
-  path?: string | object;
-  inlineBlock?: boolean;
-  block?: boolean;
-  disabled?: boolean;
-  external?: boolean;
-  gutter?: string;
-  verticalGutter?: string;
-  horizontalGutter?: string;
-  target?: string;
-  selectable?: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    path?: string | object;
+    inlineBlock?: boolean;
+    block?: boolean;
+    disabled?: boolean;
+    external?: boolean;
+    gutter?: string;
+    verticalGutter?: string;
+    horizontalGutter?: string;
+    target?: string;
+    selectable?: boolean;
+  }>(),
+  { external: false },
+);
 
 const onClicked = (event, navigationCallback) => {
   if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || props.target === '_blank') {


### PR DESCRIPTION
## Summary
- handle `external` prop as boolean defaulting to `false` to render anchors correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba08a07d74832ebc67d51aa0eb573d