### PR TITLE
Allow lists in HTML editor

### DIFF
--- a/src/shared/components/atoms/input-text-html-editor/TextHtmlEditor.vue
+++ b/src/shared/components/atoms/input-text-html-editor/TextHtmlEditor.vue
@@ -29,6 +29,15 @@ const defaultToolbarOptions = [
 
 const finalToolbarOptions = computed(() => props.toolbarOptions || defaultToolbarOptions);
 
+const editorOptions = computed(() => ({
+  modules: {
+    toolbar: finalToolbarOptions.value,
+    clipboard: {
+      allowed: { tags: ['ul', 'ol', 'li'] },
+    },
+  },
+}));
+
 watch(() => props.modelValue, (newVal) => {
   content.value = newVal || '';
 
@@ -45,7 +54,7 @@ watch(content, (newVal) => {
       v-model:content="content"
       contentType="html"
       theme="snow"
-      :toolbar="finalToolbarOptions"
+      :options="editorOptions"
       :placeholder="placeholder || 'Type here...'"
       :read-only="disabled || aiGenerating"
       style="min-height: 250px;"


### PR DESCRIPTION
## Summary
- allow ul and ol lists in TextHtmlEditor by whitelisting list tags in clipboard options

## Testing
- `npm run build` *(fails: Type '(el: InstanceType<typeof ValueInput> | null) => void' is not assignable to type 'VNodeRef | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c19ea2b200832eb43181d33b4343e0

## Summary by Sourcery

Enable support for lists in the TextHtmlEditor by whitelisting list tags and passing full editor configuration via the new `editorOptions` prop.

New Features:
- Allow unordered and ordered list tags (ul, ol, li) in the HTML editor by whitelisting them in the clipboard module

Enhancements:
- Introduce a computed `editorOptions` property to consolidate toolbar and clipboard settings