### PR TITLE
fix: prevent image cropping in media list

### DIFF
--- a/src/core/media/files/containers/FilesList.vue
+++ b/src/core/media/files/containers/FilesList.vue
@@ -238,10 +238,14 @@ const deleteAll = async (query) => {
 
                     <template v-if="item.node.type === TYPE_IMAGE">
                       <Button v-if="assignImages" @click="assignMedia(item.node)">
-                        <Image :source="item.node.onesilaThumbnailUrl" alt="File thumbnail" class="h-48 w-56 rounded-md" />
+                        <div class="w-56 h-48 rounded-md overflow-hidden flex items-center justify-center">
+                          <Image :source="item.node.onesilaThumbnailUrl" :alt="t('media.media.labels.fileThumbnail')" class="w-full h-full object-contain" />
+                        </div>
                       </Button>
                       <Link v-else :path="getPath(item.node)">
-                        <Image :source="item.node.onesilaThumbnailUrl" alt="File thumbnail" class="h-48 w-56 rounded-md" />
+                        <div class="w-56 h-48 rounded-md overflow-hidden flex items-center justify-center">
+                          <Image :source="item.node.onesilaThumbnailUrl" :alt="t('media.media.labels.fileThumbnail')" class="w-full h-full object-contain" />
+                        </div>
                       </Link>
                     </template>
 

--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
@@ -215,7 +215,9 @@ const handleMainImageChange = async (changedItem: Item) => {
             <div v-for="item in items" :key="item.media.id" class="file-entry relative">
                 <template v-if="item.media.type === TYPE_IMAGE">
                   <Link :path="getPath(item.media)">
-                    <Image :source="item.media.onesilaThumbnailUrl" alt="File thumbnail" class="h-48 w-56 rounded-md object-contain"/>
+                    <div class="w-56 h-48 rounded-md overflow-hidden flex items-center justify-center">
+                      <Image :source="item.media.onesilaThumbnailUrl" :alt="t('media.media.labels.fileThumbnail')" class="w-full h-full object-contain" />
+                    </div>
                   </Link>
                 </template>
                 <template v-else-if="item.media.type === TYPE_VIDEO">

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -338,6 +338,11 @@
           "invalidUrl": "Bitte geben Sie eine gültige Bild-URL ein (jpg, jpeg, png, webp)."
         }
       }
+    },
+    "media": {
+      "labels": {
+        "fileThumbnail": "Datei-Miniaturansicht"
+      }
     }
   },
   "properties": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1836,7 +1836,8 @@
         "files": "Files",
         "recentFiles": "Recent Files",
         "addExistingFiles": "Add from existing media",
-        "images": "Images"
+        "images": "Images",
+        "fileThumbnail": "File thumbnail"
       },
       "alert": {
         "toast": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -333,6 +333,11 @@
           "invalidUrl": "Veuillez saisir une URL d'image valide (jpg, jpeg, png, webp)."
         }
       }
+    },
+    "media": {
+      "labels": {
+        "fileThumbnail": "Vignette du fichier"
+      }
     }
   },
   "properties": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1486,7 +1486,8 @@
         "files": "Bestanden",
         "recentFiles": "Recente Bestanden",
         "addExistingFiles": "Toevoegen van bestaande media",
-        "images": ""
+        "images": "",
+        "fileThumbnail": "Bestandsminiatuur"
       }
     },
     "images": {


### PR DESCRIPTION
## Summary
- ensure media thumbnails scale without cropping by wrapping images in fixed containers and using `object-contain`
- localize file thumbnail alt text

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1c4296828832e9b48ea7d4b412b1e