### PR TITLE
feat: add video tab to Magento info card

### DIFF
--- a/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/MagentoInfoCard.vue
+++ b/src/core/integrations/integrations/integrations-create/containers/type-step/info-cards/MagentoInfoCard.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Card } from '../../../../../../../shared/components/atoms/card';
 import { Button } from '../../../../../../../shared/components/atoms/button';
+import { Tabs } from '../../../../../../../shared/components/molecules/tabs';
 
 const emit = defineEmits<{ (e: 'close'): void }>();
 const { t } = useI18n();
+const tabItems = ref([
+  { name: 'instructions', label: t('integrations.create.wizard.step1.magentoInfoModal.tabs.instructions') },
+  { name: 'video', label: t('integrations.create.wizard.step1.magentoInfoModal.tabs.video') },
+]);
 const close = () => emit('close');
 </script>
 
@@ -15,49 +21,61 @@ const close = () => emit('close');
         {{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationTitle') }}
       </h3>
     </div>
-    <div class="space-y-6 pr-2 mb=4 overflow-y-auto max-h-96">
-      <div>
-        <p class="text-sm text-gray-700">
-          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationDescription') }}
-        </p>
-        <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
-          <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationStep1') }}</li>
-          <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationStep2') }}</li>
-        </ul>
-      </div>
+    <Tabs :tabs="tabItems">
+      <template #instructions>
+        <div class="space-y-6 pr-2 mb=4 overflow-y-auto max-h-96">
+          <div>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationDescription') }}
+            </p>
+            <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
+              <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationStep1') }}</li>
+              <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.integrationStep2') }}</li>
+            </ul>
+          </div>
 
-      <div>
-        <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSettingsTitle') }}</h4>
-        <p class="text-sm text-gray-700">
-          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSettingsDescription') }}
-        </p>
-        <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
-          <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSetting1') }}</li>
-          <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSetting2') }}</li>
-        </ul>
-      </div>
+          <div>
+            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSettingsTitle') }}</h4>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSettingsDescription') }}
+            </p>
+            <ul class="list-disc list-inside text-sm text-gray-700 mt-2">
+              <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSetting1') }}</li>
+              <li>{{ t('integrations.create.wizard.step1.magentoInfoModal.section.apiSetting2') }}</li>
+            </ul>
+          </div>
 
-      <div>
-        <h4 class="text-lg font-semibold text-red-500">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.legacyAuthTitle') }}</h4>
-        <p class="text-sm text-gray-700">
-          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.legacyAuthWarning') }}
-        </p>
-      </div>
+          <div>
+            <h4 class="text-lg font-semibold text-red-500">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.legacyAuthTitle') }}</h4>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.legacyAuthWarning') }}
+            </p>
+          </div>
 
-      <div>
-        <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.importTitle') }}</h4>
-        <p class="text-sm text-gray-700">
-          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.importRecommendation') }}
-        </p>
-      </div>
+          <div>
+            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.importTitle') }}</h4>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.importRecommendation') }}
+            </p>
+          </div>
 
-      <div>
-        <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.eanTitle') }}</h4>
-        <p class="text-sm text-gray-700">
-          {{ t('integrations.create.wizard.step1.magentoInfoModal.section.eanDescription') }}
-        </p>
-      </div>
-    </div>
+          <div>
+            <h4 class="text-lg font-semibold">{{ t('integrations.create.wizard.step1.magentoInfoModal.section.eanTitle') }}</h4>
+            <p class="text-sm text-gray-700">
+              {{ t('integrations.create.wizard.step1.magentoInfoModal.section.eanDescription') }}
+            </p>
+          </div>
+        </div>
+      </template>
+      <template #video>
+        <div class="pr-2 mb=4 overflow-y-auto max-h-96">
+          <div style="padding:56.25% 0 0 0;position:relative;">
+            <iframe src="https://player.vimeo.com/video/1073931917?badge=0&autopause=0&player_id=0&app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="integrating OneSila with Magento"></iframe>
+          </div>
+          <script src="https://player.vimeo.com/api/player.js"></script>
+        </div>
+      </template>
+    </Tabs>
 
     <hr/>
     <div class="flex justify-end gap-4 mt-4">

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2513,6 +2513,10 @@
           "webhookExample": "Send events to your application via HTTP",
           "magentoInfoModal": {
             "title": "How to connect your Magento store",
+            "tabs": {
+              "instructions": "Instructions",
+              "video": "Video"
+            },
             "section": {
               "integrationTitle": "Create an integration in Magento",
               "integrationDescription": "Before connecting your store, make sure to create and activate an integration in your Magento Admin Panel.",


### PR DESCRIPTION
## Summary
- add tabbed view to Magento info card with Vimeo video
- add translations for new tabs

## Testing
- `npm run build` *(fails: src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue(547,13): error TS2322: Type '(el: InstanceType<typeof ValueInput> | null) => void' is not assignable to type 'VNodeRef | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b67d1ba0832e99b102f55c78efe2

## Summary by Sourcery

Use a tabbed interface for the Magento info card by migrating existing static instructions into an 'Instructions' tab and adding a new 'Video' tab with an embedded Vimeo player, along with translations for the new tabs.

New Features:
- Embed a Vimeo video in a new 'Video' tab within the Magento info card

Enhancements:
- Refactor Magento info card into a tabbed layout using the shared Tabs component

Documentation:
- Add i18n translations for the new 'Instructions' and 'Video' tabs