### PR TITLE
fix: keep bullet points and adjust product card

### DIFF
--- a/src/core/products/products/product-show/ProductShowController.vue
+++ b/src/core/products/products/product-show/ProductShowController.vue
@@ -158,14 +158,14 @@ const copySkuToClipboard = async (sku: string) => {
         <template v-if="!loading && result">
           <Card>
             <div class="grid xl:grid-cols-2 gap-8 mb-6">
-              <div class="w-full bg-white shadow-[4px_6px_10px_-3px_#bfc9d4] rounded border border-[#e0e6ed] dark:border-[#1b2e4b] dark:bg-[#191e3a] dark:shadow-none sm:max-h-48 max-h-none">
+              <div class="w-full bg-white shadow-[4px_6px_10px_-3px_#bfc9d4] rounded border border-[#e0e6ed] dark:border-[#1b2e4b] dark:bg-[#191e3a] dark:shadow-none">
                 <div class="p-5 flex items-center sm:items-center flex-col sm:flex-row">
                   <Link v-if="getResultData(result, 'thumbnailUrl')" :path="{ name: 'products.products.show', params: { id: id }, query: { ...route.query, tab: 'media' } }">
-                    <div class="mb-5 w-20 h-20 overflow-hidden">
-                      <Image class="w-20 h-20 rounded-md overflow-hidden object-cover" :source="getResultData(result, 'thumbnailUrl')" />
+                    <div class="mb-5 w-20 h-20">
+                      <Image class="w-20 h-20 rounded-md object-contain" :source="getResultData(result, 'thumbnailUrl')" />
                     </div>
                   </Link>
-                  <div v-else class="mb-5 w-20 h-20 overflow-hidden rounded-md bg-gray-300 flex justify-center items-center">
+                  <div v-else class="mb-5 w-20 h-20 rounded-md bg-gray-300 flex justify-center items-center">
                     <Icon class="text-white" size="xl" name="question" />
                   </div>
                   <div class="flex-1 ltr:sm:pl-5 rtl:sm:pr-5 text-left">

--- a/src/core/products/products/product-show/containers/tabs/content/contentFieldRules.ts
+++ b/src/core/products/products/product-show/containers/tabs/content/contentFieldRules.ts
@@ -26,5 +26,6 @@ export const FIELD_RULES: Record<string, ContentFieldRules> = {
 
 export function getContentFieldRules(type?: string): ContentFieldRules {
   if (!type) return FIELD_RULES.default;
-  return FIELD_RULES[type] || FIELD_RULES.default;
+  const normalized = type.toLowerCase();
+  return FIELD_RULES[normalized] || FIELD_RULES.default;
 }


### PR DESCRIPTION
## Summary
- normalize integration type before applying content field rules so bullet points stay visible
- resize product thumbnail with object-contain and remove height limits for adaptable card

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3da7d276c832ebde1e855ffa20a3e