### PR TITLE
Refetch Amazon products on website assign deletion

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -18,6 +18,7 @@ import AliasProductsView from "../../tabs/alias-parents/AliasProductsView.vue";
 import AmazonView from "../../tabs/amazon/AmazonView.vue";
 import { amazonProductsQuery } from "../../../../../../../shared/api/queries/amazonProducts.js";
 import apolloClient from "../../../../../../../../apollo-client";
+import type { FetchPolicy } from "@apollo/client";
 import { injectAuth } from "../../../../../../../shared/modules/auth";
 
 const props = defineProps<{ product: Product }>();
@@ -27,17 +28,17 @@ const auth = injectAuth();
 
 const amazonProducts = ref<any[]>([]);
 
-const fetchAmazonProducts = async () => {
+const fetchAmazonProducts = async (fetchPolicy: FetchPolicy = 'cache-first') => {
   const { data } = await apolloClient.query({
     query: amazonProductsQuery,
     variables: { localInstance: props.product.id },
-    fetchPolicy: 'cache-first',
+    fetchPolicy,
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
 };
 
 if (auth.user.company?.hasAmazonIntegration) {
-  onMounted(fetchAmazonProducts);
+  onMounted(() => fetchAmazonProducts());
 }
 
 const tabItems = computed(() => {
@@ -99,7 +100,11 @@ const tabItems = computed(() => {
         <ProductSalePriceView :product="product" />
       </template>
       <template v-slot:websites>
-        <WebsitesView :product="product" @assign-added="fetchAmazonProducts" />
+        <WebsitesView
+          :product="product"
+          @assign-added="fetchAmazonProducts('network-only')"
+          @assign-deleted="fetchAmazonProducts('network-only')"
+        />
       </template>
       <template v-slot:priceLists>
         <SalesPricelistList :product="product" />
@@ -114,7 +119,7 @@ const tabItems = computed(() => {
         <AmazonView
           :product="product"
           :amazon-products="amazonProducts"
-          @refresh-amazon-products="fetchAmazonProducts"
+          @refresh-amazon-products="fetchAmazonProducts('network-only')"
         />
       </template>
     </Tabs>

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -18,6 +18,7 @@ import AliasProductsView from "../../tabs/alias-parents/AliasProductsView.vue";
 import AmazonView from "../../tabs/amazon/AmazonView.vue";
 import { amazonProductsQuery } from "../../../../../../../shared/api/queries/amazonProducts.js";
 import apolloClient from "../../../../../../../../apollo-client";
+import type { FetchPolicy } from "@apollo/client";
 import { injectAuth } from "../../../../../../../shared/modules/auth";
 
 const props = defineProps<{ product: Product }>();
@@ -27,17 +28,17 @@ const auth = injectAuth();
 
 const amazonProducts = ref<any[]>([]);
 
-const fetchAmazonProducts = async () => {
+const fetchAmazonProducts = async (fetchPolicy: FetchPolicy = 'cache-first') => {
   const { data } = await apolloClient.query({
     query: amazonProductsQuery,
     variables: { localInstance: props.product.id },
-    fetchPolicy: 'cache-first',
+    fetchPolicy,
   });
   amazonProducts.value = data.amazonProducts?.edges?.map((edge: any) => edge.node) || [];
 };
 
 if (auth.user.company?.hasAmazonIntegration) {
-  onMounted(fetchAmazonProducts);
+  onMounted(() => fetchAmazonProducts());
 }
 
 const tabItems = computed(() => {
@@ -97,7 +98,11 @@ const tabItems = computed(() => {
         <AliasProductsView :product="product" />
       </template>
       <template v-slot:websites>
-        <WebsitesView :product="product" @assign-added="fetchAmazonProducts" />
+        <WebsitesView
+          :product="product"
+          @assign-added="fetchAmazonProducts('network-only')"
+          @assign-deleted="fetchAmazonProducts('network-only')"
+        />
       </template>
       <template v-slot:properties>
         <PropertiesView :product="product" />
@@ -115,7 +120,7 @@ const tabItems = computed(() => {
         <AmazonView
           :product="product"
           :amazon-products="amazonProducts"
-          @refresh-amazon-products="fetchAmazonProducts"
+          @refresh-amazon-products="fetchAmazonProducts('network-only')"
         />
       </template>
     </Tabs>

--- a/src/core/products/products/product-show/containers/tabs/websites/WebsitesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/WebsitesView.vue
@@ -10,7 +10,7 @@ import {computed, Ref, ref, watch} from "vue";
 const { t } = useI18n();
 
 const props = defineProps<{ product: Product }>();
-const emit = defineEmits(['assign-added']);
+const emit = defineEmits(['assign-added', 'assign-deleted']);
 const ids: Ref<string[]> = ref([]);
 
 
@@ -31,7 +31,7 @@ watch(
 <template>
   <TabContentTemplate>
     <template v-slot:content>
-      <WebsitesList :product="product" />
+      <WebsitesList :product="product" @assign-deleted="emit('assign-deleted')" />
 
       <div class="mt-2">
         <WebsiteAssignCreate :product="product" :views-ids="ids" @assign-added="emit('assign-added')" />

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
@@ -16,6 +16,7 @@ import { LogsInfoModal } from "../logs-info-modal";
 
 const { t } = useI18n();
 const props = defineProps<{ product: Product }>();
+const emit = defineEmits(['assign-deleted']);
 const infoId = ref<string | null>(null);
 const showInfoModal = ref(false);
 const infoIntegrationType = ref<string | undefined>(undefined);
@@ -98,6 +99,7 @@ const issuesModalClosed = () => {
                 <ApolloAlertMutation
                   :mutation="deleteSalesChannelViewAssignMutation"
                   :mutation-variables="{ id: item.id }"
+                  @done="emit('assign-deleted')"
                 >
                   <template v-slot="{ loading, confirmAndMutate }">
                     <Button :disabled="loading" class="btn btn-sm btn-outline-danger" @click="confirmAndMutate">


### PR DESCRIPTION
## Summary
- Parameterize Amazon product fetch to accept custom fetch policy and use network-only for event-driven refreshes
- Emit assign-deleted events from websites list and propagate to refresh Amazon data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type 'string' is not assignable to type 'FetchPolicy | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68bf09ee3068832ea48b9a6f525127c1