### PR TITLE
Improve properties search UI and add type filter

### DIFF
--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -102,7 +102,8 @@
         "amazon": "Amazon"
       },
       "properties": {
-        "searchPlaceholder": "Eigenschaften suchen"
+        "searchPlaceholder": "Eigenschaften suchen",
+        "typePlaceholder": "Nach Typ filtern"
       },
       "labels": {
         "configuratorValue": ""

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -992,9 +992,10 @@
         "hsCodes": "HS Codes",
         "eanCodes": "EAN Codes"
       },
-      "properties": {
-        "searchPlaceholder": "Search properties"
-      },
+        "properties": {
+          "searchPlaceholder": "Search properties",
+          "typePlaceholder": "Filter by type"
+        },
       "amazon": {
         "validationIssues": "Detected Validation Issues",
         "validationIssuesDescription": "Likely Amazon validation issues based on the product structure Amazon expects",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -96,9 +96,10 @@
       "tabs": {
         "amazon": "Amazon"
       },
-      "properties": {
-        "searchPlaceholder": "Rechercher des propriétés"
-      },
+        "properties": {
+          "searchPlaceholder": "Rechercher des propriétés",
+          "typePlaceholder": "Filtrer par type"
+        },
       "labels": {
         "configuratorValue": ""
       },

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -675,9 +675,10 @@
         "websites": "Verkoopskanalen",
         "amazon": "Amazon"
       },
-      "properties": {
-        "searchPlaceholder": "Zoek eigenschappen"
-      },
+        "properties": {
+          "searchPlaceholder": "Zoek eigenschappen",
+          "typePlaceholder": "Filter op type"
+        },
       "amazon": {
         "validationIssues": "Gedetecteerde validatieproblemen",
         "validationIssuesDescription": "Waarschijnlijke Amazon-validatieproblemen op basis van de productstructuur die Amazon verwacht",


### PR DESCRIPTION
## Summary
- Match language selector and save button height to search bar
- Add property type multi-select filter and hook into search
- Localize placeholder for type selector in all languages

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c4350e8fe8832eb17d302eca897fde