### PR TITLE
Hide 'All' chip for strict boolean filters

### DIFF
--- a/src/shared/components/organisms/general-listing/GeneralListing.vue
+++ b/src/shared/components/organisms/general-listing/GeneralListing.vue
@@ -198,6 +198,8 @@ const filterChips = computed(() => {
     if (param === undefined || param === null || param === '') {
       return;
     }
+    const isStrictBoolean =
+      filter.type === FieldType.Boolean && filter.strict;
     const map =
       'options' in filter && filter.options
         ? Object.fromEntries(
@@ -207,6 +209,9 @@ const filterChips = computed(() => {
     if (Array.isArray(param)) {
       param.forEach((v: any) => {
         const key = String(v);
+        if (isStrictBoolean && key === 'all') {
+          return;
+        }
         let display = map?.[key] || stored[key]?.label;
         if (!display && 'query' in filter && filter.query) {
           fetchFilterLabel(filter, key, stored);
@@ -216,6 +221,9 @@ const filterChips = computed(() => {
       });
     } else {
       const key = String(param);
+      if (isStrictBoolean && key === 'all') {
+        return;
+      }
       let display = map?.[key] || stored[key]?.label;
       if (!display && 'query' in filter && filter.query) {
         fetchFilterLabel(filter, key, stored);


### PR DESCRIPTION
## Summary
- Skip rendering filter chips when a strict boolean filter is set to "all"
- Remove translation changes around the boolean selector's "All" option

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb42c29b74832e804a14ae476aa3b7