### PR TITLE
feat: guard store switches in product tabs

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -123,6 +123,16 @@ const hasUnsavedChanges = computed(
 
 defineExpose({ hasUnsavedChanges });
 
+const handleMarketplaceSelection = (newId: string) => {
+  if (hasUnsavedChanges.value) {
+    const confirmChange = confirm(t('products.products.messages.unsavedChanges'));
+    if (!confirmChange) {
+      return;
+    }
+  }
+  selectedViewId.value = newId;
+};
+
 const onResyncSuccess = () => {
   Toast.success(t('integrations.salesChannel.toast.resyncSuccess'));
   emit('refreshAmazonProducts');
@@ -166,9 +176,10 @@ const formatDate = (dateString?: string | null) => {
       <div v-if="!loading && views.length" class="flex">
         <AmazonMarketplaceTabs
           class="w-72"
-          v-model="selectedViewId"
+          :model-value="selectedViewId"
           :views="views"
           :amazon-products="amazonProducts"
+          @update:modelValue="handleMarketplaceSelection"
         />
           <div class="flex-1 p-6">
             <div v-if="selectedView">

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonExternalProductIdSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonExternalProductIdSection.vue
@@ -55,7 +55,9 @@ const valueField = (): ValueFormField => ({
   placeholder: t('products.products.amazon.externalProductIdPlaceholder'),
 });
 
-const fetchExternalId = async () => {
+const fetchExternalId = async (
+  fetchPolicy: 'cache-first' | 'network-only' = 'cache-first',
+) => {
   if (!props.product?.id || !props.view?.id) return;
   loading.value = true;
   const { data } = await apolloClient.query({
@@ -66,7 +68,7 @@ const fetchExternalId = async () => {
         view: { id: { exact: props.view.id } },
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy,
   });
   const node = data?.amazonExternalProductIds?.edges?.[0]?.node;
   externalId.value = node?.id || null;
@@ -108,6 +110,7 @@ const handleSave = async () => {
         createdAsin.value = '';
         lastSavedType.value = 'ASIN';
         lastSavedValue.value = '';
+        await fetchExternalId('network-only');
       }
       return;
     }
@@ -133,7 +136,7 @@ const handleSave = async () => {
     Toast.success(t('products.products.amazon.externalProductIdSaved'));
     lastSavedType.value = type.value;
     lastSavedValue.value = trimmed;
-    fetchExternalId();
+    await fetchExternalId('network-only');
   } catch (err) {
     errors.value = processGraphQLErrors(err, t);
   }

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonVariationThemeSection.vue
@@ -163,7 +163,7 @@ defineExpose({ hasUnsavedChanges });
           label-by="name"
           value-by="id"
           :filterable="true"
-          :placeholder="t('shared.placeholders.select')"
+          :placeholder="t('products.products.amazon.variationThemePlaceholder')"
         />
       </FlexCell>
       <FlexCell>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -201,7 +201,7 @@ const handleLanguageSelection = async (newLanguage) => {
 const handleSalesChannelSelection = async (newChannel) => {
 
   if (JSON.stringify(form) !== JSON.stringify(initialForm.value)) {
-    const confirmChange = confirm(t('products.translation.confirmLanguageChange'));
+    const confirmChange = confirm(t('products.products.messages.unsavedChanges'));
     if (!confirmChange) {
       currentSalesChannel.value = oldChannel.value;
       return;

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -134,6 +134,7 @@
         "statusDescription": "Synchronization status and available actions.",
         "variationTheme": "Amazon-Variationsthema",
         "variationThemeDescription": "Wählen Sie aus, welche Feldeigenschaften Nutzer auswählen sollen, wenn sie das richtige Produkt wählen.",
+        "variationThemePlaceholder": "Variationsthema auswählen",
         "variationThemeSaved": "Variation theme saved",
         "variationThemeDeleted": "Variation theme deleted"
       }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -996,6 +996,7 @@
         "noStatus": "The product is not present yet on the marketplace!",
         "variationTheme": "Amazon Variation Theme",
         "variationThemeDescription": "Select which fields properties you want people to select when choosing the right product.",
+        "variationThemePlaceholder": "Select variation theme",
         "variationThemeSaved": "Variation theme saved",
         "variationThemeDeleted": "Variation theme deleted",
         "asin": "ASIN",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -134,6 +134,7 @@
         "statusDescription": "Synchronization status and available actions.",
         "variationTheme": "Thème de variation Amazon",
         "variationThemeDescription": "Sélectionnez les propriétés que vous souhaitez que les utilisateurs choisissent lors du choix du bon produit.",
+        "variationThemePlaceholder": "Sélectionner un thème de variation",
         "variationThemeSaved": "Variation theme saved",
         "variationThemeDeleted": "Variation theme deleted"
       }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -678,6 +678,7 @@
         "statusDescription": "Synchronization status and available actions.",
         "variationTheme": "Amazon-variatiethema",
         "variationThemeDescription": "Selecteer welke veldeigenschappen je wilt dat mensen kiezen bij het selecteren van het juiste product.",
+        "variationThemePlaceholder": "Selecteer variatiethema",
         "variationThemeSaved": "Variation theme saved",
         "variationThemeDeleted": "Variation theme deleted",
         "asin": "ASIN",


### PR DESCRIPTION
## Summary
- prompt before switching Amazon marketplace when sections have unsaved changes
- refresh Amazon external product IDs from network after saving
- add specific variation theme placeholder and translations
- use generic unsaved-changes warning when changing sales channel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1402a4048832e9bab981ae159da3c

## Summary by Sourcery

Add unsaved-changes guards for marketplace and sales channel switches, refresh external IDs on save, and improve variation theme placeholder translations

New Features:
- Prompt users before switching Amazon marketplace when there are unsaved changes
- Use a generic unsaved-changes warning when changing the sales channel

Enhancements:
- Refresh Amazon external product IDs from the network after saving
- Update the variation theme selector placeholder with specific translation keys