### PR TITLE
feat: integrate AI translation for property values

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -83,6 +83,11 @@
   }
   ,
   "products": {
+    "translation": {
+      "messages": {
+        "noSourceText": "Es gibt keinen Quelltext zum Übersetzen."
+      }
+    },
     "products": {
       "create": {
         "wizard": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -939,6 +939,9 @@
       },
       "warning": {
         "inheritFromDefault": "Fields left empty will be inherited from the Default version for this language in the final product content."
+      },
+      "messages": {
+        "noSourceText": "There is no source text to translate."
       }
     },
     "products": {


### PR DESCRIPTION
## Summary
- allow translating empty property texts via AI in Properties tab
- surface error when no English source text is available

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1b6394b40832e93251cecd5769109

## Summary by Sourcery

Integrate AI-powered translation for empty property text and description values in the Properties tab, fetching English source text on demand and showing an error if none is found.

New Features:
- Enable AI translation for empty TEXT and DESCRIPTION property values via the AiContentTranslator component
- Fetch English source text using a new GraphQL query before performing AI translation

Bug Fixes:
- Show an error toast when no English source text is available for translation

Enhancements:
- Conditionally display the translation UI based on property type, target language, and whether the current value is unchanged