### PR TITLE
Improve product tab change protection

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -46,12 +46,16 @@ const generalRef = ref<InstanceType<typeof ProductEditView> | null>(null);
 const contentRef = ref<InstanceType<typeof ProductContentView> | null>(null);
 const priceRef = ref<InstanceType<typeof ProductSalePriceView> | null>(null);
 const propertiesRef = ref<InstanceType<typeof PropertiesView> | null>(null);
+const variationsRef = ref<InstanceType<typeof VariationsView> | null>(null);
+const eanCodesRef = ref<InstanceType<typeof ProductEanCodesList> | null>(null);
 
 const tabRefs: Record<string, any> = {
   general: generalRef,
   productContent: contentRef,
   price: priceRef,
   properties: propertiesRef,
+  variations: variationsRef,
+  eanCodes: eanCodesRef,
 };
 
 const beforeTabChange = async (newTab: string, oldTab: string) => {
@@ -113,7 +117,7 @@ const tabItems = computed(() => {
         <ProductContentView ref="contentRef" :product="product" />
       </template>
       <template v-slot:variations>
-        <VariationsView :product="product" />
+        <VariationsView ref="variationsRef" :product="product" />
       </template>
       <template v-slot:media>
         <MediaView :product="product" />
@@ -141,7 +145,7 @@ const tabItems = computed(() => {
 <!--        <ProductHsCodesList :product="product" />-->
 <!--      </template>-->
       <template v-slot:eanCodes>
-        <ProductEanCodesList :product="product" />
+        <ProductEanCodesList ref="eanCodesRef" :product="product" />
       </template>
       <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -40,11 +40,13 @@ if (auth.user.company?.hasAmazonIntegration) {
 const generalRef = ref<InstanceType<typeof ProductEditView> | null>(null);
 const contentRef = ref<InstanceType<typeof ProductContentView> | null>(null);
 const propertiesRef = ref<InstanceType<typeof PropertiesView> | null>(null);
+const variationsRef = ref<InstanceType<typeof VariationsView> | null>(null);
 
 const tabRefs: Record<string, any> = {
   general: generalRef,
   productContent: contentRef,
   properties: propertiesRef,
+  variations: variationsRef,
 };
 
 const beforeTabChange = async (newTab: string, oldTab: string) => {
@@ -112,7 +114,7 @@ const tabItems = computed(() => {
         <AliasProductsView :product="product" />
       </template>
       <template v-slot:variations>
-        <VariationsView :product="product" />
+        <VariationsView ref="variationsRef" :product="product" />
       </template>
       <template v-slot:websites>
         <WebsitesView

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -46,12 +46,14 @@ const generalRef = ref<InstanceType<typeof ProductEditView> | null>(null);
 const contentRef = ref<InstanceType<typeof ProductContentView> | null>(null);
 const priceRef = ref<InstanceType<typeof ProductSalePriceView> | null>(null);
 const propertiesRef = ref<InstanceType<typeof PropertiesView> | null>(null);
+const eanCodesRef = ref<InstanceType<typeof ProductEanCodesList> | null>(null);
 
 const tabRefs: Record<string, any> = {
   general: generalRef,
   productContent: contentRef,
   price: priceRef,
   properties: propertiesRef,
+  eanCodes: eanCodesRef,
 };
 
 const beforeTabChange = async (newTab: string, oldTab: string) => {
@@ -142,7 +144,7 @@ const tabItems = computed(() => {
         <SalesPricelistList :product="product" />
       </template>
       <template v-slot:eanCodes>
-        <ProductEanCodesList :product="product" />
+        <ProductEanCodesList ref="eanCodesRef" :product="product" />
       </template>
       <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView

--- a/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodeInput.vue
+++ b/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodeInput.vue
@@ -188,6 +188,10 @@ const handleSave = async () => {
 
 const isSaveDisabled = computed(() => lastSavedEanCode.value === eanCode.value.ean);
 
+const hasUnsavedChanges = computed(() => lastSavedEanCode.value !== eanCode.value.ean);
+
+defineExpose({ hasUnsavedChanges });
+
 </script>
 
 <template>

--- a/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/ean-codes/ProductEanCodesList.vue
@@ -44,6 +44,11 @@ const inputNeeded = computed(() => !eanCode.value.id || eanCode.value.internal =
 const showEanCode = computed(() => eanCode.value.id && eanCode.value.internal);
 const showDivider = computed(() => assignNeeded.value && inputNeeded.value);
 
+const inputRef = ref<InstanceType<typeof ProductEanCodeInput> | null>(null);
+const hasUnsavedChanges = computed(() => inputRef.value?.hasUnsavedChanges ?? false);
+
+defineExpose({ hasUnsavedChanges });
+
 const setDefaultValues = async () => {
   eanCode.value.id = null;
   eanCode.value.ean = '';
@@ -212,7 +217,7 @@ const handleRelease = async () => {
         <!-- EAN Code Input -->
         <FlexCell v-if="inputNeeded">
           <div class="border border-gray-300 p-3 pb-6 rounded-lg">
-            <ProductEanCodeInput :product="product" :initial-ean-code="eanCode" @ean-updated="() => fetchNeededData('network-only')"/>
+            <ProductEanCodeInput ref="inputRef" :product="product" :initial-ean-code="eanCode" @ean-updated="() => fetchNeededData('network-only')"/>
           </div>
         </FlexCell>
 

--- a/src/core/products/products/product-show/containers/tabs/general/ProductEditView.vue
+++ b/src/core/products/products/product-show/containers/tabs/general/ProductEditView.vue
@@ -34,8 +34,6 @@ const form = reactive({
   allowBackorder: props.product.allowBackorder,
 });
 
-const initialForm = ref({ ...form });
-
 const router = useRouter();
 
 const fields = {
@@ -92,6 +90,8 @@ const getCleanData = (data) => {
   return cleanedData;
 };
 
+const initialForm = ref(JSON.parse(JSON.stringify(getCleanData(form))));
+
 const hasUnsavedChanges = computed(() => {
   return JSON.stringify(getCleanData(form)) !== JSON.stringify(initialForm.value);
 });
@@ -117,6 +117,8 @@ const handleSubmit = async (overrideData = {}) => {
       if (data.updateProduct.vatRate && data.updateProduct.vatRate.id) {
         form.vatRate.id = data.updateProduct.vatRate.id
       }
+
+      initialForm.value = JSON.parse(JSON.stringify(getCleanData(form)));
 
       Toast.success(t('products.products.edit.updateSuccessfully'));
     }

--- a/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
+++ b/src/core/products/products/product-show/containers/tabs/sales-price/ProductSalePriceView.vue
@@ -19,8 +19,8 @@ const props = defineProps<{ product: Product }>();
 const loading = ref(false);
 interface Price {
   id: string;
-  price: string | number | null;
-  rrp: string | number | null;
+  price: string | null;
+  rrp: string | null;
   currency: string;
   symbol: string;
   readonly: boolean;
@@ -54,14 +54,12 @@ const loadPrices = async (policy: FetchPolicy = 'cache-first') => {
 
   prices.value = data.salesPrices.edges.map(edge => ({
     id: edge.node.id,
-    price: edge.node.price,
-    rrp: edge.node.rrp,
+    price: edge.node.price?.toString() || '',
+    rrp: edge.node.rrp?.toString() || '',
     currency: edge.node.currency.isoCode,
     symbol: edge.node.currency.symbol,
     readonly: !edge.node.currency.isDefaultCurrency && !!edge.node.currency.inheritsFrom,
   }));
-
-  initialPrices.value = JSON.parse(JSON.stringify(prices.value));
 
   const defaultCurrencyPrice = prices.value.find(price => price.currency === defaultCurrency.value.isoCode);
 
@@ -69,13 +67,15 @@ const loadPrices = async (policy: FetchPolicy = 'cache-first') => {
 
     prices.value.unshift({
       id: '',
-      price: null,
-      rrp: null,
+      price: '',
+      rrp: '',
       currency: defaultCurrency.value.isoCode,
       symbol: defaultCurrency.value.symbol,
-      readonly: false,
-    });
-  }
+    readonly: false,
+  });
+}
+
+  initialPrices.value = JSON.parse(JSON.stringify(prices.value));
 
   loading.value = false;
 };
@@ -117,8 +117,8 @@ const createPrice = async (price) => {
       mutation: createSalesPriceMutation,
       variables: {
         data: {
-          price: price.price,
-          rrp: price.rrp,
+          price: parseFloat(price.price),
+          rrp: price.rrp === '' ? null : parseFloat(price.rrp),
           product: { id: props.product.id },
           currency: { id: defaultCurrency.value.id }
         }
@@ -135,8 +135,8 @@ const editPrice = async (price) => {
   if (JSON.stringify(price) !== JSON.stringify(originalPrice)) {
     const priceData = {
       id: price.id,
-      price: price.price,
-      rrp: price.rrp == '' ? null : price.rrp
+      price: parseFloat(price.price),
+      rrp: price.rrp === '' ? null : parseFloat(price.rrp)
     };
     const { data } = await apolloClient.mutate({
       mutation: updateSalesPriceMutation,

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -701,6 +701,8 @@ const hasChanges = computed(
   () => toCreate.value.length || toUpdate.value.length || toDelete.value.length
 )
 
+const hasUnsavedChanges = hasChanges
+
 const save = async () => {
   skipHistory.value = true
   const createdCount = toCreate.value.length
@@ -767,7 +769,7 @@ const save = async () => {
   }
 }
 
-defineExpose({ save, hasChanges })
+defineExpose({ save, hasUnsavedChanges })
 
 const showTextModal = ref(false)
 const showDescriptionModal = ref(false)


### PR DESCRIPTION
## Summary
- fix unsaved-change tracking in general and sales price tabs
- add change guards for EAN codes and variations bulk edit
- warn when leaving variations editor with unsaved changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c136775a08832e9b6ad81d43c68297