### PR TITLE
feat: track unsaved changes in Amazon tab

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -107,6 +107,22 @@ const otherIssues = computed(() => {
 });
 const isConfigurable = computed(() => props.product.type === ProductType.Configurable);
 
+const externalIdRef = ref<InstanceType<typeof AmazonExternalProductIdSection> | null>(null);
+const gtinExemptionRef = ref<InstanceType<typeof AmazonGtinExemptionSection> | null>(null);
+const browseNodeRef = ref<InstanceType<typeof AmazonBrowseNodeSection> | null>(null);
+const variationThemeRef = ref<InstanceType<typeof AmazonVariationThemeSection> | null>(null);
+
+const hasUnsavedChanges = computed(
+  () =>
+    externalIdRef.value?.hasUnsavedChanges ||
+    gtinExemptionRef.value?.hasUnsavedChanges ||
+    browseNodeRef.value?.hasUnsavedChanges ||
+    variationThemeRef.value?.hasUnsavedChanges ||
+    false,
+);
+
+defineExpose({ hasUnsavedChanges });
+
 const onResyncSuccess = () => {
   Toast.success(t('integrations.salesChannel.toast.resyncSuccess'));
   emit('refreshAmazonProducts');
@@ -183,6 +199,7 @@ const formatDate = (dateString?: string | null) => {
 
               <AmazonExternalProductIdSection
                 class="mb-4"
+                ref="externalIdRef"
                 :product="product"
                 :view="selectedView"
               />
@@ -191,6 +208,7 @@ const formatDate = (dateString?: string | null) => {
 
               <AmazonGtinExemptionSection
                 class="mb-4"
+                ref="gtinExemptionRef"
                 :product-id="props.product.id"
                 :view-id="selectedView?.id"
                 :view="selectedView"
@@ -208,6 +226,7 @@ const formatDate = (dateString?: string | null) => {
 
               <AmazonBrowseNodeSection
                 class="mb-4"
+                ref="browseNodeRef"
                 :product-id="props.product.id"
                 :sales-channel-id="selectedView?.salesChannel.id"
                 :sales-channel-view-id="selectedView?.id"
@@ -220,6 +239,7 @@ const formatDate = (dateString?: string | null) => {
               <AmazonVariationThemeSection
                 v-if="isConfigurable && selectedView"
                 class="mb-4"
+                ref="variationThemeRef"
                 :product="product"
                 :view="selectedView"
               />

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonBrowseNodeSection.vue
@@ -356,6 +356,10 @@ const showAlert = computed(
   () =>
     props.view && !props.view.isDefault && !loadingSelected.value && !productBrowseNodeId.value,
 );
+
+const hasUnsavedChanges = computed(() => pendingNode.value !== null);
+
+defineExpose({ hasUnsavedChanges });
 </script>
 
 <template>

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonExternalProductIdSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonExternalProductIdSection.vue
@@ -145,6 +145,10 @@ const isSaveDisabled = computed(
 const showAlert = computed(
   () => !props.view?.isDefault && !loading.value && isMissing.value,
 );
+
+const hasUnsavedChanges = computed(() => !isSaveDisabled.value);
+
+defineExpose({ hasUnsavedChanges });
 </script>
 
 <template>

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonGtinExemptionSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonGtinExemptionSection.vue
@@ -91,6 +91,10 @@ const save = async () => {
 const showAlert = computed(
   () => props.view && !props.view.isDefault && !loading.value && !exemptionId.value,
 );
+
+const hasUnsavedChanges = computed(() => value.value !== initialValue.value);
+
+defineExpose({ hasUnsavedChanges });
 </script>
 
 <template>

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
@@ -131,6 +131,10 @@ const save = async () => {
 const showAlert = computed(
   () => props.view && !props.view.isDefault && !loading.value && !recordId.value,
 );
+
+const hasUnsavedChanges = computed(() => hasChanges.value);
+
+defineExpose({ hasUnsavedChanges });
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- expose unsaved state from Amazon external ID, GTIN exemption, browse node, and variation theme sections
- aggregate those states in Amazon tab to block tab changes when edits are pending

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c13aea465c832e8fae4d42c1b27a81