### PR TITLE
fix(media): prevent gallery images from being cropped

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
@@ -215,7 +215,7 @@ const handleMainImageChange = async (changedItem: Item) => {
             <div v-for="item in items" :key="item.media.id" class="file-entry relative">
                 <template v-if="item.media.type === TYPE_IMAGE">
                   <Link :path="getPath(item.media)">
-                    <Image :source="item.media.onesilaThumbnailUrl" alt="File thumbnail" class="h-48 w-56 rounded-md"/>
+                    <Image :source="item.media.onesilaThumbnailUrl" alt="File thumbnail" class="h-48 w-56 rounded-md object-contain"/>
                   </Link>
                 </template>
                 <template v-else-if="item.media.type === TYPE_VIDEO">


### PR DESCRIPTION
## Summary
- ensure product media gallery images resize to fit instead of being cropped

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1c235ee90832e949d183d1dc188fe

## Summary by Sourcery

Bug Fixes:
- Add object-contain CSS class to media gallery image thumbnails to avoid cropping and maintain aspect ratio