### PR TITLE
Add Name Too Long and Invalid Variation Theme filters to Amazon issues

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/configs.ts
@@ -9,6 +9,8 @@ const getCodeBadgeMap = (t: Function) => ({
   NO_MAPPED_PRODUCT_TYPE: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE') },
   PRODUCT_TYPE_MISMATCH: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH') },
   UPDATE_ONLY_NOT_FOUND: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND') },
+  NAME_TOO_LONG: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.NAME_TOO_LONG') },
+  INVALID_VARIATION_THEME: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.INVALID_VARIATION_THEME') },
 });
 
 export const searchConfigConstructor = (t: Function): SearchConfig => ({
@@ -24,6 +26,8 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
         { label: t('integrations.imports.brokenRecords.codes.NO_MAPPED_PRODUCT_TYPE'), value: 'NO_MAPPED_PRODUCT_TYPE' },
         { label: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH'), value: 'PRODUCT_TYPE_MISMATCH' },
         { label: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND'), value: 'UPDATE_ONLY_NOT_FOUND' },
+        { label: t('integrations.imports.brokenRecords.codes.NAME_TOO_LONG'), value: 'NAME_TOO_LONG' },
+        { label: t('integrations.imports.brokenRecords.codes.INVALID_VARIATION_THEME'), value: 'INVALID_VARIATION_THEME' },
       ],
       labelBy: 'label',
       valueBy: 'value',

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -158,7 +158,9 @@
           "MISSING_DATA": "Missing data",
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
-          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found",
+          "NAME_TOO_LONG": "Name too long",
+          "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       }
     }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2815,7 +2815,9 @@
           "MISSING_DATA": "Missing data",
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
-          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found",
+          "NAME_TOO_LONG": "Name too long",
+          "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       },
       "create": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -158,7 +158,9 @@
           "MISSING_DATA": "Missing data",
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
-          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found",
+          "NAME_TOO_LONG": "Name too long",
+          "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       }
     }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1949,7 +1949,9 @@
           "MISSING_DATA": "Missing data",
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
-          "UPDATE_ONLY_NOT_FOUND": "Update only not found"
+          "UPDATE_ONLY_NOT_FOUND": "Update only not found",
+          "NAME_TOO_LONG": "Name too long",
+          "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       }
     }


### PR DESCRIPTION
## Summary
- add NAME_TOO_LONG and INVALID_VARIATION_THEME codes to Amazon import issues filter
- translate NAME_TOO_LONG and INVALID_VARIATION_THEME labels for Amazon import broken records

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb48298114832e8b279bc3af7d0677

## Summary by Sourcery

Add support for two new Amazon import issue codes and their translations

New Features:
- Add NAME_TOO_LONG and INVALID_VARIATION_THEME codes to the badge map and filters for Amazon import broken records
- Add corresponding translation entries for NAME_TOO_LONG and INVALID_VARIATION_THEME in en, de, fr, and nl locale files