### PR TITLE
Adjust query debounce delays based on search length

### DIFF
--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -231,17 +231,35 @@ if (props.field.multiple) {
   showCreateOnFlyModal.value = false;
 };
 
-const handleInput = debounce(async (searchValue: string) => {
+const debouncedFetchFast = debounce(async (searchValue: string) => {
+  if (!searchValue.length) {
+    fetchData();
+  } else {
+    fetchData(searchValue);
+  }
+}, 500);
+
+const debouncedFetchSlow = debounce(async (searchValue: string) => {
+  if (!searchValue.length) {
+    fetchData();
+  } else {
+    fetchData(searchValue);
+  }
+}, 1000);
+
+const handleInput = (searchValue: string) => {
   if (!isLiveUpdate.value) {
     return;
   }
 
-  if (searchValue.length >= minSearchLength.value) {
-    fetchData(searchValue);
-  } else if (!searchValue.length) {
-    fetchData();
+  if (searchValue.length < minSearchLength.value) {
+    debouncedFetchFast.cancel();
+    debouncedFetchSlow(searchValue);
+  } else {
+    debouncedFetchSlow.cancel();
+    debouncedFetchFast(searchValue);
   }
-}, 500);
+};
 
 const showAddEntry = computed(() => !!props.field.createOnFlyConfig);
 

--- a/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
+++ b/src/shared/components/organisms/general-search/containers/filter-modal/containers/filter-query/FilterQuery.vue
@@ -161,13 +161,31 @@ watch([selectedValue, cleanedData], () => {
 
 watch(() => props.filter.queryVariables, () => fetchData(), { deep: true });
 
-const handleInput = debounce(async (searchValue: string) => {
-  if (searchValue.length >= minSearchLength.value) {
-    fetchData(searchValue, true);
-  } else if (!searchValue.length) {
+const debouncedFetchFast = debounce(async (searchValue: string) => {
+  if (!searchValue.length) {
     fetchData(null, true);
+  } else {
+    fetchData(searchValue, true);
   }
 }, 500);
+
+const debouncedFetchSlow = debounce(async (searchValue: string) => {
+  if (!searchValue.length) {
+    fetchData(null, true);
+  } else {
+    fetchData(searchValue, true);
+  }
+}, 1000);
+
+const handleInput = (searchValue: string) => {
+  if (searchValue.length < minSearchLength.value) {
+    debouncedFetchFast.cancel();
+    debouncedFetchSlow(searchValue);
+  } else {
+    debouncedFetchSlow.cancel();
+    debouncedFetchFast(searchValue);
+  }
+};
 
 const cleanData = (rawData) => {
   if (props.filter.isEdge && rawData?.edges) {


### PR DESCRIPTION
## Summary
- always trigger query fetching when typing in field and filter selectors
- introduce dynamic debounce delays so short search terms wait longer before querying

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cacc735bec832e9ec44f98acdadc75

## Summary by Sourcery

Implement dynamic debounce delays for query fetching in FieldQuery and FilterQuery components, switching between fast and slow intervals based on the input length and ensuring immediate fetch on clear.

Enhancements:
- Introduce separate fast (500ms) and slow (1000ms) debounce handlers for query fetching.
- Switch debounce intervals depending on whether the search length meets the minimum threshold.
- Ensure fetchData is always called immediately when the input is cleared.