### PR TITLE
Add Save all button for properties

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -17,6 +17,7 @@ import {translationLanguagesQuery} from "../../../../../../../shared/api/queries
 import {Selector} from "../../../../../../../shared/components/atoms/selector";
 import {Icon} from "../../../../../../../shared/components/atoms/icon";
 import {Pagination} from "../../../../../../../shared/components/molecules/pagination";
+import {Button} from "../../../../../../../shared/components/atoms/button";
 
 
 const {t} = useI18n();
@@ -27,6 +28,15 @@ const values: Ref<ProductPropertyValue[]> = ref([]);
 const lastSavedValues: Ref<ProductPropertyValue[]> = ref([]);
 const loading = ref(false);
 const language: Ref<string | null> = ref(null);
+const valueInputs = ref<InstanceType<typeof ValueInput>[]>([]);
+const hasUnsavedChanges = computed(() => valueInputs.value.some(v => v?.hasChanges));
+const saveAll = async () => {
+  for (const v of valueInputs.value) {
+    if (v?.hasChanges) {
+      await v.saveChanges();
+    }
+  }
+};
 
 const currentPage = ref(1);
 const limit = ref(10);
@@ -491,8 +501,8 @@ const handleValueUpdate = ({id, type, value, language}) => {
           </div>
         </div>
       </FlexCell>
-      <FlexCell v-if="language">
-        <ApolloQuery :query="translationLanguagesQuery" fetch-policy="cache-and-network">
+      <FlexCell class="flex items-center space-x-2">
+        <ApolloQuery v-if="language" :query="translationLanguagesQuery" fetch-policy="cache-and-network">
           <template v-slot="{ result: { data } }">
             <Selector v-if="data"
                       v-model="language"
@@ -506,6 +516,9 @@ const handleValueUpdate = ({id, type, value, language}) => {
                       filterable/>
           </template>
         </ApolloQuery>
+        <Button class="btn btn-primary" :disabled="!hasUnsavedChanges" @click="saveAll">
+          {{ t('shared.button.saveAll') }}
+        </Button>
       </FlexCell>
     </Flex>
     <Loader :loading="loading"/>
@@ -520,6 +533,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
             @update-id="handleUpdatedId"
             @update-value="handleValueUpdate"
             @remove="handleRemove"
+            ref="valueInputs"
         />
         <hr class="my-4"/>
       </div>
@@ -533,6 +547,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
             @update-id="handleUpdatedId"
             @update-value="handleValueUpdate"
             @remove="handleRemove"
+            ref="valueInputs"
         />
       </div>
     </div>

--- a/src/core/products/products/product-show/containers/tabs/properties/value-input/ValueInput.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/value-input/ValueInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import {ref, onMounted, watch, Ref} from 'vue';
+import {ref, onMounted, watch, Ref, computed} from 'vue';
 import {ProductPropertyValue} from "../../../../../configs";
 import {ConfigTypes, FieldType, flagMapping, PropertyTypes} from "../../../../../../../../shared/utils/constants";
 import {FieldQuery} from "../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
@@ -36,6 +36,7 @@ const val: Ref<any> = ref(null);
 const lastSavedVal: Ref<any> = ref(null);
 const lastSavedLanguage: Ref<any> = ref(null);
 const saving = ref(false);
+const hasChanges = computed(() => val.value !== lastSavedVal.value);
 
 const createInputData = () => {
   const inputData: any = {
@@ -372,6 +373,8 @@ const getTooltip = (requireType) => {
       return '';
   }
 }
+
+defineExpose({ saveChanges, hasChanges });
 
 </script>
 

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -8,7 +8,8 @@
       "duplicate": "Duplizieren",
       "resync": "Resync",
       "validate": "Validate",
-      "fetchIssues": "Fetch Issues"
+      "fetchIssues": "Fetch Issues",
+      "saveAll": "Alles speichern"
     },
     "colors": {
       "red": "Rot",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -330,6 +330,7 @@
       "invite": "Invite",
       "search": "Search",
       "save": "Save",
+      "saveAll": "Save all",
       "details": "Details",
       "fix": "Fix",
       "back": "Back",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -8,7 +8,8 @@
       "duplicate": "Dupliquer",
       "resync": "Resync",
       "validate": "Validate",
-      "fetchIssues": "Fetch Issues"
+      "fetchIssues": "Fetch Issues",
+      "saveAll": "Tout enregistrer"
     },
     "colors": {
       "red": "Rouge",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -160,6 +160,7 @@
       "invite": "Uitnodigen",
       "search": "Zoeken",
       "save": "Opslaan",
+      "saveAll": "Alles opslaan",
       "back": "Terug",
       "next": "Volgende",
       "finish": "Afwerken",


### PR DESCRIPTION
## Summary
- add Save all button to product properties view
- expose bulk save capability in value input components
- add translations for Save all button

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68befeb4fca4832e9330cd1a6d7a1fe9

## Summary by Sourcery

Add a Save all button to bulk save modified product property values and enable change detection in value inputs.

New Features:
- Add 'Save all' button to product properties view for bulk saving of modified values

Enhancements:
- Expose hasChanges computed property and saveChanges method in ValueInput component to support bulk save operations

Documentation:
- Add translations for 'Save all' button in locale files