### PR TITLE
Validate image URLs in image creation modal

### DIFF
--- a/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
+++ b/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
@@ -131,6 +131,11 @@ const switchTab = (tab: 'upload' | 'urls') => {
 
 const addImageUrl = () => {
   if (urlInput.value) {
+    const isValid = /(\.jpg|\.jpeg|\.png|\.webp)(\?.*)?$/i.test(urlInput.value)
+    if (!isValid) {
+      Toast.error(t('media.images.alert.toast.invalidUrl'))
+      return
+    }
     images.value.push({ file: null, url: urlInput.value, type: IMAGE_TYPE_PACK })
     urlInput.value = ''
   }

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -323,6 +323,11 @@
       "tabs": {
         "upload": "Hochladen",
         "urls": "URLs"
+      },
+      "alert": {
+        "toast": {
+          "invalidUrl": "Bitte geben Sie eine gültige Bild-URL ein (jpg, jpeg, png, webp)."
+        }
       }
     }
   },

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1863,7 +1863,8 @@
       "alert": {
         "toast": {
           "bulkDeleteSuccess": "Images deleted successfully.",
-          "bulkDeleteError": "Failed to delete images."
+          "bulkDeleteError": "Failed to delete images.",
+          "invalidUrl": "Please enter a valid image URL (jpg, jpeg, png, webp)."
         }
       }
     },

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -323,6 +323,11 @@
       "tabs": {
         "upload": "Téléverser",
         "urls": "URLs"
+      },
+      "alert": {
+        "toast": {
+          "invalidUrl": "Veuillez saisir une URL d'image valide (jpg, jpeg, png, webp)."
+        }
       }
     }
   },

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1509,6 +1509,11 @@
       },
       "placeholders": {
         "imageType": "Afbeeldingstype"
+      },
+      "alert": {
+        "toast": {
+          "invalidUrl": "Voer een geldige afbeeldings-URL in (jpg, jpeg, png, webp)."
+        }
       }
     },
     "videos": {


### PR DESCRIPTION
## Summary
- validate image URL extensions before adding new image links
- add translations for invalid image URL warnings

## Testing
- `npm run build` *(fails: Type 'string' is not assignable to type 'FetchPolicy | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68bf26cb1280832ea9f58db762363fa6