### PR TITLE
Use cache-first queries for dashboard cards

### DIFF
--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-general/DashboardSectionGeneral.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-general/DashboardSectionGeneral.vue
@@ -121,36 +121,29 @@ const generalCards = ref([
 async function fetchGeneralCounts() {
   loading.value = true
 
-  const fetchPromises = generalCards.value.map((card) => {
-    return new Promise<void>((resolve) => {
-      const queryRef = apolloClient.watchQuery({
+  const fetchPromises = generalCards.value.map(async (card) => {
+    try {
+      const { data } = await apolloClient.query({
         query: card.query,
-        fetchPolicy: 'cache-and-network',
+        fetchPolicy: 'cache-first',
       });
 
-      queryRef.subscribe({
-        next: ({ data }) => {
-          if (data[card.key]) {
-            card.counter = data[card.key].totalCount;
-          } else {
-            card.counter = 0;
-          }
+      if (data[card.key]) {
+        card.counter = data[card.key].totalCount;
+      } else {
+        card.counter = 0;
+      }
 
-          if (card.counter !== 0 && hideGeneralSection.value) {
-            hideGeneralSection.value = false;
-          }
+      if (card.counter !== 0 && hideGeneralSection.value) {
+        hideGeneralSection.value = false;
+      }
 
-          card.loading = false;
-          resolve();
-        },
-        error: (err) => {
-          console.error(`Error fetching data for ${card.key}:`, err);
-          card.counter = 0;
-          card.loading = false;
-          resolve();
-        },
-      });
-    });
+      card.loading = false;
+    } catch (err) {
+      console.error(`Error fetching data for ${card.key}:`, err);
+      card.counter = 0;
+      card.loading = false;
+    }
   });
 
   await Promise.all(fetchPromises);

--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-products/DashboardSectionProducts.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-products/DashboardSectionProducts.vue
@@ -42,40 +42,26 @@ const productErrors = ref([
 
 async function fetchErrorCounts() {
   loading.value = true;
-  const promises = productErrors.value.map((error) => {
-    return new Promise<void>((resolve) => {
-      try {
-        const queryRef = apolloClient.watchQuery({
-          query: productsDashboardCardsQuery,
-          variables: { errorCode: error.errorCode.toString() },
-          fetchPolicy: 'cache-and-network',
-        });
+  const promises = productErrors.value.map(async (error) => {
+    try {
+      const { data } = await apolloClient.query({
+        query: productsDashboardCardsQuery,
+        variables: { errorCode: error.errorCode.toString() },
+        fetchPolicy: 'cache-first',
+      });
 
-        queryRef.subscribe({
-          next: ({ data }) => {
-            error.counter = data?.products.totalCount || 0;
+      error.counter = data?.products.totalCount || 0;
 
-            if (error.counter !== 0 && allCardsCompleted.value) {
-              allCardsCompleted.value = false;
-            }
-
-            error.loading = false;
-            resolve();
-          },
-          error: (err) => {
-            console.error(`Error fetching data for error code ${error.errorCode}:`, err);
-            error.counter = 0;
-            error.loading = false;
-            resolve();
-          },
-        });
-      } catch (err) {
-        console.error(`Error fetching data for error code ${error.errorCode}:`, err);
-        error.counter = 0;
-        error.loading = false;
-        resolve();
+      if (error.counter !== 0 && allCardsCompleted.value) {
+        allCardsCompleted.value = false;
       }
-    });
+
+      error.loading = false;
+    } catch (err) {
+      console.error(`Error fetching data for error code ${error.errorCode}:`, err);
+      error.counter = 0;
+      error.loading = false;
+    }
   });
 
   await Promise.all(promises);


### PR DESCRIPTION
## Summary
- switch dashboard Amazon queries to `cache-first` and use `apolloClient.query`
- update general dashboard cards to query with cache-first
- update product dashboard cards to query with cache-first

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb3f8de864832ea137a01392f82d0e