### PR TITLE
feat: support image uploads via URLs

### DIFF
--- a/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
+++ b/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
@@ -8,8 +8,9 @@ import { DropZone } from "../../../../../../shared/components/molecules/drop-zon
 import { useI18n } from "vue-i18n";
 import { Image } from "../../../../../../shared/components/atoms/image";
 import { Button } from "../../../../../../shared/components/atoms/button";
+import { TextInput } from "../../../../../../shared/components/atoms/input-text";
 import apolloClient from "../../../../../../../apollo-client";
-import { createImagesMutation, createMediaProductThroughMutation } from "../../../../../../shared/api/mutations/media.js"
+import { createImagesMutation, createMediaProductThroughMutation, uploadImagesFromUrlsMutation } from "../../../../../../shared/api/mutations/media.js"
 import { Toast } from "../../../../../../shared/modules/toast";
 import { IMAGE_TYPE_MOOD, IMAGE_TYPE_PACK } from "../../../media";
 import { processGraphQLErrors } from "../../../../../../shared/utils";
@@ -35,6 +36,8 @@ type Image = {
 
 const images: Ref<ShowImage[]> = ref([])
 const dropZone: Ref<any> = ref(null)
+const urlInput = ref('')
+const activeTab = ref<'upload' | 'urls'>('upload')
 
 const imageTypeOptions = [
   { label: t('media.images.labels.packShot'), value: IMAGE_TYPE_PACK },
@@ -48,6 +51,8 @@ watch(() => props.modelValue, (newVal) => {
 const closeModal = () => {
   localShowModal.value = false;
   images.value = [];
+  activeTab.value = 'upload'
+  urlInput.value = ''
   emit('update:modelValue', false);
 };
 
@@ -71,46 +76,65 @@ const updateImageType = (index, type) => {
 };
 
 const submitImages = async () => {
+  let mutation = createImagesMutation
+  let variables: any = {}
+  let dataKey = 'createImages'
 
-  let variables: Image[] = [];
-  images.value.forEach(image => {
-    variables.push({image: image.file, imageType: image.type});
-  });
-
-  const {data} = await apolloClient.mutate({
-    mutation: createImagesMutation,
-    variables: { data: variables }
-
-  });
-
-  if (data && data.createImages) {
-      if (props.productId) {
-        for (const image of data.createImages) {
-          const variables = {
-            product: {id: props.productId},
-            media: {id: image.id},
-          };
-          try {
-            const { data } = await apolloClient.mutate({
-              mutation: createMediaProductThroughMutation,
-              variables: { data: variables }
-            });
-            Toast.success(t('media.images.create.successfullyCreated'));
-          } catch (error) {
-            const validationErrors = processGraphQLErrors(error, t);
-            if (validationErrors['__all__']) {
-              Toast.error(validationErrors['__all__']);
-            }
-            console.error('Failed to link video and product:', error);
-          }
-        }
-    }
-
-    emit('entries-created');
-    closeModal();
+  if (activeTab.value === 'upload') {
+    variables.data = images.value.map(image => ({ image: image.file, imageType: image.type }))
+  } else {
+    mutation = uploadImagesFromUrlsMutation
+    dataKey = 'uploadImagesFromUrls'
+    variables.urls = images.value.map(image => ({ url: image.url, type: image.type }))
   }
 
+  const { data } = await apolloClient.mutate({
+    mutation,
+    variables
+  })
+
+  const createdImages = data && data[dataKey]
+
+  if (createdImages) {
+    if (props.productId) {
+      for (const image of createdImages) {
+        const variables = {
+          product: { id: props.productId },
+          media: { id: image.id },
+        }
+        try {
+          await apolloClient.mutate({
+            mutation: createMediaProductThroughMutation,
+            variables: { data: variables }
+          })
+          Toast.success(t('media.images.create.successfullyCreated'))
+        } catch (error) {
+          const validationErrors = processGraphQLErrors(error, t)
+          if (validationErrors['__all__']) {
+            Toast.error(validationErrors['__all__'])
+          }
+          console.error('Failed to link video and product:', error)
+        }
+      }
+    }
+
+    emit('entries-created')
+    closeModal()
+  }
 };
+
+const switchTab = (tab: 'upload' | 'urls') => {
+  if (images.value.length === 0) {
+    activeTab.value = tab
+  }
+}
+
+const addImageUrl = () => {
+  if (urlInput.value) {
+    images.value.push({ file: null, url: urlInput.value, type: IMAGE_TYPE_PACK })
+    urlInput.value = ''
+  }
+}
 
 </script>
 
@@ -121,7 +145,27 @@ const submitImages = async () => {
         <div class="mb-4">
           <h3 class="text-xl font-semibold leading-7 text-gray-900">{{ t('media.images.upload') }}</h3>
         </div>
-        <DropZone ref="dropZone" class="mt-2" :formats="['.jpg', '.png', '.jpeg']" @uploaded="onUploaded" />
+        <div class="flex border-b">
+          <button
+            class="mr-4 pb-2"
+            :class="{ 'border-b-2 border-primary text-primary': activeTab === 'upload', 'opacity-50 cursor-not-allowed': images.length > 0 && activeTab !== 'upload' }"
+            @click="switchTab('upload')"
+          >
+            {{ t('media.images.tabs.upload') }}
+          </button>
+          <button
+            class="pb-2"
+            :class="{ 'border-b-2 border-primary text-primary': activeTab === 'urls', 'opacity-50 cursor-not-allowed': images.length > 0 && activeTab !== 'urls' }"
+            @click="switchTab('urls')"
+          >
+            {{ t('media.images.tabs.urls') }}
+          </button>
+        </div>
+        <DropZone v-if="activeTab === 'upload'" ref="dropZone" class="mt-2" :formats="['.jpg', '.png', '.jpeg']" @uploaded="onUploaded" />
+        <div v-else class="mt-2 flex gap-2">
+          <TextInput class="flex-1" v-model="urlInput" :placeholder="t('media.images.labels.imageUrl')" />
+          <Button class="btn btn-primary" :disabled="!urlInput" @click="addImageUrl">{{ t('shared.button.add') }}</Button>
+        </div>
         <div class="gallery mt-2 grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4 p-4">
           <div v-for="(image, index) in images" :key="index" class="file-entry relative w-full h-full border border-gray-300 p-2 rounded-lg">
             <Flex vertical class="w-full">

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -318,6 +318,14 @@
       }
     }
   },
+  "media": {
+    "images": {
+      "tabs": {
+        "upload": "Hochladen",
+        "urls": "URLs"
+      }
+    }
+  },
   "properties": {
     "duplicateModal": {
       "title": "Properties with Similar Names Found",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1835,6 +1835,10 @@
     "images": {
       "title": "Images",
       "upload": "Upload New Images",
+      "tabs": {
+        "upload": "Upload",
+        "urls": "URLs"
+      },
       "create": {
         "successfullyCreated": "Images were successfully uploaded!"
       },

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -318,6 +318,14 @@
       }
     }
   },
+  "media": {
+    "images": {
+      "tabs": {
+        "upload": "Téléverser",
+        "urls": "URLs"
+      }
+    }
+  },
   "properties": {
     "duplicateModal": {
       "title": "Properties with Similar Names Found",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1485,6 +1485,10 @@
     "images": {
       "title": "Afbeeldingen",
       "upload": "Upload nieuwe afbeeldingen",
+      "tabs": {
+        "upload": "Uploaden",
+        "urls": "URL's"
+      },
       "create": {
         "successfullyCreated": "Afbeeldingen opgeslagen!"
       },

--- a/src/shared/api/mutations/media.js
+++ b/src/shared/api/mutations/media.js
@@ -64,6 +64,15 @@ export const createImagesMutation = gql`
   }
 `;
 
+export const uploadImagesFromUrlsMutation = gql`
+  mutation uploadImagesFromUrls($urls: [ImageUrlInput!]!) {
+    uploadImagesFromUrls(urls: $urls) {
+      id
+      imageWebUrl
+    }
+  }
+`;
+
 export const updateImageMutation = gql`
   mutation updateImage($data: ImagePartialInput!) {
     updateImage(data: $data) {


### PR DESCRIPTION
## Summary
- add Upload/URLs tabs to image modal and prevent tab switch after adding images
- allow submitting external image URLs with dedicated mutation
- localize tab labels across languages

## Testing
- `npm run build` *(fails: Type 'string' is not assignable to type 'FetchPolicy | undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68bf22f53f64832e9a7576bd124de2a2