### PR TITLE
feat: add property search to product properties view

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -101,6 +101,9 @@
       "tabs": {
         "amazon": "Amazon"
       },
+      "properties": {
+        "searchPlaceholder": "Eigenschaften suchen"
+      },
       "labels": {
         "configuratorValue": ""
       },

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -992,6 +992,9 @@
         "hsCodes": "HS Codes",
         "eanCodes": "EAN Codes"
       },
+      "properties": {
+        "searchPlaceholder": "Search properties"
+      },
       "amazon": {
         "validationIssues": "Detected Validation Issues",
         "validationIssuesDescription": "Likely Amazon validation issues based on the product structure Amazon expects",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -96,6 +96,9 @@
       "tabs": {
         "amazon": "Amazon"
       },
+      "properties": {
+        "searchPlaceholder": "Rechercher des propriétés"
+      },
       "labels": {
         "configuratorValue": ""
       },

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -675,6 +675,9 @@
         "websites": "Verkoopskanalen",
         "amazon": "Amazon"
       },
+      "properties": {
+        "searchPlaceholder": "Zoek eigenschappen"
+      },
       "amazon": {
         "validationIssues": "Gedetecteerde validatieproblemen",
         "validationIssuesDescription": "Waarschijnlijke Amazon-validatieproblemen op basis van de productstructuur die Amazon verwacht",

--- a/src/shared/components/molecules/search-input/SearchInput.vue
+++ b/src/shared/components/molecules/search-input/SearchInput.vue
@@ -14,8 +14,9 @@ const props = withDefaults(
     routeKey?: string;
     debounce?: number;
     loading?: boolean;
+    size?: 'sm' | 'md';
   }>(),
-  { routeKey: "search", debounce: 600, loading: false }
+  { routeKey: "search", debounce: 600, loading: false, size: 'md' }
 );
 
 const { t } = useI18n();
@@ -25,6 +26,7 @@ const input = ref<HTMLInputElement | null>(null);
 const emit = defineEmits(["update:modelValue"]);
 const inputValue = ref((props.modelValue || "").slice(0, 100));
 const loading = computed(() => props.loading);
+const sizeClass = computed(() => (props.size === 'sm' ? 'h-9' : 'h-12'));
 
 watch(() => props.modelValue, (newValue) => {
   if (newValue === null) {
@@ -65,7 +67,7 @@ const onInput = () => {
 
 <template>
   <div class="w-full" :class="disabled ? 'bg-gray-100' : 'bg-white'">
-    <div class="relative flex items-center w-full h-12 rounded-lg focus-within:shadow-lg  overflow-hidden border-2 border-gray100">
+    <div :class="['relative flex items-center w-full rounded-lg focus-within:shadow-lg  overflow-hidden border-2 border-gray100', sizeClass]">
       <div class="grid place-items-center h-full w-12 text-gray-300">
         <Icon v-if="!loading" name="search" class="h-6 w-6" />
         <div v-else class="loader-mini"></div>


### PR DESCRIPTION
## Summary
- add client-side search bar in product properties tab
- localize search placeholder text
- add status filters and improved search bar design
- align search bar, filters, and actions on a single row with consistent heights
- allow compact sizing for SearchInput component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c42532074c832e9595cfa56527ab81