### PR TITLE
Load selected filter options immediately

### DIFF
--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
@@ -131,6 +131,10 @@ watchEffect(() => {
   emit('update-value', selectedValue.value);
 });
 
+watch(selectedValue, async () => {
+  await ensureSelectedValuesArePresent();
+}, { deep: true });
+
 watch([selectedValue, cleanedData], () => {
   const values = Array.isArray(selectedValue.value)
     ? selectedValue.value


### PR DESCRIPTION
## Summary
- ensure FilterQuery fetches missing selected values when selection changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Type 'string' is not assignable to type 'FetchPolicy | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68bfd7ee3038832eb3b6676e3deeb13e