### PR TITLE
Refactor property filters and fix bulk edit toggles

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -555,6 +555,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
             v-model:search-query="searchQuery"
             v-model:selected-property-types="selectedPropertyTypes"
             v-model:filters="filters"
+            add-filled
         />
       </FlexCell>
       <FlexCell>

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -42,10 +42,9 @@ const { t } = useI18n()
 const language = ref<string | null>(null)
 
 const searchQuery = ref('')
-const filters = reactive({
+const filters = ref<Record<string, boolean>>({
   [ConfigTypes.REQUIRED]: true,
   [ConfigTypes.OPTIONAL]: true,
-  FILLED: true,
 })
 const selectedPropertyTypes = ref<string[]>([])
 
@@ -89,7 +88,7 @@ const filteredProperties = computed(() => {
     ].includes(p.requireType as ConfigTypes)
       ? ConfigTypes.REQUIRED
       : ConfigTypes.OPTIONAL
-    if (!filters[type]) return false
+    if (!filters.value[type]) return false
     if (selectedPropertyTypes.value.length && !selectedPropertyTypes.value.includes(p.type)) return false
     if (!searchQuery.value) return true
     return p.name.toLowerCase().includes(searchQuery.value.toLowerCase())

--- a/src/shared/components/molecules/property-filters/PropertyFilters.vue
+++ b/src/shared/components/molecules/property-filters/PropertyFilters.vue
@@ -3,12 +3,15 @@ import { ref, reactive, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Selector } from '../../atoms/selector';
 import { Icon } from '../../atoms/icon';
+import { Flex, FlexCell } from '../../layouts/flex';
+import { TextInput } from '../../atoms/input-text';
 import { ConfigTypes, getPropertyTypeOptions } from '../../../utils/constants';
 
 const props = defineProps<{
   searchQuery: string;
   selectedPropertyTypes: string[];
   filters: Record<string, boolean>;
+  addFilled?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -31,11 +34,16 @@ const localFilters = reactive({ ...props.filters });
 watch(() => props.filters, val => { Object.assign(localFilters, val); });
 watch(localFilters, val => emit('update:filters', val), { deep: true });
 
-const requireTypes = [
-  { value: ConfigTypes.REQUIRED, label: t('properties.rule.configTypes.required.title') },
-  { value: ConfigTypes.OPTIONAL, label: t('properties.rule.configTypes.optional.title') },
-  { value: 'FILLED', label: t('properties.rule.configTypes.filled.title') },
-];
+const requireTypes = computed(() => {
+  const types = [
+    { value: ConfigTypes.REQUIRED, label: t('properties.rule.configTypes.required.title') },
+    { value: ConfigTypes.OPTIONAL, label: t('properties.rule.configTypes.optional.title') },
+  ];
+  if (props.addFilled) {
+    types.push({ value: 'FILLED', label: t('properties.rule.configTypes.filled.title') });
+  }
+  return types;
+});
 
 const propertyTypeOptions = computed(() => getPropertyTypeOptions(t));
 
@@ -55,38 +63,41 @@ const getIconColor = (requireType: string) => {
 </script>
 
 <template>
-  <div class="flex items-start gap-2 w-full">
-    <div class="flex-1 relative">
-      <input
-        v-model="localSearch"
-        :placeholder="t('products.products.properties.searchPlaceholder')"
-        class="w-full h-12 border border-gray-300 rounded-lg pl-10 pr-2 text-sm"
-        type="text"
+  <Flex gap="2" wrap class="w-full items-start">
+    <FlexCell grow>
+      <div class="relative w-full">
+        <TextInput
+          v-model="localSearch"
+          :placeholder="t('products.products.properties.searchPlaceholder')"
+          class="w-full pl-9"
+        />
+        <Icon name="search" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+      </div>
+    </FlexCell>
+    <FlexCell>
+      <Selector
+        v-model="localSelectedTypes"
+        :options="propertyTypeOptions"
+        multiple
+        :placeholder="t('products.products.properties.typePlaceholder')"
+        class="w-48"
+        labelBy="name"
+        valueBy="code"
       />
-      <Icon name="search" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-    </div>
-    <Selector
-      v-model="localSelectedTypes"
-      :options="propertyTypeOptions"
-      multiple
-      :placeholder="t('products.products.properties.typePlaceholder')"
-      class="w-48 h-12"
-      labelBy="name"
-      valueBy="code"
-    />
-    <div class="flex flex-col items-center gap-2">
-      <div class="flex gap-2">
+    </FlexCell>
+    <FlexCell>
+      <Flex gap="2">
         <button
           v-for="type in requireTypes"
           :key="type.value"
           :title="type.label"
           @click="toggleFilter(type.value)"
-          class="w-12 h-12 flex items-center justify-center rounded border cursor-pointer hover:border-blue-500"
+          class="w-10 h-10 flex items-center justify-center rounded border cursor-pointer hover:border-blue-500"
           :class="localFilters[type.value] ? 'border-blue-500' : 'border-transparent'"
         >
           <Icon name="circle-dot" :class="getIconColor(type.value)" />
         </button>
-      </div>
-    </div>
-  </div>
+      </Flex>
+    </FlexCell>
+  </Flex>
 </template>


### PR DESCRIPTION
## Summary
- refactor PropertyFilters to use Flex layout, TextInput search, and optional filled toggle
- ensure variation bulk edit filter toggles work and drop unsupported filled filter
- pass add-filled flag to properties view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c43d990a0c832e9aad4c24a1064ddb