### PR TITLE
feat: confirm unsaved changes before switching product tabs

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -20,6 +20,7 @@ import { amazonProductsQuery } from "../../../../../../../shared/api/queries/ama
 import apolloClient from "../../../../../../../../apollo-client";
 import type { FetchPolicy } from "@apollo/client";
 import { injectAuth } from "../../../../../../../shared/modules/auth";
+import Swal from 'sweetalert2';
 
 const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
@@ -40,6 +41,33 @@ const fetchAmazonProducts = async (fetchPolicy: FetchPolicy = 'cache-first') => 
 if (auth.user.company?.hasAmazonIntegration) {
   onMounted(() => fetchAmazonProducts());
 }
+
+const generalRef = ref<InstanceType<typeof ProductEditView> | null>(null);
+const contentRef = ref<InstanceType<typeof ProductContentView> | null>(null);
+const priceRef = ref<InstanceType<typeof ProductSalePriceView> | null>(null);
+const propertiesRef = ref<InstanceType<typeof PropertiesView> | null>(null);
+
+const tabRefs: Record<string, any> = {
+  general: generalRef,
+  productContent: contentRef,
+  price: priceRef,
+  properties: propertiesRef,
+};
+
+const beforeTabChange = async (newTab: string, oldTab: string) => {
+  const current = tabRefs[oldTab];
+  if (current?.value?.hasUnsavedChanges) {
+    const res = await Swal.fire({
+      icon: 'warning',
+      text: t('products.products.messages.unsavedChanges'),
+      showCancelButton: true,
+      confirmButtonText: t('shared.button.change'),
+      cancelButtonText: t('shared.button.cancel'),
+    });
+    return res.isConfirmed;
+  }
+  return true;
+};
 
 const tabItems = computed(() => {
   const items = [
@@ -77,12 +105,12 @@ const tabItems = computed(() => {
 
 <template>
   <div>
-    <Tabs :tabs="tabItems">
+    <Tabs :tabs="tabItems" :before-change="beforeTabChange">
       <template v-slot:general>
-        <ProductEditView :product="product" />
+        <ProductEditView ref="generalRef" :product="product" />
       </template>
       <template v-slot:productContent>
-        <ProductContentView :product="product" />
+        <ProductContentView ref="contentRef" :product="product" />
       </template>
       <template v-slot:variations>
         <VariationsView :product="product" />
@@ -91,13 +119,13 @@ const tabItems = computed(() => {
         <MediaView :product="product" />
       </template>
       <template v-slot:properties>
-        <PropertiesView :product="product" />
+        <PropertiesView ref="propertiesRef" :product="product" />
       </template>
       <template v-if="product.aliasProducts.length" v-slot:aliasProducts>
         <AliasProductsView :product="product" />
       </template>
       <template v-slot:price>
-        <ProductSalePriceView :product="product" />
+        <ProductSalePriceView ref="priceRef" :product="product" />
       </template>
       <template v-slot:websites>
         <WebsitesView

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -16,6 +16,7 @@ import { amazonProductsQuery } from "../../../../../../../shared/api/queries/ama
 import apolloClient from "../../../../../../../../apollo-client";
 import type { FetchPolicy } from "@apollo/client";
 import { injectAuth } from "../../../../../../../shared/modules/auth";
+import Swal from 'sweetalert2';
 
 const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
@@ -35,6 +36,31 @@ const fetchAmazonProducts = async (fetchPolicy: FetchPolicy = 'cache-first') => 
 if (auth.user.company?.hasAmazonIntegration) {
   onMounted(() => fetchAmazonProducts());
 }
+
+const generalRef = ref<InstanceType<typeof ProductEditView> | null>(null);
+const contentRef = ref<InstanceType<typeof ProductContentView> | null>(null);
+const propertiesRef = ref<InstanceType<typeof PropertiesView> | null>(null);
+
+const tabRefs: Record<string, any> = {
+  general: generalRef,
+  productContent: contentRef,
+  properties: propertiesRef,
+};
+
+const beforeTabChange = async (newTab: string, oldTab: string) => {
+  const current = tabRefs[oldTab];
+  if (current?.value?.hasUnsavedChanges) {
+    const res = await Swal.fire({
+      icon: 'warning',
+      text: t('products.products.messages.unsavedChanges'),
+      showCancelButton: true,
+      confirmButtonText: t('shared.button.change'),
+      cancelButtonText: t('shared.button.cancel'),
+    });
+    return res.isConfirmed;
+  }
+  return true;
+};
 
 const tabItems = computed(() => {
   const items = [
@@ -69,18 +95,18 @@ const tabItems = computed(() => {
 
 <template>
   <div>
-    <Tabs :tabs="tabItems">
+    <Tabs :tabs="tabItems" :before-change="beforeTabChange">
       <template v-slot:general>
-        <ProductEditView :product="product" />
+        <ProductEditView ref="generalRef" :product="product" />
       </template>
       <template v-slot:productContent>
-        <ProductContentView :product="product" />
+        <ProductContentView ref="contentRef" :product="product" />
       </template>
       <template v-slot:media>
         <MediaView :product="product" />
       </template>
       <template v-slot:properties>
-        <PropertiesView :product="product" />
+        <PropertiesView ref="propertiesRef" :product="product" />
       </template>
       <template v-if="product.aliasProducts.length" v-slot:aliasProducts>
         <AliasProductsView :product="product" />

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -270,6 +270,14 @@ const handleError = (errors) => {
   }
 }
 
+const hasUnsavedChanges = computed(() => {
+  const formChanged = JSON.stringify(form) !== JSON.stringify(initialForm.value);
+  const bulletsChanged = bulletPointsRef.value?.hasChanges;
+  return formChanged || bulletsChanged;
+});
+
+defineExpose({ hasUnsavedChanges });
+
 const shortDescriptionToolbarOptions = [
   ['bold', 'underline'],
   [{ list: 'bullet' }],

--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {ref, watch, onMounted} from 'vue';
+import {ref, watch, onMounted, computed} from 'vue';
 import {useI18n} from 'vue-i18n';
 import {TextInput} from '../../../../../../../shared/components/atoms/input-text';
 import {Button} from '../../../../../../../shared/components/atoms/button';
@@ -154,8 +154,9 @@ const save = async (newTranslationId?: string) => {
     return [];
   }
 };
+const hasChanges = computed(() => JSON.stringify(bulletPoints.value) !== JSON.stringify(initialBulletPoints.value));
 
-defineExpose({save, fetchPoints});
+defineExpose({save, fetchPoints, hasChanges});
 </script>
 
 <template>

--- a/src/core/products/products/product-show/containers/tabs/general/ProductEditView.vue
+++ b/src/core/products/products/product-show/containers/tabs/general/ProductEditView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import {onMounted, reactive, ref} from 'vue';
+import {onMounted, reactive, ref, computed} from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   CheckboxFormField, FormType,
@@ -33,6 +33,8 @@ const form = reactive({
   },
   allowBackorder: props.product.allowBackorder,
 });
+
+const initialForm = ref({ ...form });
 
 const router = useRouter();
 
@@ -89,6 +91,12 @@ const getCleanData = (data) => {
 
   return cleanedData;
 };
+
+const hasUnsavedChanges = computed(() => {
+  return JSON.stringify(getCleanData(form)) !== JSON.stringify(initialForm.value);
+});
+
+defineExpose({ hasUnsavedChanges });
 
 const handleSubmit = async (overrideData = {}) => {
   const dataToSubmit = getCleanData({ ...form, ...overrideData });

--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -39,6 +39,8 @@ const saveAll = async () => {
   }
 };
 
+defineExpose({ hasUnsavedChanges });
+
 const currentPage = ref(1);
 const limit = ref(10);
 const perPageOptions = [

--- a/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
+++ b/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import { onMounted, ref, Ref } from "vue";
+import { onMounted, ref, Ref, computed } from "vue";
 import { useI18n } from 'vue-i18n';
 import { Product } from "../../../../configs";
 import { Button } from "../../../../../../../shared/components/atoms/button";
@@ -173,6 +173,10 @@ const savePrices = async () => {
 }
 
 onMounted(loadPrices);
+
+const hasUnsavedChanges = computed(() => JSON.stringify(prices.value) !== JSON.stringify(initialPrices.value));
+
+defineExpose({ hasUnsavedChanges });
 
 </script>
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -961,6 +961,9 @@
         "deletedProductProperties": "Deleted {count} product properties."
       }
     },
+      "messages": {
+        "unsavedChanges": "You have unsaved changes. Are you sure you want to leave this tab?"
+      },
       "tabs": {
         "content": "Content",
         "aliasProducts": "Alias Products",

--- a/src/shared/components/molecules/tabs/Tabs.vue
+++ b/src/shared/components/molecules/tabs/Tabs.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { TabGroup, TabList, Tab, TabPanels, TabPanel } from '@headlessui/vue';
 import { Icon } from "../../atoms/icon";
-import { onMounted, ref,watch } from 'vue';
-import { useRoute,useRouter } from 'vue-router';
+import { onMounted, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 
 interface TabItem {
   name: string;
@@ -18,6 +18,7 @@ const props = withDefaults(
     disabledTabs?: string[];
     transparent?: boolean;
     tabKey?: string;
+    beforeChange?: (newTab: string, oldTab: string) => Promise<boolean> | boolean;
   }>(),
   {
     disabledTabs: () => ([] as string[]),
@@ -46,8 +47,16 @@ const isSelected = (tab) => tab === selectedTab.value;
 const isDisabled = (tab) => props.disabledTabs.includes(tab);
 const isHighlighted = (tab: TabItem) => !isSelected(tab.name) && tab.danger;
 
-const changeTab = (index) => {
+const changeTab = async (index) => {
   const newTab = props.tabs[index].name;
+  const oldTab = selectedTab.value;
+  if (props.beforeChange) {
+    const proceed = await props.beforeChange(newTab, oldTab);
+    if (!proceed) {
+      selectedTab.value = oldTab;
+      return;
+    }
+  }
   selectedTab.value = newTab;
   router.push({ query: { ...route.query, [props.tabKey]: newTab } });
   emit('tab-changed', newTab);


### PR DESCRIPTION
## Summary
- add before-change hook to shared Tabs component
- warn with SweetAlert when leaving tabs with unsaved edits in product views
- track unsaved changes across product info, content, price and properties tabs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1333a195c832ebb62b75c39877c91