### PR TITLE
Fix product property translation language handling

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -28,8 +28,9 @@ const values: Ref<ProductPropertyValue[]> = ref([]);
 const lastSavedValues: Ref<ProductPropertyValue[]> = ref([]);
 const loading = ref(false);
 const language: Ref<string | null> = ref(null);
+const companyLanguage: Ref<string | null> = ref(null);
 const valueInputs = ref<InstanceType<typeof ValueInput>[]>([]);
-const setValueInputRef = (el: InstanceType<typeof ValueInput> | null) => {
+const setValueInputRef = (el: any) => {
   if (el) {
     valueInputs.value.push(el);
   }
@@ -190,6 +191,7 @@ const setCurrentLanguage = async (fetchPolicy) => {
   if (data && data.translationLanguages && data.translationLanguages.defaultLanguage) {
     const defaultLanguage = data.translationLanguages.defaultLanguage;
     language.value = defaultLanguage.code;
+    companyLanguage.value = defaultLanguage.code;
   }
 
 };
@@ -325,6 +327,7 @@ const fetchRequiredAttributesValues = async (fetchPolicy = 'cache-first') => {
   loading.value = true
   values.value = [];
   language.value = null;
+  companyLanguage.value = null;
   currentPage.value = 1;
   const productTypePropertyId = await fetchRequiredProductType(fetchPolicy);
   await fetchRequiredAttributes(productTypePropertyId, fetchPolicy);
@@ -540,6 +543,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
             :product-id="product.id"
             :rule-id="ruleId"
             :value="productTypeValue"
+            :company-language="companyLanguage"
             @refetch="fetchRequiredAttributesValues('network-only')"
             @update-id="handleUpdatedId"
             @update-value="handleValueUpdate"
@@ -554,6 +558,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
             :product-id="product.id"
             :rule-id="ruleId"
             :value="val"
+            :company-language="companyLanguage"
             @refetch="fetchRequiredAttributesValues('network-only')"
             @update-id="handleUpdatedId"
             @update-value="handleValueUpdate"

--- a/src/shared/components/organisms/ai-content-translator/AiContentTranslator.vue
+++ b/src/shared/components/organisms/ai-content-translator/AiContentTranslator.vue
@@ -11,6 +11,7 @@ interface Props {
   product?: any;
   productContentType?: string;
   salesChannelId?: string;
+  beforeStart?: () => Promise<boolean> | boolean;
 }
 
 const props = defineProps<Props>();
@@ -62,6 +63,7 @@ const steps = computed(() => [
     modal-title="shared.components.organisms.aiContentTranslator.title"
     successToastKey="shared.components.organisms.aiContentTranslator.success"
     btn-class="btn-outline-success"
+    :before-start="props.beforeStart"
     @processed="text => emit('translated', text)"
   />
 </template>

--- a/src/shared/components/organisms/ai-process/AiProcess.vue
+++ b/src/shared/components/organisms/ai-process/AiProcess.vue
@@ -17,6 +17,7 @@ const props = withDefaults(
     btnClass?: string;
     label?: string;
     small?: boolean;
+    beforeStart?: () => Promise<boolean> | boolean;
   }>(),
   {
     btnClass: 'btn-outline-primary',
@@ -100,7 +101,13 @@ const onError = (error: any) => {
   }
 };
 
-const handleClick = (mutate: Function) => {
+const handleClick = async (mutate: Function) => {
+  if (props.beforeStart) {
+    const proceed = await props.beforeStart();
+    if (proceed === false) {
+      return;
+    }
+  }
   startSimulatedProgress();
   mutate();
 };


### PR DESCRIPTION
## Summary
- remove company language from auth model
- store tenant default language in PropertiesView and pass to ValueInput
- fetch and translate property values using tenant's language

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1ba7f69e8832eb0f5731f378776c3

## Summary by Sourcery

Use tenant default language for product property translations by passing it through components and dynamically fetching and translating property values instead of relying on hardcoded English.

New Features:
- Add beforeStart hook to AiProcess and AiContentTranslator to allow pre-translation checks.

Bug Fixes:
- Fix translation display logic to ensure translator appears only when the property language differs from the tenant default.

Enhancements:
- Pass tenant default language (companyLanguage) from PropertiesView to ValueInput and translation components.
- Replace hardcoded 'en' source language with dynamic companyLanguage when fetching source text and translating.
- Display language flags for source and target languages in the translator UI.
- Introduce prepareTranslation in ValueInput to fetch and validate source text before starting translation.