### PR TITLE
feat: show configurator value for variations

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
@@ -146,6 +146,7 @@ const handleQuantityChanged = debounce(async (event, id) => {
                 <tr>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">{{ t('shared.labels.name') }}</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">{{ t('shared.labels.sku') }}</th>
+                  <th v-if="parentType == ProductType.Configurable" scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">{{ t('products.products.labels.configuratorValue') }}</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">{{ t('shared.labels.active') }}</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">{{ t('products.products.labels.inspectorStatus') }}</th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900" v-if="parentType != ProductType.Configurable">{{ t('shared.labels.quantity') }}</th>
@@ -173,6 +174,9 @@ const handleQuantityChanged = debounce(async (event, id) => {
                   </td>
                   <td>
                     {{ item.node.variation.sku }}
+                  </td>
+                  <td v-if="parentType == ProductType.Configurable">
+                    {{ item.node.configuratorValue }}
                   </td>
                   <td>
                     <Icon v-if="item.node.variation.active" name="check-circle" class="ml-2 text-green-500" />

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -96,6 +96,9 @@
       "tabs": {
         "amazon": "Amazon"
       },
+      "labels": {
+        "configuratorValue": ""
+      },
       "amazon": {
         "asin": "ASIN",
         "asinDescription": "Provide the Amazon Standard Identification Number for this product.",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1114,6 +1114,7 @@
         "inspectorErrors": "Product Inspector Error",
         "allowBackorder": "Allow Backorder",
         "inspectorStatus": "Content Quality",
+        "configuratorValue": "Configurator Value",
         "aliasParentProduct": "Alias Target"
       },
       "placeholders": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -96,6 +96,9 @@
       "tabs": {
         "amazon": "Amazon"
       },
+      "labels": {
+        "configuratorValue": ""
+      },
       "amazon": {
         "asin": "ASIN",
         "asinDescription": "Provide the Amazon Standard Identification Number for this product.",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -793,7 +793,8 @@
         "productionTime": "Productie tijd",
         "forSale": "Verkoopbaar",
         "allowBackorder": "Backorder toestaan",
-        "inspectorStatus": ""
+        "inspectorStatus": "",
+        "configuratorValue": ""
       },
       "placeholders": {
         "vatRate": "Voeg BTW Tarief toe",

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -261,6 +261,7 @@ export const configurableVariationsQuery = gql`
             thumbnailUrl
             inspectorStatus
           }
+          configuratorValue
         }
         cursor
       }


### PR DESCRIPTION
## Summary
- show each variation's configurator value in the product page table
- pull configuratorValue from backend query
- add configurator value translation keys

## Testing
- `npm run build` *(fails: Type '(el: InstanceType<typeof ValueInput> | null) => void' is not assignable to type 'VNodeRef | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c16a10fc3c832eb2cc841a6203b16a

## Summary by Sourcery

Show each variation’s configurator value in the product page table for configurable products by fetching it from the backend and adding translation keys for the column header.

New Features:
- Conditionally display a "Configurator Value" column in the variations table for configurable products
- Include the configuratorValue field in the configurableVariationsQuery GraphQL request
- Add localization entries for the configurator value label in supported locale files