### PR TITLE
feat: warn on invalid HTML in text editor

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -507,6 +507,11 @@
           "label": "Deselect All"
         }
       },
+      "atoms": {
+        "textHtmlEditor": {
+          "invalidHtml": "Contains broken HTML"
+        }
+      },
       "organisms": {
         "bulkProductPropertyAssigner": {
           "title": "To assign to {count} product(s)",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -301,6 +301,11 @@
           "label": "Selecteer alles"
         }
       },
+      "atoms": {
+        "textHtmlEditor": {
+          "invalidHtml": "Bevat ongeldige HTML"
+        }
+      },
       "organisms": {
         "imageAssigner": {
           "addButton": {


### PR DESCRIPTION
## Summary
- validate HTML in TextHtmlEditor and emit warning when markup is broken
- support `<ul>` bullet lists and allow basic tags
- add translations for invalid HTML message

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1b4068ac0832eb7cc99589003d7bf

## Summary by Sourcery

Add HTML validation and warning in TextHtmlEditor and expand support for basic formatting and lists

New Features:
- Validate editor HTML using DOMParser and display a warning for invalid markup
- Allow paragraph, line break, bold, italic, and list tags in the editor toolbar
- Include translations for the invalid HTML warning message

Enhancements:
- Apply default list styling for unordered lists within the editor