### PR TITLE
fix: save all properties

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -31,7 +31,8 @@ const language: Ref<string | null> = ref(null);
 const valueInputs = ref<InstanceType<typeof ValueInput>[]>([]);
 const hasUnsavedChanges = computed(() => valueInputs.value.some(v => v?.hasChanges));
 const saveAll = async () => {
-  for (const v of valueInputs.value) {
+  const inputs = [...valueInputs.value];
+  for (const v of inputs) {
     if (v?.hasChanges) {
       await v.saveChanges();
     }


### PR DESCRIPTION
## Summary
- iterate over a snapshot of valueInputs when saving to avoid skipping last property

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf0300a9dc832ea566caa793a6ba97

## Summary by Sourcery

Bug Fixes:
- Fix saveAll to copy the valueInputs array before iterating so the last changed property is not skipped