### PR TITLE
fix product tab leave dialog and unsaved detection

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -67,10 +67,10 @@ const beforeTabChange = async (newTab: string, oldTab: string) => {
       icon: 'warning',
       text: t('products.products.messages.unsavedChanges'),
       showCancelButton: true,
-      confirmButtonText: t('shared.button.change'),
-      cancelButtonText: t('shared.button.cancel'),
+      confirmButtonText: t('shared.button.cancel'),
+      cancelButtonText: t('shared.button.leaveTab'),
     });
-    return res.isConfirmed;
+    return res.dismiss === Swal.DismissReason.cancel;
   }
   return true;
 };

--- a/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-configurable/ProductConfigurable.vue
@@ -58,10 +58,10 @@ const beforeTabChange = async (newTab: string, oldTab: string) => {
       icon: 'warning',
       text: t('products.products.messages.unsavedChanges'),
       showCancelButton: true,
-      confirmButtonText: t('shared.button.change'),
-      cancelButtonText: t('shared.button.cancel'),
+      confirmButtonText: t('shared.button.cancel'),
+      cancelButtonText: t('shared.button.leaveTab'),
     });
-    return res.isConfirmed;
+    return res.dismiss === Swal.DismissReason.cancel;
   }
   return true;
 };

--- a/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-variation/ProductVariation.vue
@@ -65,10 +65,10 @@ const beforeTabChange = async (newTab: string, oldTab: string) => {
       icon: 'warning',
       text: t('products.products.messages.unsavedChanges'),
       showCancelButton: true,
-      confirmButtonText: t('shared.button.change'),
-      cancelButtonText: t('shared.button.cancel'),
+      confirmButtonText: t('shared.button.cancel'),
+      cancelButtonText: t('shared.button.leaveTab'),
     });
-    return res.isConfirmed;
+    return res.dismiss === Swal.DismissReason.cancel;
   }
   return true;
 };

--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -130,10 +130,10 @@ const handleMarketplaceSelection = async (newId: string) => {
       icon: 'warning',
       text: t('products.products.messages.unsavedChanges'),
       showCancelButton: true,
-      confirmButtonText: t('shared.button.change'),
-      cancelButtonText: t('shared.button.cancel'),
+      confirmButtonText: t('shared.button.cancel'),
+      cancelButtonText: t('shared.button.leaveTab'),
     });
-    if (!res.isConfirmed) {
+    if (res.dismiss !== Swal.DismissReason.cancel) {
       return;
     }
   }

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -8,7 +8,7 @@ import { getProductContentByLanguageAndChannelQuery, getProductContentByLanguage
 import { createProductTranslationMutation, updateProductTranslationMutation } from "../../../../../../../shared/api/mutations/products.js";
 import { integrationsQuery } from "../../../../../../../shared/api/queries/integrations.js";
 import { Selector} from "../../../../../../../shared/components/atoms/selector";
-import { reactive, watch, ref, onMounted, computed } from "vue";
+import { reactive, watch, ref, onMounted, computed, nextTick } from "vue";
 import { translationLanguagesQuery } from '../../../../../../../shared/api/queries/languages.js';
 import { Toast } from "../../../../../../../shared/modules/toast";
 import { processGraphQLErrors } from "../../../../../../../shared/utils";
@@ -110,7 +110,6 @@ const setFormAndMutation = async (language, channel) => {
         mutation.value = createProductTranslationMutation;
         previewContent.value = null;
       }
-      initialForm.value = { ...form };
       defaultPreviewContent.value = null;
 
     } else {
@@ -143,7 +142,6 @@ const setFormAndMutation = async (language, channel) => {
         mutation.value = createProductTranslationMutation;
         previewContent.value = null;
       }
-      initialForm.value = { ...form };
 
       // Fetch default translation for preview/fallback
       const { data: def } = await apolloClient.query({
@@ -161,6 +159,8 @@ const setFormAndMutation = async (language, channel) => {
     previewBulletPoints.value = await bulletPointsRef.value.fetchPoints();
   }
 
+  await nextTick();
+  initialForm.value = { ...form };
 };
 
 

--- a/src/core/products/products/product-show/containers/tabs/general/ProductEditView.vue
+++ b/src/core/products/products/product-show/containers/tabs/general/ProductEditView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import {onMounted, reactive, ref, computed} from 'vue';
+import {onMounted, reactive, ref, computed, nextTick} from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   CheckboxFormField, FormType,
@@ -90,7 +90,11 @@ const getCleanData = (data) => {
   return cleanedData;
 };
 
-const initialForm = ref(JSON.parse(JSON.stringify(getCleanData(form))));
+const initialForm = ref({});
+onMounted(async () => {
+  await nextTick();
+  initialForm.value = JSON.parse(JSON.stringify(getCleanData(form)));
+});
 
 const hasUnsavedChanges = computed(() => {
   return JSON.stringify(getCleanData(form)) !== JSON.stringify(initialForm.value);

--- a/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
@@ -85,10 +85,10 @@ const changeMode = async (newMode: 'list' | 'edit') => {
       icon: 'warning',
       text: t('products.products.messages.unsavedChanges'),
       showCancelButton: true,
-      confirmButtonText: t('shared.button.change'),
-      cancelButtonText: t('shared.button.cancel'),
+      confirmButtonText: t('shared.button.cancel'),
+      cancelButtonText: t('shared.button.leaveTab'),
     });
-    if (!res.isConfirmed) {
+    if (res.dismiss !== Swal.DismissReason.cancel) {
       return;
     }
   }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -369,6 +369,7 @@
       "editAll": "Edit all",
       "copy": "Copy",
       "change": "Change",
+      "leaveTab": "Leave tab",
       "createAnyway": "Create anyway",
       "abort": "Abort"
     },

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -179,6 +179,7 @@
       "generate": "Genereren",
       "duplicate": "Dupliceren",
       "change": "Wijzig",
+      "leaveTab": "Tab verlaten",
       "fix": "Fixen",
       "downloadConfirmation": "",
       "createAnyway": "Toch aanmaken",


### PR DESCRIPTION
## Summary
- show Cancel as primary and Leave tab as secondary for unsaved product tab changes
- avoid false unsaved changes in product General and Content tabs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c337585028832ead64b6abec7882b5

## Summary by Sourcery

Fix unsaved changes detection and improve leave-tab confirmation dialogs in product edit views

Bug Fixes:
- Prevent false unsaved-change flags in General and Content tabs by initializing initial form data after next tick
- Correct leave-tab confirmation logic to rely on dismiss reason instead of isConfirmed

Enhancements:
- Swap primary and secondary button labels to show Cancel first and Leave tab second across product bundle, configurable, variation, Amazon, and variations views
- Standardize confirmation dialog configurations (confirmButtonText, cancelButtonText) for unsaved changes prompts