### PR TITLE
Re-emit website assignment events to refresh Amazon products

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -99,7 +99,7 @@ const tabItems = computed(() => {
         <ProductSalePriceView :product="product" />
       </template>
       <template v-slot:websites>
-        <WebsitesView :product="product" />
+        <WebsitesView :product="product" @assign-added="fetchAmazonProducts" />
       </template>
       <template v-slot:priceLists>
         <SalesPricelistList :product="product" />

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -88,7 +88,7 @@ const tabItems = computed(() => {
         <VariationsView :product="product" />
       </template>
       <template v-slot:websites>
-        <WebsitesView :product="product" />
+        <WebsitesView :product="product" @assign-added="fetchAmazonProducts" />
       </template>
       <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -97,7 +97,7 @@ const tabItems = computed(() => {
         <AliasProductsView :product="product" />
       </template>
       <template v-slot:websites>
-        <WebsitesView :product="product" />
+        <WebsitesView :product="product" @assign-added="fetchAmazonProducts" />
       </template>
       <template v-slot:properties>
         <PropertiesView :product="product" />

--- a/src/core/products/products/product-show/containers/tabs/websites/WebsitesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/WebsitesView.vue
@@ -10,6 +10,7 @@ import {computed, Ref, ref, watch} from "vue";
 const { t } = useI18n();
 
 const props = defineProps<{ product: Product }>();
+const emit = defineEmits(['assign-added']);
 const ids: Ref<string[]> = ref([]);
 
 
@@ -33,7 +34,7 @@ watch(
       <WebsitesList :product="product" />
 
       <div class="mt-2">
-        <WebsiteAssignCreate :product="product" :views-ids="ids" />
+        <WebsiteAssignCreate :product="product" :views-ids="ids" @assign-added="emit('assign-added')" />
       </div>
     </template>
   </TabContentTemplate>


### PR DESCRIPTION
## Summary
- Re-emit `assign-added` from WebsitesView
- Refresh Amazon products when a website assignment is added for configurable, bundle, and variation products

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf03067edc832e83fdfe139758f3be

## Summary by Sourcery

Emit website assignment events from WebsitesView and trigger Amazon product refresh in bundle, configurable, and variation product tabs

New Features:
- Emit 'assign-added' event from WebsitesView when a new website assignment is created
- Invoke fetchAmazonProducts to refresh Amazon products in bundle, configurable, and variation views upon assignment