### PR TITLE
Adjust inspector popover and highlight row in product list

### DIFF
--- a/src/shared/components/organisms/general-show/containers/field-inspector-progress/FieldInspectorProgress.vue
+++ b/src/shared/components/organisms/general-show/containers/field-inspector-progress/FieldInspectorProgress.vue
@@ -18,6 +18,15 @@ const props = defineProps<{
 const { t } = useI18n();
 
 const isMobile = ref(false);
+const container = ref<HTMLElement | null>(null);
+const highlightRow = () => {
+  const row = container.value?.closest('tr');
+  row?.classList.add('bg-indigo-50');
+};
+const unhighlightRow = () => {
+  const row = container.value?.closest('tr');
+  row?.classList.remove('bg-indigo-50');
+};
 const updateIsMobile = () => {
   isMobile.value = window.innerWidth <= 768;
 };
@@ -68,10 +77,10 @@ const barColor = computed(() => {
 </script>
 
 <template>
-  <div :class="field.customCssClass" :style="field.customCss">
-    <Popover position="middle" :hover="!isMobile">
+  <div ref="container" :class="field.customCssClass" :style="field.customCss">
+    <Popover position="bottom" :hover="!isMobile" @hidden="unhighlightRow">
       <template #trigger>
-        <div>
+        <div @mouseover="highlightRow" @click="highlightRow">
           <div class="w-20 mb-1">
             <span :class="[labelColor, 'text-sm', 'font-medium', 'block sm:hidden']">
               {{ Math.floor(modelValue?.percentage ?? 0) }}%


### PR DESCRIPTION
## Summary
- Position inspector popover below its trigger
- Highlight product row when inspector issues popover is open

## Testing
- `npm run build` (fails: Type 'string' is not assignable to type 'FetchPolicy | undefined')

------
https://chatgpt.com/codex/tasks/task_e_68bfdb2033f8832e95f73af2b0a5a909

## Summary by Sourcery

Adjust the inspector popover to appear below its trigger and highlight the corresponding product row when active.

Enhancements:
- Change the field inspector popover position from middle to bottom
- Add highlightRow and unhighlightRow methods to toggle the bg-indigo-50 class on the containing table row
- Bind highlightRow to popover trigger events and unhighlightRow to the popover hidden event