### PR TITLE
Add mapping for INVALID_VARIATION_THEME import error

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/configs.ts
@@ -10,6 +10,7 @@ const getCodeBadgeMap = (t: Function) => ({
   PRODUCT_TYPE_MISMATCH: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH') },
   UPDATE_ONLY_NOT_FOUND: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND') },
   NAME_TOO_LONG: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.NAME_TOO_LONG') },
+  INVALID_VARIATION_THEME: { color: 'orange', text: t('integrations.imports.brokenRecords.codes.INVALID_VARIATION_THEME') },
 });
 
 export const searchConfigConstructor = (t: Function): SearchConfig => ({
@@ -26,6 +27,7 @@ export const searchConfigConstructor = (t: Function): SearchConfig => ({
         { label: t('integrations.imports.brokenRecords.codes.PRODUCT_TYPE_MISMATCH'), value: 'PRODUCT_TYPE_MISMATCH' },
         { label: t('integrations.imports.brokenRecords.codes.UPDATE_ONLY_NOT_FOUND'), value: 'UPDATE_ONLY_NOT_FOUND' },
         { label: t('integrations.imports.brokenRecords.codes.NAME_TOO_LONG'), value: 'NAME_TOO_LONG' },
+        { label: t('integrations.imports.brokenRecords.codes.INVALID_VARIATION_THEME'), value: 'INVALID_VARIATION_THEME' },
       ],
       labelBy: 'label',
       valueBy: 'value',

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -159,7 +159,8 @@
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
           "UPDATE_ONLY_NOT_FOUND": "Update only not found",
-          "NAME_TOO_LONG": "Name too long"
+          "NAME_TOO_LONG": "Name too long",
+          "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       }
     }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2816,7 +2816,8 @@
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
           "UPDATE_ONLY_NOT_FOUND": "Update only not found",
-          "NAME_TOO_LONG": "Name too long"
+          "NAME_TOO_LONG": "Name too long",
+          "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       },
       "create": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -159,7 +159,8 @@
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
           "UPDATE_ONLY_NOT_FOUND": "Update only not found",
-          "NAME_TOO_LONG": "Name too long"
+          "NAME_TOO_LONG": "Name too long",
+          "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       }
     }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1950,7 +1950,8 @@
           "NO_MAPPED_PRODUCT_TYPE": "No mapped product type",
           "PRODUCT_TYPE_MISMATCH": "Product type mismatch",
           "UPDATE_ONLY_NOT_FOUND": "Update only not found",
-          "NAME_TOO_LONG": "Name too long"
+          "NAME_TOO_LONG": "Name too long",
+          "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       }
     }


### PR DESCRIPTION
## Summary
- handle `INVALID_VARIATION_THEME` in broken import records
- add translations for `INVALID_VARIATION_THEME`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe602275c832e895462a68b735314

## Summary by Sourcery

Add support for the INVALID_VARIATION_THEME import error by updating the UI mapping and including necessary translations.

New Features:
- Support INVALID_VARIATION_THEME error code in broken import records UI with badge and search filter
- Add translation entries for INVALID_VARIATION_THEME in de, en, fr, and nl locales