### PR TITLE
Improve filter modal responsiveness

### DIFF
--- a/src/shared/components/organisms/general-search/containers/filter-modal/FilterModal.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/FilterModal.vue
@@ -40,7 +40,8 @@ const getFilterComponent = (type) => {
 };
 
 const gridClass = computed(() => {
-  return `grid grid-cols-1 ${props.cols === 2 ? 'md:grid-cols-2' : ''} gap-4`;});
+  return 'grid grid-cols-1 md:grid-cols-2 gap-4';
+});
 
 const cancel = () => {
   emit('cancel-clicked');
@@ -53,7 +54,7 @@ const submit = () => {
 </script>
 
 <template>
-  <Card class="w-1/2">
+  <Card class="w-full md:w-4/5 lg:w-3/4 max-h-[80vh] overflow-y-auto">
     <div :class="gridClass">
       <component
         v-for="filter in filters"


### PR DESCRIPTION
## Summary
- widen filter modal on large screens and add internal scrolling
- show two filters per row on medium screens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb403fb1dc832e91b856db2fe5dcee