### PR TITLE
feat: reposition bullet points inputs

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
@@ -80,6 +80,10 @@ const emit = defineEmits<{
       </div>
     </FlexCell>
 
+    <FlexCell v-if="$slots['bullet-points']">
+      <slot name="bullet-points"></slot>
+    </FlexCell>
+
     <FlexCell v-if="showShortDescription">
       <Flex class="gap-4">
         <FlexCell center>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -356,16 +356,19 @@ const shortDescriptionToolbarOptions = [
           :sales-channel-id="currentSalesChannel !== 'default' ? currentSalesChannel : undefined"
           @description="handleGeneratedDescriptionContent"
           @shortDescription="handleGeneratedShortDescriptionContent"
-        />
-        <ProductTranslationBulletPoints
-          v-if="fieldRules.bulletPoints"
-          ref="bulletPointsRef"
-          :translation-id="translationId"
-          :product-id="product.id"
-          :language-code="currentLanguage"
-          :sales-channel-id="currentSalesChannel !== 'default' ? currentSalesChannel : undefined"
-          @initial-bullet-points="previewBulletPoints = [...$event]"
-        />
+        >
+          <template #bullet-points>
+            <ProductTranslationBulletPoints
+              v-if="fieldRules.bulletPoints"
+              ref="bulletPointsRef"
+              :translation-id="translationId"
+              :product-id="product.id"
+              :language-code="currentLanguage"
+              :sales-channel-id="currentSalesChannel !== 'default' ? currentSalesChannel : undefined"
+              @initial-bullet-points="previewBulletPoints = [...$event]"
+            />
+          </template>
+        </ProductContentForm>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- show bullet point inputs immediately after name field in product content form

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bf00d7fdf8832eb43c5ad71e8999d9

## Summary by Sourcery

Reposition bullet point inputs in the product content form by adding a named slot and injecting the ProductTranslationBulletPoints component directly after the name field.

Enhancements:
- Introduce a bullet-points named slot in ProductContentForm to enable insertion of bullet point inputs.
- Move the ProductTranslationBulletPoints component into the new slot so it renders immediately after the name field in the product content form.