### PR TITLE
Handle literal quote searches in FieldQuery

### DIFF
--- a/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
+++ b/src/shared/components/organisms/general-form/containers/form-fields/field-query/FieldQuery.vue
@@ -247,12 +247,19 @@ const debouncedFetchSlow = debounce(async (searchValue: string) => {
   }
 }, 1000);
 
+const getSanitizedLength = (searchValue: string) => {
+  return searchValue.replace(/["']/g, '').trim().length;
+};
+
 const handleInput = (searchValue: string) => {
   if (!isLiveUpdate.value) {
     return;
   }
 
-  if (searchValue.length < minSearchLength.value) {
+  const sanitizedLength = getSanitizedLength(searchValue);
+  const bypassMinLength = sanitizedLength > 0 && (searchValue.includes('"') || searchValue.includes("'"));
+
+  if (sanitizedLength < minSearchLength.value && !bypassMinLength) {
     debouncedFetchFast.cancel();
     debouncedFetchSlow(searchValue);
   } else {


### PR DESCRIPTION
## Summary
- adjust FieldQuery search debounce to measure query length without quotes
- bypass minimum search length threshold when literal (quoted) searches are used to keep results visible

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc1dc79104832eb3f05f9f267ce0ed

## Summary by Sourcery

Enable literal (quoted) searches in FieldQuery by stripping quotes when measuring query length and bypassing the minimum search length threshold for quoted inputs.

Enhancements:
- Add getSanitizedLength to compute search length excluding quotation marks
- Modify debounce logic to use sanitized length and bypass the minimum length requirement when the query contains quotes