### PR TITLE
fix: type fetchPolicy parameters

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodesList.vue
@@ -21,6 +21,7 @@ import {
   releaseEanCodeMutation
 } from "../../../../../../../shared/api/mutations/eanCodes.js";
 import ProductEanCodeInput from "./ProductEanCodeInput.vue";
+import type { FetchPolicy } from "@apollo/client";
 
 const {t} = useI18n();
 
@@ -50,7 +51,7 @@ const setDefaultValues = async () => {
   hasAvailableEanCodes.value = false;
 }
 
-const fetchCurrentEanCode = async (policy = 'cache-first') => {
+const fetchCurrentEanCode = async (policy: FetchPolicy = 'cache-first') => {
   const {data} = await apolloClient.query({
     query: eanCodesQuery,
     variables: {filter: {product: {id: {exact: props.product.id}}}},
@@ -64,7 +65,7 @@ const fetchCurrentEanCode = async (policy = 'cache-first') => {
   }
 }
 
-const fetchAvailableEanCode = async (policy = 'cache-first') => {
+const fetchAvailableEanCode = async (policy: FetchPolicy = 'cache-first') => {
 
   if (eanCode.value.id) {
     return
@@ -81,7 +82,7 @@ const fetchAvailableEanCode = async (policy = 'cache-first') => {
   }
 }
 
-const fetchNeededData = async (policy = 'cache-first') => {
+const fetchNeededData = async (policy: FetchPolicy = 'cache-first') => {
   await setDefaultValues();
   await fetchCurrentEanCode(policy);
   await fetchAvailableEanCode(policy);

--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
@@ -15,6 +15,7 @@ import { VueDraggableNext } from 'vue-draggable-next';
 import apolloClient from "../../../../../../../../../../apollo-client";
 import {Toggle} from "../../../../../../../../../shared/components/atoms/toggle";
 import {VideoListingPreview} from "../../../../../../../../media/videos/videos-list/containers/video-listing-preview";
+import type { FetchPolicy } from "@apollo/client";
 
 type Media = {
   id: string;
@@ -65,7 +66,7 @@ const extractNodes = (data) => {
 };
 
 
-const fetchData = async (policy = 'cache-first') => {
+const fetchData = async (policy: FetchPolicy = 'cache-first') => {
 
   const { data } = await apolloClient.query({
     query: mediaProductThroughQuery,

--- a/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
+++ b/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
@@ -12,6 +12,7 @@ import { createSalesPriceMutation, updateSalesPriceMutation } from "../../../../
 import { Toast } from "../../../../../../../shared/modules/toast";
 import { currenciesQuerySelector } from "../../../../../../../shared/api/queries/currencies.js";
 import {TextInputPrepend} from "../../../../../../../shared/components/atoms/input-text-prepend";
+import type { FetchPolicy } from "@apollo/client";
 
 const { t } = useI18n();
 const props = defineProps<{ product: Product }>();
@@ -28,7 +29,7 @@ const prices: Ref<Price[]> = ref([]);
 const initialPrices: Ref<Price[]> = ref([]);
 const defaultCurrency = ref({ id: '', isoCode: '', symbol: '' });
 
-const getDefaultCurrency = async (policy = 'cache-first') => {
+const getDefaultCurrency = async (policy: FetchPolicy = 'cache-first') => {
   const { data } = await apolloClient.query({
     query: currenciesQuerySelector,
     variables: { filter: { isDefaultCurrency: { exact: true } } },
@@ -39,7 +40,7 @@ const getDefaultCurrency = async (policy = 'cache-first') => {
 }
 
 
-const loadPrices = async (policy = 'cache-first') => {
+const loadPrices = async (policy: FetchPolicy = 'cache-first') => {
   loading.value = true;
 
   // Fetch the default currency first


### PR DESCRIPTION
## Summary
- type Apollo fetch policy parameters in product EAN codes list, media list, and sale price view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfdcb7486c832ea352970fb35faa19