### PR TITLE
refactor: streamline price list queries

### DIFF
--- a/src/core/sales/price-lists/price-list-show/containers/items/configs.ts
+++ b/src/core/sales/price-lists/price-list-show/containers/items/configs.ts
@@ -13,7 +13,6 @@ export const baseFormConfigConstructor = (
   mutationKey: string,
   salesPriceListId: string,
   autoUpdatePrice: boolean = false,
-  productsId: string[] = [],
   currency: string | undefined = undefined
 ): FormConfig => {
   let fields: FormField[] = [
@@ -30,10 +29,17 @@ export const baseFormConfigConstructor = (
       valueBy: 'id',
       query: productsQuerySelector,
       dataKey: 'products',
-      queryVariables:
-        productsId.length > 0
-          ? { filter: { NOT: { id: { inList: productsId } } } }
-          : undefined,
+      queryVariables: {
+        filter: {
+          NOT: {
+            salespricelistitemSet: {
+              some: {
+                salespricelist: { id: { exact: salesPriceListId } }
+              }
+            }
+          }
+        }
+      },
       isEdge: true,
       multiple: false,
       filterable: true,

--- a/src/core/sales/price-lists/price-list-show/containers/items/item-create/ItemCreateController.vue
+++ b/src/core/sales/price-lists/price-list-show/containers/items/item-create/ItemCreateController.vue
@@ -2,12 +2,12 @@
 
 import { useI18n } from 'vue-i18n';
 import { GeneralForm } from "../../../../../../../shared/components/organisms/general-form";
-import { filterAndExtractIds, FormConfig, FormType } from '../../../../../../../shared/components/organisms/general-form/formConfig';
+import { FormConfig, FormType } from '../../../../../../../shared/components/organisms/general-form/formConfig';
 import { createSalesPriceListItemMutation } from "../../../../../../../shared/api/mutations/salesPrices.js"
 import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../shared/components/molecules/breadcrumbs";
 import { ref, onMounted, Ref} from "vue";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import { baseFormConfigConstructor} from "../configs";
 import apolloClient from "../../../../../../../../apollo-client";
 import { getSalesPriceListQuery } from "../../../../../../../shared/api/queries/salesPrices.js";
@@ -16,7 +16,6 @@ const route = useRoute();
 const { t } = useI18n();
 const priceListId = ref(route.params.priceListId);
 const formConfig: Ref<any | null> = ref(null);
-const productIds = ref([]);
 
 onMounted(async () => {
   const { data } = await apolloClient.query({
@@ -26,7 +25,6 @@ onMounted(async () => {
 
   if (data && data.salesPriceList) {
     const autoUpdatePrices = data.salesPriceList.autoUpdatePrices;
-    productIds.value = filterAndExtractIds(data.salesPriceList.salespricelistitemSet, ['product', 'id']);
 
     formConfig.value = {
       ...baseFormConfigConstructor(
@@ -36,7 +34,6 @@ onMounted(async () => {
         'createSalesPriceListItem',
         priceListId.value.toString(),
         autoUpdatePrices,
-        productIds.value,
         data.salesPriceList.currency.symbol
       ),
       submitAndContinueUrl: { name: 'sales.priceLists.items.edit', params: { priceListId: priceListId.value } }

--- a/src/core/sales/price-lists/price-list-show/containers/items/item-edit/ItemEditController.vue
+++ b/src/core/sales/price-lists/price-list-show/containers/items/item-edit/ItemEditController.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from "vue-router";
 import { Ref, ref, onMounted } from "vue";
 import { GeneralForm } from "../../../../../../../shared/components/organisms/general-form";
-import {filterAndExtractIds, FormConfig, FormType} from "../../../../../../../shared/components/organisms/general-form/formConfig";
+import { FormConfig, FormType} from "../../../../../../../shared/components/organisms/general-form/formConfig";
 import { FieldType } from "../../../../../../../shared/utils/constants";
 import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
 import { Breadcrumbs } from "../../../../../../../shared/components/molecules/breadcrumbs";
@@ -18,7 +18,6 @@ const { t } = useI18n();
 const route = useRoute();
 const id = ref(String(route.params.id));
 const priceListId = ref(route.params.priceListId);
-const productIds = ref([]);
 const formConfig: Ref<any| null> = ref(null);
 
 onMounted(async () => {
@@ -28,15 +27,7 @@ onMounted(async () => {
   });
 
   if (data && data.salesPriceList) {
-    const autoUpdatePrice = data.salesPriceList.autoUpdate;
-
-    productIds.value = filterAndExtractIds(
-      data.salesPriceList.salespricelistitemSet,
-      ['product', 'id'],
-      ['id'],
-      id.value.toString()
-    );
-
+    const autoUpdatePrice = data.salesPriceList.autoUpdatePrices;
 
     const baseForm = baseFormConfigConstructor(
       t,
@@ -45,7 +36,6 @@ onMounted(async () => {
       'updateSalesPriceListItem',
       priceListId.value.toString(),
       autoUpdatePrice,
-      productIds.value,
       data.salesPriceList.currency.symbol
     );
 

--- a/src/shared/api/queries/salesPrices.js
+++ b/src/shared/api/queries/salesPrices.js
@@ -186,12 +186,6 @@ export const getSalesPriceListQuery = gql`
       autoUpdatePrices
       startDate
       endDate
-      salespricelistitemSet {
-        id
-        product {
-          id
-        }
-      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- remove loading of price list items in `getSalesPriceListQuery`
- exclude existing products server-side in item form config
- simplify price list item edit/create controllers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be92f57e08832e95fd446ecb1b232e

## Summary by Sourcery

Refactor price list item queries and form logic to remove client-side filtering and prefetching, instead using server-side exclusion and simplifying controllers

Enhancements:
- Remove salespricelistitemSet from getSalesPriceListQuery to stop loading existing price list items
- Exclude already associated products in form configs via a server-side GraphQL filter instead of passing id arrays
- Simplify ItemEditController and ItemCreateController by removing productIds refs and filterAndExtractIds usage
- Rename autoUpdate to autoUpdatePrices to align with the updated GraphQL schema