### PR TITLE
Handle multiple Amazon products per marketplace view

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1028,6 +1028,7 @@
         "createdAsin": "Created ASIN",
         "defaultMarketplace": "Default marketplace",
         "defaultMarketplaceFallback": "Value missing. The default marketplace value will be used.",
+        "parentProductLabel": "Parent Product:",
         "browseNode": "Browse node",
         "browseNodeDescription": "Select the browse node for this product.",
         "browseNodeSaved": "Browse node saved",

--- a/src/shared/api/queries/amazonProducts.js
+++ b/src/shared/api/queries/amazonProducts.js
@@ -9,6 +9,14 @@ export const amazonProductsQuery = gql`
           createdMarketplaces
           lastSyncAt
           syncingCurrentPercentage
+          remoteParentProduct {
+            id
+            localInstance {
+              id
+              name
+              sku
+            }
+          }
           issues {
             id
             createdAt


### PR DESCRIPTION
## Summary
- allow selecting between multiple Amazon product records per sales channel view by keying tabs with combined view and product identifiers
- surface parent product links in the marketplace tab and request the necessary data via the Amazon products query
- update selection logic in the Amazon tab view to keep view/product pairs in sync when data reloads

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cb3420a350832e882bc3b2cf52da1c

## Summary by Sourcery

Enable handling of multiple Amazon product records per marketplace view by keying tabs with combined view and product identifiers, surfacing parent product links, and synchronizing selections on data reload.

New Features:
- Support selecting multiple Amazon products per marketplace view via combined view/product tab keys
- Surface remote parent product links in the marketplace tabs
- Extend amazonProducts GraphQL query to fetch remoteParentProduct data

Enhancements:
- Compute dynamic marketplace entries per view and group them by sales channel
- Update tab selection logic to maintain synchronized view/product pairs upon data reloads