### PR TITLE
Add Amazon inspector error cards

### DIFF
--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-products/DashboardSectionProducts.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-products/DashboardSectionProducts.vue
@@ -28,6 +28,8 @@ const productErrors = ref([
   { errorCode: 111, importance: 'high', icon: 'exclamation-triangle', color: 'red', counter: 0, loading: true  },
   { errorCode: 117, importance: 'high', icon: 'exclamation-triangle', color: 'red', counter: 0, loading: true  },
   { errorCode: 124, importance: 'high', icon: 'exclamation-triangle', color: 'red', counter: 0, loading: true  },
+  { errorCode: 125, importance: 'high', icon: 'exclamation-triangle', color: 'red', counter: 0, loading: true  },
+  { errorCode: 126, importance: 'high', icon: 'exclamation-triangle', color: 'red', counter: 0, loading: true  },
 
   // Medium importance errors
   { errorCode: 109, importance: 'medium', icon: 'exclamation-circle', color: 'orange', counter: 0, loading: true  },

--- a/src/core/products/products/configs.ts
+++ b/src/core/products/products/configs.ts
@@ -59,6 +59,8 @@ export const getInspectorErrors = (t) => [
   { code: "122", name: t(`dashboard.cards.products.inspector.122.title`) },
   { code: "123", name: t(`dashboard.cards.products.inspector.123.title`) },
   { code: "124", name: t(`dashboard.cards.products.inspector.124.title`) },
+  { code: "125", name: t(`dashboard.cards.products.inspector.125.title`) },
+  { code: "126", name: t(`dashboard.cards.products.inspector.126.title`) },
 ];
 
 

--- a/src/core/products/products/product-show/containers/product-inspector/ProductInspector.vue
+++ b/src/core/products/products/product-show/containers/product-inspector/ProductInspector.vue
@@ -132,6 +132,8 @@ const tabMap: Record<number, string> = {
   122: 'variations',
   123: 'variations',
   124: 'properties',
+  125: 'amazon',
+  126: 'amazon',
 };
 
 function setTab(tabName: string) {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -114,6 +114,14 @@
           "124": {
             "title": "Configurable Product Missing Rule Configuration",
             "description": "Define at least one configurator required item for these configurable products."
+          },
+          "125": {
+            "title": "Products with Amazon Validation Issues",
+            "description": "Review Amazon validation issues for these products in the Amazon tab."
+          },
+          "126": {
+            "title": "Products with Amazon Remote Issues",
+            "description": "Check the Amazon tab for remote issues reported by Amazon and resolve them."
           }
         }
       },
@@ -1039,7 +1047,9 @@
           "121": "Some Variations are incomplete",
           "122": "Some Bill of materials are incomplete",
           "123": "Some variations are duplicates",
-          "124": "Product type rule is not configured for a configurable product"
+          "124": "Product type rule is not configured for a configurable product",
+          "125": "Product has Amazon validation issues",
+          "126": "Product on Amazon has remote issues"
         },
         "help": {
           "101": "add at least one image to the product",
@@ -1065,7 +1075,9 @@
           "121": "resolve missing mandatory information in the variations",
           "122": "resolve missing mandatory information in the bills of materials",
           "123": "ensure all variations have a different configuration on their configurable properties",
-          "124": "define at least one configurator required item on the product type rule"
+          "124": "define at least one configurator required item on the product type rule",
+          "125": "Review the Amazon tab for validation issues and resolve them",
+          "126": "Check the Amazon tab for remote issues reported by Amazon"
         },
         "labels": {
           "missingInfo": "Missing Information",


### PR DESCRIPTION
## Summary
- support new Amazon validation and remote issue inspector codes
- show new Amazon issues in product and dashboard cards
- add translations for Amazon issue messaging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Type 'string' is not assignable to type 'FetchPolicy | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1a9738a4832e8f32b5c936024d1e