### PR TITLE
Add Name Too Long filter to Amazon issues

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/configs.ts
@@ -9,6 +9,7 @@ const getCodeBadgeMap = (t: Function) => ({
   NO_MAPPED_PRODUCT_TYPE: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE') },
   PRODUCT_TYPE_MISMATCH: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH') },
   UPDATE_ONLY_NOT_FOUND: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND') },
+  NAME_TOO_LONG: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.NAME_TOO_LONG') },
 });
 
 export const searchConfigConstructor = (t: Function): SearchConfig => ({
@@ -24,6 +25,7 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
         { label: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE'), value: 'NO_MAPPED_PRODUCT_TYPE' },
         { label: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH'), value: 'PRODUCT_TYPE_MISMATCH' },
         { label: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND'), value: 'UPDATE_ONLY_NOT_FOUND' },
+        { label: t('integrations.imports.brokenRecords.codes.NAME_TOO_LONG'), value: 'NAME_TOO_LONG' },
       ],
       labelBy: 'label',
       valueBy: 'value',

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -158,7 +158,8 @@
           "MISSING_DATA": "Missing data",
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
-          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found",
+          "NAME_TOO_LONG": "Name too long"
         }
       }
     }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2815,7 +2815,8 @@
           "MISSING_DATA": "Missing data",
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
-          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found",
+          "NAME_TOO_LONG": "Name too long"
         }
       },
       "create": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -158,7 +158,8 @@
           "MISSING_DATA": "Missing data",
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
-          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found",
+          "NAME_TOO_LONG": "Name too long"
         }
       }
     }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1949,7 +1949,8 @@
           "MISSING_DATA": "Missing data",
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
-          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found",
+          "NAME_TOO_LONG": "Name too long"
         }
       }
     }


### PR DESCRIPTION
## Summary
- add NAME_TOO_LONG code to Amazon import issues filter
- translate NAME_TOO_LONG label for Amazon import broken records

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb48298114832e8b279bc3af7d0677

## Summary by Sourcery

Add a new NAME_TOO_LONG filter for Amazon import broken records and include its badge mapping, search option, and translations.

New Features:
- Add NAME_TOO_LONG code to the broken records badge map and filter dropdown

Documentation:
- Provide NAME_TOO_LONG translation entries in locale files for all supported languages