### PR TITLE
Add full update option to Amazon product resync

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonStatusSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonStatusSection.vue
@@ -51,12 +51,24 @@ const formatDate = (dateString?: string | null) => {
       <FlexCell>
         <div class="flex gap-2 sm:ml-auto">
         <ApolloMutation
+          v-if="remoteProductId"
           :mutation="resyncAmazonProductMutation"
-          :variables="{ remoteProduct: { id: remoteProductId }, view: { id: selectedView?.id }, forceValidationOnly: false }"
+          :variables="{ remoteProduct: { id: remoteProductId }, view: { id: selectedView?.id }, forceValidationOnly: false, forceFullUpdate: true }"
           @done="() => emit('resync-success')"
           @error="(e) => emit('error', e)"
         >
-
+          <template #default="{ mutate, loading }">
+            <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
+              {{ t('shared.button.fullUpdate') }}
+            </Button>
+          </template>
+        </ApolloMutation>
+        <ApolloMutation
+          :mutation="resyncAmazonProductMutation"
+          :variables="{ remoteProduct: { id: remoteProductId }, view: { id: selectedView?.id }, forceValidationOnly: false, forceFullUpdate: false }"
+          @done="() => emit('resync-success')"
+          @error="(e) => emit('error', e)"
+        >
           <template #default="{ mutate, loading }">
             <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
               {{ t('shared.button.resync') }}
@@ -64,8 +76,9 @@ const formatDate = (dateString?: string | null) => {
           </template>
         </ApolloMutation>
         <ApolloMutation
+          v-if="remoteProductId"
           :mutation="resyncAmazonProductMutation"
-          :variables="{ remoteProduct: { id: remoteProductId }, view: { id: selectedView?.id }, forceValidationOnly: true }"
+          :variables="{ remoteProduct: { id: remoteProductId }, view: { id: selectedView?.id }, forceValidationOnly: true, forceFullUpdate: false }"
           @done="() => emit('validate-success')"
           @error="(e) => emit('error', e)"
         >

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -7,6 +7,7 @@
       "select": "Auswählen",
       "duplicate": "Duplizieren",
       "resync": "Resync",
+      "fullUpdate": "Full Update",
       "validate": "Validate",
       "fetchIssues": "Fetch Issues",
       "saveAll": "Alles speichern"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -354,6 +354,7 @@
       "refresh": "Refresh",
       "add": "Add",
       "resync": "Resync",
+      "fullUpdate": "Full Update",
       "validate": "Validate",
       "fetchIssues": "Fetch Issues",
       "download": "Download",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -7,6 +7,7 @@
       "select": "Sélectionner",
       "duplicate": "Dupliquer",
       "resync": "Resync",
+      "fullUpdate": "Full Update",
       "validate": "Validate",
       "fetchIssues": "Fetch Issues",
       "saveAll": "Tout enregistrer"

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -185,6 +185,7 @@
       "createAnyway": "Toch aanmaken",
       "abort": "Afbreken",
       "resync": "Resync",
+      "fullUpdate": "Full Update",
       "validate": "Validate",
       "fetchIssues": "Fetch Issues"
     },

--- a/src/shared/api/mutations/amazonProducts.js
+++ b/src/shared/api/mutations/amazonProducts.js
@@ -16,11 +16,13 @@ export const resyncAmazonProductMutation = gql`
     $remoteProduct: AmazonProductPartialInput!
     $view: AmazonSalesChannelViewPartialInput!
     $forceValidationOnly: Boolean!
+    $forceFullUpdate: Boolean!
   ) {
     resyncAmazonProduct(
       remoteProduct: $remoteProduct
       view: $view
       forceValidationOnly: $forceValidationOnly
+      forceFullUpdate: $forceFullUpdate
     ) {
       id
     }


### PR DESCRIPTION
## Summary
- add forceFullUpdate parameter to the Amazon resync mutation and expose the new full update action in the Amazon status section
- hide validate/fetch buttons when no remote product exists and ensure translations include the new button label

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68caf847c538832e94fd2da9aec1a03a