### PR TITLE
feat: add reusable property filters

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -10,7 +10,7 @@ import {
   productPropertiesRulesQuery, productPropertyTextTranslationsQuery,
   propertiesQuery
 } from "../../../../../../../shared/api/queries/properties.js";
-import {ConfigTypes, ProductType, PropertyTypes, getPropertyTypeOptions} from "../../../../../../../shared/utils/constants";
+import {ConfigTypes, ProductType, PropertyTypes} from "../../../../../../../shared/utils/constants";
 import {ValueInput} from "./value-input";
 import {Loader} from "../../../../../../../shared/components/atoms/loader";
 import {translationLanguagesQuery} from "../../../../../../../shared/api/queries/languages.js";
@@ -18,7 +18,7 @@ import {Selector} from "../../../../../../../shared/components/atoms/selector";
 import {Icon} from "../../../../../../../shared/components/atoms/icon";
 import {Pagination} from "../../../../../../../shared/components/molecules/pagination";
 import {Button} from "../../../../../../../shared/components/atoms/button";
-import {SearchInput} from "../../../../../../../shared/components/molecules/search-input";
+import {PropertyFilters} from "../../../../../../../shared/components/molecules/property-filters";
 
 
 const {t} = useI18n();
@@ -67,7 +67,6 @@ const filters = reactive({
   FILLED: true,
 });
 const selectedPropertyTypes = ref<string[]>([]);
