### PR TITLE
Hide 'All' chip for strict boolean filters

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -28,7 +28,9 @@
       "context": "Kontext",
       "noIssues": "Keine Probleme",
       "active": "Active",
-      "inactive": "Inactive"
+      "inactive": "Inactive",
+      "yes": "Ja",
+      "no": "Nein"
     },
     "alert": {
       "noData": "Die Regel hat keine erforderlichen Konfiguratoreigenschaften, daher k\u00f6nnen keine Varianten generiert werden."

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -28,7 +28,9 @@
       "context": "Contexte",
       "noIssues": "Aucun problème",
       "active": "Active",
-      "inactive": "Inactive"
+      "inactive": "Inactive",
+      "yes": "Oui",
+      "no": "Non"
     },
     "alert": {
       "noData": "La règle ne contient aucune propriété requise dans le configurateur, nous ne pouvons donc pas générer de variations."

--- a/src/shared/components/organisms/general-listing/GeneralListing.vue
+++ b/src/shared/components/organisms/general-listing/GeneralListing.vue
@@ -198,6 +198,8 @@ const filterChips = computed(() => {
     if (param === undefined || param === null || param === '') {
       return;
     }
+    const isStrictBoolean =
+      filter.type === FieldType.Boolean && filter.strict;
     const map =
       'options' in filter && filter.options
         ? Object.fromEntries(
@@ -207,21 +209,35 @@ const filterChips = computed(() => {
     if (Array.isArray(param)) {
       param.forEach((v: any) => {
         const key = String(v);
+        if (isStrictBoolean && key === 'all') {
+          return;
+        }
         let display = map?.[key] || stored[key]?.label;
         if (!display && 'query' in filter && filter.query) {
           fetchFilterLabel(filter, key, stored);
           display = key;
         }
-        chips.push({ key: filter.name, label, value: display || key, rawValue: key });
+        let value = display || key;
+        if (filter.type === FieldType.Boolean) {
+          value = value === 'true' ? t('shared.labels.yes') : value === 'false' ? t('shared.labels.no') : value;
+        }
+        chips.push({ key: filter.name, label, value, rawValue: key });
       });
     } else {
       const key = String(param);
+      if (isStrictBoolean && key === 'all') {
+        return;
+      }
       let display = map?.[key] || stored[key]?.label;
       if (!display && 'query' in filter && filter.query) {
         fetchFilterLabel(filter, key, stored);
         display = key;
       }
-      chips.push({ key: filter.name, label, value: display || key, rawValue: key });
+      let value = display || key;
+      if (filter.type === FieldType.Boolean) {
+        value = value === 'true' ? t('shared.labels.yes') : value === 'false' ? t('shared.labels.no') : value;
+      }
+      chips.push({ key: filter.name, label, value, rawValue: key });
     }
   });
   return chips;


### PR DESCRIPTION
## Summary
- Skip rendering filter chips when a strict boolean filter is set to "all"
- Translate boolean filter chip values to localized "Yes"/"No"
- Add missing "yes"/"no" keys to French and German locale files

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb42c29b74832e804a14ae476aa3b7

## Summary by Sourcery

Prevent 'All' chips from rendering for strict boolean filters and enhance filter chip display by translating boolean values to localized 'Yes'/'No' with added French and German locale entries

Bug Fixes:
- Hide 'All' chip for strict boolean filters in the filter chips UI

Enhancements:
- Localize boolean filter chip values to display 'Yes'/'No' instead of raw 'true'/'false'
- Add missing 'yes' and 'no' keys to French and German locale files