### PR TITLE
fix external link protocol

### DIFF
--- a/src/shared/components/atoms/link/Link.vue
+++ b/src/shared/components/atoms/link/Link.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from 'vue';
+
 const props = defineProps<{
   path?: string | object;
   inlineBlock?: boolean;
@@ -11,6 +13,16 @@ const props = defineProps<{
   target?: string;
   selectable?: boolean;
 }>();
+
+const externalHref = computed(() => {
+  if (props.external && typeof props.path === 'string') {
+    if (!props.path.startsWith('http://') && !props.path.startsWith('https://')) {
+      return `https://${props.path}`;
+    }
+  }
+
+  return props.path;
+});
 
 const onClicked = (event, navigationCallback) => {
   if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || props.target === '_blank') {
@@ -49,7 +61,7 @@ const onClicked = (event, navigationCallback) => {
       v-if="external && !disabled"
       class="hover:text-gray-600"
       target="_blank"
-      :href="String(path)"
+      :href="String(externalHref)"
     >
       <slot />
     </a>

--- a/src/shared/components/atoms/link/__tests__/Link.spec.ts
+++ b/src/shared/components/atoms/link/__tests__/Link.spec.ts
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils';
+import Link from '../Link.vue';
+
+describe('Link', () => {
+  it('prefixes https when external path lacks protocol', () => {
+    const wrapper = mount(Link, {
+      props: {
+        external: true,
+        path: 'www.amazon.co.uk/dp/B06XSLGTC5',
+      },
+    });
+
+    const anchor = wrapper.find('a');
+    expect(anchor.attributes('href')).toBe('https://www.amazon.co.uk/dp/B06XSLGTC5');
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure external links include protocol
- add unit test for external link protocol

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68ba0c54a080832ea47b72e575c8dbe5

## Summary by Sourcery

Ensure external links include a protocol and add tests to verify this behavior

Bug Fixes:
- Automatically prepend "https://" to external link paths missing a protocol

Enhancements:
- Use a computed property to generate the href for external links

Tests:
- Add unit tests for external link protocol handling