-const propertyTypeOptions = computed(() => getPropertyTypeOptions(t));
 
 const requiredTypes = [
   ConfigTypes.REQUIRED,
@@ -93,10 +92,6 @@ const isFilled = (val: ProductPropertyValue) => {
 };
 
 const productTypeValue = computed(() => values.value.find(v => v.property.isProductType));
-
-const toggleFilter = (type: string) => {
-  filters[type] = !filters[type];
-};
 
 const sortedValues = computed(() => {
   const req: ProductPropertyValue[] = [];
@@ -556,26 +551,11 @@ const handleValueUpdate = ({id, type, value, language}) => {
     </Flex>
     <Flex center gap="2" class="my-2 items-start">
       <FlexCell grow>
-        <SearchInput v-model="searchQuery" :placeholder="t('products.products.properties.searchPlaceholder')" />
-      </FlexCell>
-      <FlexCell>
-                <Selector
-            v-model="selectedPropertyTypes"
-            :options="propertyTypeOptions"
-            multiple
-            :placeholder="t('products.products.properties.typePlaceholder')"
-            class="w-48 h-12"
-            labelBy="name"
-            valueBy="code"/>
-      </FlexCell>
-      <FlexCell class="flex flex-col items-center gap-2">
-        <div class="flex gap-2">
-          <button v-for="type in requireTypes" :key="type.value" :title="type.label" @click="toggleFilter(type.value)"
-              class="w-12 h-12 flex items-center justify-center rounded border cursor-pointer hover:border-blue-500"
-              :class="filters[type.value] ? 'border-blue-500' : 'border-transparent'">
-            <Icon name="circle-dot" :class="getIconColor(type.value)"/>
-          </button>
-        </div>
+        <PropertyFilters
+            v-model:search-query="searchQuery"
+            v-model:selected-property-types="selectedPropertyTypes"
+            v-model:filters="filters"
+        />
       </FlexCell>
       <FlexCell>
         <ApolloQuery v-if="language" :query="translationLanguagesQuery" fetch-policy="cache-and-network">

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { Product } from '../../../../../../configs'
 import { bundleVariationsQuery, configurableVariationsQuery } from '../../../../../../../../../shared/api/queries/products.js'
 import { ProductType, PropertyTypes, FieldType, ConfigTypes } from '../../../../../../../../../shared/utils/constants'
+import { PropertyFilters } from '../../../../../../../../../shared/components/molecules/property-filters'
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { TextInput } from "../../../../../../../../../shared/components/atoms/input-text";
 import { TextEditor } from "../../../../../../../../../shared/components/atoms/input-text-editor";
@@ -40,6 +41,14 @@ const { t } = useI18n()
 
 const language = ref<string | null>(null)
 
+const searchQuery = ref('')
+const filters = reactive({
+  [ConfigTypes.REQUIRED]: true,
+  [ConfigTypes.OPTIONAL]: true,
+  FILLED: true,
+})
+const selectedPropertyTypes = ref<string[]>([])
+
 const baseColumns: { key: string; label: string; requireType?: string }[] = [
   { key: 'sku', label: t('shared.labels.sku') },
   { key: 'name', label: t('shared.labels.name') },
@@ -71,9 +80,25 @@ const perPageOptions = [
 const fetchPaginationData = ref<Record<string, any>>({})
 fetchPaginationData.value['first'] = limit.value
 
+const filteredProperties = computed(() => {
+  return properties.value.filter((p) => {
+    const type = [
+      ConfigTypes.REQUIRED,
+      ConfigTypes.REQUIRED_IN_CONFIGURATOR,
+      ConfigTypes.OPTIONAL_IN_CONFIGURATOR,
+    ].includes(p.requireType as ConfigTypes)
+      ? ConfigTypes.REQUIRED
+      : ConfigTypes.OPTIONAL
+    if (!filters[type]) return false
+    if (selectedPropertyTypes.value.length && !selectedPropertyTypes.value.includes(p.type)) return false
+    if (!searchQuery.value) return true
+    return p.name.toLowerCase().includes(searchQuery.value.toLowerCase())
+  })
+})
+
 const columns = computed(() => [
   ...baseColumns,
-  ...properties.value.map((p) => ({ key: p.id, label: p.name, requireType: p.requireType })),
+  ...filteredProperties.value.map((p) => ({ key: p.id, label: p.name, requireType: p.requireType })),
 ])
 
 const getIconColor = (requireType: string) => {
@@ -911,7 +936,13 @@ const startResize = (e: MouseEvent, key: string) => {
       <LocalLoader :loading="loading" />
     </div>
     <Flex between middle gap="2" class="mb-4">
-      <FlexCell grow></FlexCell>
+      <FlexCell grow>
+        <PropertyFilters
+          v-model:search-query="searchQuery"
+          v-model:selected-property-types="selectedPropertyTypes"
+          v-model:filters="filters"
+        />
+      </FlexCell>
       <FlexCell class="flex">
         <Button
           class="btn btn-secondary"
@@ -928,7 +959,7 @@ const startResize = (e: MouseEvent, key: string) => {
           <Icon name="arrow-right" />
         </Button>
       </FlexCell>
-      <FlexCell >
+      <FlexCell>
         <ApolloQuery :query="translationLanguagesQuery" fetch-policy="cache-and-network">
           <template v-slot="{ result: { data } }">
             <Selector

--- a/src/shared/components/molecules/property-filters/PropertyFilters.vue
+++ b/src/shared/components/molecules/property-filters/PropertyFilters.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { ref, reactive, watch, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Selector } from '../../atoms/selector';
+import { Icon } from '../../atoms/icon';
+import { ConfigTypes, getPropertyTypeOptions } from '../../../utils/constants';
+
+const props = defineProps<{
+  searchQuery: string;
+  selectedPropertyTypes: string[];
+  filters: Record<string, boolean>;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:searchQuery', value: string): void;
+  (e: 'update:selectedPropertyTypes', value: string[]): void;
+  (e: 'update:filters', value: Record<string, boolean>): void;
+}>();
+
+const { t } = useI18n();
+
+const localSearch = ref(props.searchQuery);
+watch(() => props.searchQuery, val => { localSearch.value = val; });
+watch(localSearch, val => emit('update:searchQuery', val));
+
+const localSelectedTypes = ref<string[]>([...props.selectedPropertyTypes]);
+watch(() => props.selectedPropertyTypes, val => { localSelectedTypes.value = [...val]; });
+watch(localSelectedTypes, val => emit('update:selectedPropertyTypes', val));
+
+const localFilters = reactive({ ...props.filters });
+watch(() => props.filters, val => { Object.assign(localFilters, val); });
+watch(localFilters, val => emit('update:filters', val), { deep: true });
+
+const requireTypes = [
+  { value: ConfigTypes.REQUIRED, label: t('properties.rule.configTypes.required.title') },
+  { value: ConfigTypes.OPTIONAL, label: t('properties.rule.configTypes.optional.title') },
+  { value: 'FILLED', label: t('properties.rule.configTypes.filled.title') },
+];
+
+const propertyTypeOptions = computed(() => getPropertyTypeOptions(t));
+
+const toggleFilter = (type: string) => {
+  localFilters[type] = !localFilters[type];
+};
+
+const getIconColor = (requireType: string) => {
+  if ([ConfigTypes.REQUIRED, ConfigTypes.REQUIRED_IN_CONFIGURATOR, ConfigTypes.OPTIONAL_IN_CONFIGURATOR].includes(requireType as ConfigTypes)) {
+    return 'text-red-500';
+  }
+  if (requireType === ConfigTypes.OPTIONAL) {
+    return 'text-orange-400';
+  }
+  return 'text-gray-400';
+};
+</script>
+
+<template>
+  <div class="flex items-start gap-2 w-full">
+    <div class="flex-1 relative">
+      <input
+        v-model="localSearch"
+        :placeholder="t('products.products.properties.searchPlaceholder')"
+        class="w-full h-12 border border-gray-300 rounded-lg pl-10 pr-2 text-sm"
+        type="text"
+      />
+      <Icon name="search" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+    </div>
+    <Selector
+      v-model="localSelectedTypes"
+      :options="propertyTypeOptions"
+      multiple
+      :placeholder="t('products.products.properties.typePlaceholder')"
+      class="w-48 h-12"
+      labelBy="name"
+      valueBy="code"
+    />
+    <div class="flex flex-col items-center gap-2">
+      <div class="flex gap-2">
+        <button
+          v-for="type in requireTypes"
+          :key="type.value"
+          :title="type.label"
+          @click="toggleFilter(type.value)"
+          class="w-12 h-12 flex items-center justify-center rounded border cursor-pointer hover:border-blue-500"
+          :class="localFilters[type.value] ? 'border-blue-500' : 'border-transparent'"
+        >
+          <Icon name="circle-dot" :class="getIconColor(type.value)" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/shared/components/molecules/property-filters/index.ts
+++ b/src/shared/components/molecules/property-filters/index.ts
@@ -1,0 +1,1 @@
+export { default as PropertyFilters } from './PropertyFilters.vue';


### PR DESCRIPTION
## Summary
- add PropertyFilters component for compact property search and filtering
- replace PropertiesView search bar with PropertyFilters
- allow bulk variations table to filter columns in real time

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c43a0f37d0832ea655ad4d42815f9a