### PR TITLE
Fix property filter selectors and configurable property display

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
+++ b/src/core/products/products/product-show/containers/tabs/properties/PropertiesView.vue
@@ -61,7 +61,7 @@ const perPageOptions = [
 ];
 
 const searchQuery = ref('');
-const filters = reactive({
+const filters = ref<Record<string, boolean>>({
   [ConfigTypes.REQUIRED]: true,
   [ConfigTypes.OPTIONAL]: true,
   FILLED: true,
@@ -117,7 +117,7 @@ const filteredValues = computed(() => {
         : requiredTypes.includes(v.property.requireType as ConfigTypes)
             ? ConfigTypes.REQUIRED
             : ConfigTypes.OPTIONAL;
-    if (!filters[type]) return false;
+    if (!filters.value[type]) return false;
     if (selectedPropertyTypes.value.length && !selectedPropertyTypes.value.includes(v.property.type)) return false;
     if (!searchQuery.value) return true;
     return v.property.name.toLowerCase().includes(searchQuery.value.toLowerCase());
@@ -582,7 +582,7 @@ const handleValueUpdate = ({id, type, value, language}) => {
     </Flex>
     <Loader :loading="loading"/>
     <div class="mt-4 space-y-6">
-      <div v-if="productTypeValue">
+      <div v-if="productTypeValue && product.type !== ProductType.Configurable">
         <ValueInput
             v-if="!loading || [PropertyTypes.TEXT, PropertyTypes.DESCRIPTION].includes(productTypeValue.property.type)"
             :product-id="product.id"

--- a/src/shared/components/molecules/property-filters/PropertyFilters.vue
+++ b/src/shared/components/molecules/property-filters/PropertyFilters.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, watch, computed } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Selector } from '../../atoms/selector';
 import { Icon } from '../../atoms/icon';
@@ -22,17 +22,20 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-const localSearch = ref(props.searchQuery);
-watch(() => props.searchQuery, val => { localSearch.value = val; });
-watch(localSearch, val => emit('update:searchQuery', val));
+const localSearch = computed({
+  get: () => props.searchQuery,
+  set: val => emit('update:searchQuery', val),
+});
 
-const localSelectedTypes = ref<string[]>([...props.selectedPropertyTypes]);
-watch(() => props.selectedPropertyTypes, val => { localSelectedTypes.value = [...val]; });
-watch(localSelectedTypes, val => emit('update:selectedPropertyTypes', val));
+const localSelectedTypes = computed<string[]>({
+  get: () => props.selectedPropertyTypes,
+  set: val => emit('update:selectedPropertyTypes', val),
+});
 
-const localFilters = reactive({ ...props.filters });
-watch(() => props.filters, val => { Object.assign(localFilters, val); });
-watch(localFilters, val => emit('update:filters', val), { deep: true });
+const localFilters = computed<Record<string, boolean>>({
+  get: () => props.filters,
+  set: val => emit('update:filters', val),
+});
 
 const requireTypes = computed(() => {
   const types = [
@@ -48,7 +51,7 @@ const requireTypes = computed(() => {
 const propertyTypeOptions = computed(() => getPropertyTypeOptions(t));
 
 const toggleFilter = (type: string) => {
-  localFilters[type] = !localFilters[type];
+  localFilters.value = { ...localFilters.value, [type]: !localFilters.value[type] };
 };
 
 const getIconColor = (requireType: string) => {
@@ -93,7 +96,7 @@ const getIconColor = (requireType: string) => {
           :title="type.label"
           @click="toggleFilter(type.value)"
           class="w-9 h-9 flex items-center justify-center rounded border cursor-pointer hover:border-blue-500"
-          :class="localFilters[type.value] ? 'border-blue-500' : 'border-transparent'"
+          :class="localFilters.value[type.value] ? 'border-blue-500' : 'border-transparent'"
         >
           <Icon name="circle-dot" :class="getIconColor(type.value)" />
         </button>


### PR DESCRIPTION
## Summary
- Rework PropertyFilters state management to eliminate recursive updates and allow type selectors and toggles to update
- Store property filters as a ref so toggles work in PropertiesView and hide product type section for configurable products

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c4427bc2f8832e9281865043cb0eb8