### PR TITLE
feat: isolate tab query in amazon import issues modal

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/AmazonImportBrokenRecordsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/import-show/components/AmazonImportBrokenRecordsListing.vue
@@ -43,6 +43,7 @@ const openModal = (record: any) => {
     <Modal v-model="showModal" @closed="showModal = false">
       <Card class="modal-content w-[800px] h-[600px] overflow-auto">
         <Tabs
+          tab-key="amazonImportIssuesModal"
           :tabs="[
             { name: 'message', label: t('shared.labels.message'), alwaysRender: true },
             { name: 'data', label: t('shared.labels.data'), alwaysRender: true },

--- a/src/shared/components/molecules/tabs/Tabs.vue
+++ b/src/shared/components/molecules/tabs/Tabs.vue
@@ -17,9 +17,11 @@ const props = withDefaults(
     tabs: TabItem[];
     disabledTabs?: string[];
     transparent?: boolean;
+    tabKey?: string;
   }>(),
   {
     disabledTabs: () => ([] as string[]),
+    tabKey: 'tab',
   }
 );
 const emit = defineEmits(['tab-changed']);
@@ -28,14 +30,14 @@ const selectedTab = ref(props.tabs[0]?.name);
 const route = useRoute();
 const router = useRouter();
 
-watch(() => route.query.tab, (newTab) => {
+watch(() => route.query[props.tabKey], (newTab) => {
   if (newTab && props.tabs.some(tab => tab.name === newTab)) {
     selectedTab.value = newTab.toString();
   }
 });
 
 onMounted(() => {
-  const queryTab = route.query.tab;
+  const queryTab = route.query[props.tabKey];
   if (queryTab && props.tabs.some(tab => tab.name === queryTab)) {
     selectedTab.value = queryTab.toString();
   }
@@ -47,7 +49,7 @@ const isHighlighted = (tab: TabItem) => !isSelected(tab.name) && tab.danger;
 const changeTab = (index) => {
   const newTab = props.tabs[index].name;
   selectedTab.value = newTab;
-  router.push({ query: { tab: newTab } });
+  router.push({ query: { ...route.query, [props.tabKey]: newTab } });
   emit('tab-changed', newTab);
 };
 


### PR DESCRIPTION
## Summary
- add configurable `tabKey` to Tabs component and preserve existing route queries
- use separate query key for Amazon import issues modal tabs to avoid interfering with main page

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build` *(fails: command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bbefe1b0b8832e947c3f8401d889b5