### PR TITLE
fix: improve content editor and preview

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentForm.vue
@@ -23,7 +23,7 @@ const props = defineProps({
     required: true,
   },
   currentLanguage: {
-    type: String as PropType<string | null>,
+    type: [String, null] as unknown as PropType<string | null>,
     required: true,
   },
   shortDescriptionToolbarOptions: {

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentPreview.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentPreview.vue
@@ -97,7 +97,7 @@ const previewUrl = computed(() => {
       </div>
       <div class="w-2/3">
         <div v-if="fieldRules.shortDescription"
-          class="min-h-16 text-gray-700"
+          class="min-h-16 text-gray-700 prose prose-sm"
           :class="{ 'opacity-50 italic': !props.content?.shortDescription && props.defaultContent }"
           v-html="finalPreview.shortDescription"
         />
@@ -139,6 +139,16 @@ const previewUrl = computed(() => {
 
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {
   background-color: #c0c0c0;
+}
+
+:deep(ol > li[data-list="bullet"]::before) {
+  content: "•";
+  color: inherit;
+}
+
+:deep(ol) {
+  list-style: none;
+  margin-left: 1.5rem;
 }
 
 </style>

--- a/src/shared/components/atoms/input-text-html-editor/TextHtmlEditor.vue
+++ b/src/shared/components/atoms/input-text-html-editor/TextHtmlEditor.vue
@@ -34,7 +34,7 @@ const editorOptions = computed(() => ({
   modules: {
     toolbar: finalToolbarOptions.value,
     clipboard: {
-      allowed: { tags: ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li'] },
+      allowed: { tags: ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'div'] },
     },
   },
 }));
@@ -42,7 +42,8 @@ const editorOptions = computed(() => ({
 const validateHtml = (value: string) => {
   const parser = new DOMParser();
   const doc = parser.parseFromString(value, 'text/html');
-  invalidHtml.value = doc.querySelector('parsererror') !== null;
+  const parsed = doc.body.innerHTML.trim();
+  invalidHtml.value = parsed !== value.trim();
 };
 
 watch(
@@ -62,6 +63,7 @@ watch(content, (newVal) => {
 </script>
 
 <template>
+  <div v-bind="$attrs">
     <QuillEditor
       v-model:content="content"
       contentType="html"
@@ -71,9 +73,10 @@ watch(content, (newVal) => {
       :read-only="disabled || aiGenerating"
       style="min-height: 250px;"
     />
-      <p v-if="invalidHtml" class="mt-2 text-sm text-red-600">
-        {{ t('shared.components.atoms.textHtmlEditor.invalidHtml') }}
-      </p>
+    <p v-if="invalidHtml" class="mt-2 text-sm text-red-600">
+      {{ t('shared.components.atoms.textHtmlEditor.invalidHtml') }}
+    </p>
+  </div>
 </template>
 
 <style scoped>
@@ -82,6 +85,11 @@ watch(content, (newVal) => {
   content: "• " !important;
   left: -1.5rem;
   color: inherit;
+}
+
+:deep(ol) {
+  list-style: none;
+  margin-left: 1.5rem;
 }
 
 :deep(ul) {


### PR DESCRIPTION
## Summary
- allow null language prop in product content form
- improve HTML editor validation and list rendering
- show bullet lists in product content preview

## Testing
- `npm run build` *(fails: %VITE_APP_API_GRAPHQL_URL% is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c1eae0c4832e9d47128a460485e6

## Summary by Sourcery

Improve content editor and preview by allowing null language in forms, enhancing HTML validation, and adding refined list rendering and styling across editor and preview components.

Enhancements:
- Allow currentLanguage prop to be null in the product content form
- Extend HTML editor to permit <div> tags and fine-tune validation by comparing trimmed parsed content
- Wrap the HTML editor in a container for attribute binding consistency
- Add consistent CSS rules for ordered and unordered lists to render bullets and proper indentation
- Apply prose styling to product content preview to support formatted lists