### PR TITLE
fix: warn on unsaved changes in Amazon tab

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -48,6 +48,7 @@ const priceRef = ref<InstanceType<typeof ProductSalePriceView> | null>(null);
 const propertiesRef = ref<InstanceType<typeof PropertiesView> | null>(null);
 const variationsRef = ref<InstanceType<typeof VariationsView> | null>(null);
 const eanCodesRef = ref<InstanceType<typeof ProductEanCodesList> | null>(null);
+const amazonRef = ref<InstanceType<typeof AmazonView> | null>(null);
 
 const tabRefs: Record<string, any> = {
   general: generalRef,
@@ -56,6 +57,7 @@ const tabRefs: Record<string, any> = {
   properties: propertiesRef,
   variations: variationsRef,
   eanCodes: eanCodesRef,
+  amazon: amazonRef,
 };
 
 const beforeTabChange = async (newTab: string, oldTab: string) => {
@@ -149,6 +151,7 @@ const tabItems = computed(() => {
       </template>
       <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView
+          ref="amazonRef"
           :product="product"
           :amazon-products="amazonProducts"
           @refresh-amazon-products="fetchAmazonProducts('network-only')"

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -41,12 +41,14 @@ const generalRef = ref<InstanceType<typeof ProductEditView> | null>(null);
 const contentRef = ref<InstanceType<typeof ProductContentView> | null>(null);
 const propertiesRef = ref<InstanceType<typeof PropertiesView> | null>(null);
 const variationsRef = ref<InstanceType<typeof VariationsView> | null>(null);
+const amazonRef = ref<InstanceType<typeof AmazonView> | null>(null);
 
 const tabRefs: Record<string, any> = {
   general: generalRef,
   productContent: contentRef,
   properties: propertiesRef,
   variations: variationsRef,
+  amazon: amazonRef,
 };
 
 const beforeTabChange = async (newTab: string, oldTab: string) => {
@@ -125,6 +127,7 @@ const tabItems = computed(() => {
       </template>
       <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView
+          ref="amazonRef"
           :product="product"
           :amazon-products="amazonProducts"
           @refresh-amazon-products="fetchAmazonProducts('network-only')"

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -47,6 +47,7 @@ const contentRef = ref<InstanceType<typeof ProductContentView> | null>(null);
 const priceRef = ref<InstanceType<typeof ProductSalePriceView> | null>(null);
 const propertiesRef = ref<InstanceType<typeof PropertiesView> | null>(null);
 const eanCodesRef = ref<InstanceType<typeof ProductEanCodesList> | null>(null);
+const amazonRef = ref<InstanceType<typeof AmazonView> | null>(null);
 
 const tabRefs: Record<string, any> = {
   general: generalRef,
@@ -54,6 +55,7 @@ const tabRefs: Record<string, any> = {
   price: priceRef,
   properties: propertiesRef,
   eanCodes: eanCodesRef,
+  amazon: amazonRef,
 };
 
 const beforeTabChange = async (newTab: string, oldTab: string) => {
@@ -148,6 +150,7 @@ const tabItems = computed(() => {
       </template>
       <template v-if="auth.user.company?.hasAmazonIntegration" v-slot:amazon>
         <AmazonView
+          ref="amazonRef"
           :product="product"
           :amazon-products="amazonProducts"
           @refresh-amazon-products="fetchAmazonProducts('network-only')"

--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, watch } from 'vue';
+import { computed, ref, onMounted, watch, unref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import TabContentTemplate from '../TabContentTemplate.vue';
 import { Product } from '../../../../configs';
@@ -114,10 +114,10 @@ const variationThemeRef = ref<InstanceType<typeof AmazonVariationThemeSection> |
 
 const hasUnsavedChanges = computed(
   () =>
-    externalIdRef.value?.hasUnsavedChanges ||
-    gtinExemptionRef.value?.hasUnsavedChanges ||
-    browseNodeRef.value?.hasUnsavedChanges ||
-    variationThemeRef.value?.hasUnsavedChanges ||
+    unref(externalIdRef.value?.hasUnsavedChanges) ||
+    unref(gtinExemptionRef.value?.hasUnsavedChanges) ||
+    unref(browseNodeRef.value?.hasUnsavedChanges) ||
+    unref(variationThemeRef.value?.hasUnsavedChanges) ||
     false,
 );
 


### PR DESCRIPTION
## Summary
- track unsaved state across Amazon tab sections
- block tab switches when Amazon tab has unsaved edits

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c13dd285c8832e9aa6ad3a38f80463