### PR TITLE
Fix PropertiesView valueInputs handling

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -2,7 +2,7 @@
 
 import {useI18n} from 'vue-i18n';
 import {Product, ProductPropertyValue} from "../../../../configs";
-import {onMounted, ref, Ref, watch, computed} from "vue";
+import {onMounted, ref, Ref, watch, computed, onBeforeUpdate} from "vue";
 import apolloClient from "../../../../../../../../apollo-client";
 import {
   getPropertySelectValueQuery,
@@ -29,6 +29,14 @@ const lastSavedValues: Ref<ProductPropertyValue[]> = ref([]);
 const loading = ref(false);
 const language: Ref<string | null> = ref(null);
 const valueInputs = ref<InstanceType<typeof ValueInput>[]>([]);
+const setValueInputRef = (el: InstanceType<typeof ValueInput> | null) => {
+  if (el) {
+    valueInputs.value.push(el);
+  }
+};
+onBeforeUpdate(() => {
+  valueInputs.value = [];
+});
 const hasUnsavedChanges = computed(() => valueInputs.value.some(v => v?.hasChanges));
 const saveAll = async () => {
   const inputs = [...valueInputs.value];
@@ -536,7 +544,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
             @update-id="handleUpdatedId"
             @update-value="handleValueUpdate"
             @remove="handleRemove"
-            ref="valueInputs"
+            :ref="setValueInputRef"
         />
         <hr class="my-4"/>
       </div>
@@ -550,7 +558,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
             @update-id="handleUpdatedId"
             @update-value="handleValueUpdate"
             @remove="handleRemove"
-            ref="valueInputs"
+            :ref="setValueInputRef"
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- ensure valueInputs refs are collected into an array
- reset refs before component updates to avoid stale entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: process did not complete in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c164c0e18c832e846e3e909a877ebc

## Summary by Sourcery

Fix handling of ValueInput component refs in PropertiesView by using a callback ref to collect inputs in an array and clearing them before updates to prevent stale entries.

Bug Fixes:
- Clear stale valueInputs refs before component updates to avoid outdated entries

Enhancements:
- Switch from static ref attribute to a setValueInputRef callback to accumulate ValueInput refs
- Add setValueInputRef helper and register onBeforeUpdate hook to reset the refs array