### PR TITLE
Restore eBay integration general tab

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/stores/containers/EbayStoreEditView.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/stores/containers/EbayStoreEditView.vue
@@ -1,0 +1,385 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import { Label } from "../../../../../../../shared/components/atoms/label";
+import { TextInput } from "../../../../../../../shared/components/atoms/input-text";
+import { Selector } from "../../../../../../../shared/components/atoms/selector";
+import { Toggle } from "../../../../../../../shared/components/atoms/toggle";
+import { Flex, FlexCell } from "../../../../../../../shared/components/layouts/flex";
+import { PrimaryButton } from "../../../../../../../shared/components/atoms/button-primary";
+import { SecondaryButton } from "../../../../../../../shared/components/atoms/button-secondary";
+import { CancelButton } from "../../../../../../../shared/components/atoms/button-cancel";
+import { Toast } from "../../../../../../../shared/modules/toast";
+import { useEnterKeyboardListener, useShiftBackspaceKeyboardListener, useShiftEnterKeyboardListener } from "../../../../../../../shared/modules/keyboard";
+import { processGraphQLErrors } from "../../../../../../../shared/utils";
+import { getEbaySalesChannelViewQuery } from "../../../../../../../shared/api/queries/salesChannels.js";
+import { updateEbaySalesChannelViewMutation } from "../../../../../../../shared/api/mutations/salesChannels.js";
+import apolloClient from "../../../../../../../../apollo-client";
+
+interface EbayChoiceOption {
+  label: string;
+  value: string;
+}
+
+interface EbayStoreForm {
+  id: string;
+  name: string;
+  url: string | null;
+  fulfillmentPolicyId: string | null;
+  fulfillmentPolicyChoices?: EbayChoiceOption[];
+  paymentPolicyId: string | null;
+  paymentPolicyChoices?: EbayChoiceOption[];
+  returnPolicyId: string | null;
+  returnPolicyChoices?: EbayChoiceOption[];
+  merchantLocationKey: string | null;
+  merchantLocationChoices?: EbayChoiceOption[];
+  lengthUnit: string | null;
+  lengthUnitChoices?: EbayChoiceOption[];
+  weightUnit: string | null;
+  weightUnitChoices?: EbayChoiceOption[];
+  isDefault: boolean;
+}
+
+const props = defineProps<{
+  storeId: string;
+  integrationId: string;
+  integrationType: string;
+}>();
+
+const { t } = useI18n();
+const router = useRouter();
+
+const formData = ref<EbayStoreForm | null>(null);
+const fieldErrors = ref<Record<string, string>>({});
+const isLoading = ref(false);
+const isSaving = ref(false);
+const isSavingAndContinue = ref(false);
+const submitButtonRef = ref();
+const submitContinueButtonRef = ref();
+
+const storesRoute = computed(() => ({
+  name: 'integrations.integrations.show',
+  params: { type: props.integrationType, id: props.integrationId },
+  query: { tab: 'stores' },
+}));
+
+const withDefaults = (data: any): EbayStoreForm => ({
+  id: data.id,
+  name: data.name ?? '',
+  url: data.url ?? '',
+  fulfillmentPolicyId: data.fulfillmentPolicyId ?? null,
+  fulfillmentPolicyChoices: data.fulfillmentPolicyChoices ?? [],
+  paymentPolicyId: data.paymentPolicyId ?? null,
+  paymentPolicyChoices: data.paymentPolicyChoices ?? [],
+  returnPolicyId: data.returnPolicyId ?? null,
+  returnPolicyChoices: data.returnPolicyChoices ?? [],
+  merchantLocationKey: data.merchantLocationKey ?? null,
+  merchantLocationChoices: data.merchantLocationChoices ?? [],
+  lengthUnit: data.lengthUnit ?? null,
+  lengthUnitChoices: data.lengthUnitChoices ?? [],
+  weightUnit: data.weightUnit ?? null,
+  weightUnitChoices: data.weightUnitChoices ?? [],
+  isDefault: data.isDefault ?? false,
+});
+
+const defaultLengthUnitOptions = computed<EbayChoiceOption[]>(() => [
+  { value: 'CENTIMETER', label: t('integrations.ebay.lengthUnits.centimeter') },
+  { value: 'METER', label: t('integrations.ebay.lengthUnits.meter') },
+  { value: 'INCH', label: t('integrations.ebay.lengthUnits.inch') },
+  { value: 'FOOT', label: t('integrations.ebay.lengthUnits.foot') },
+]);
+
+const defaultWeightUnitOptions = computed<EbayChoiceOption[]>(() => [
+  { value: 'GRAM', label: t('integrations.ebay.weightUnits.gram') },
+  { value: 'KILOGRAM', label: t('integrations.ebay.weightUnits.kilogram') },
+  { value: 'OUNCE', label: t('integrations.ebay.weightUnits.ounce') },
+  { value: 'POUND', label: t('integrations.ebay.weightUnits.pound') },
+]);
+
+const lengthUnitOptions = computed(() => {
+  const choices = formData.value?.lengthUnitChoices ?? [];
+  return choices.length ? choices : defaultLengthUnitOptions.value;
+});
+
+const weightUnitOptions = computed(() => {
+  const choices = formData.value?.weightUnitChoices ?? [];
+  return choices.length ? choices : defaultWeightUnitOptions.value;
+});
+
+const goBack = () => {
+  router.push(storesRoute.value);
+};
+
+const onSubmitPressed = () => submitButtonRef.value?.$el.click();
+const onSubmitAndContinuePressed = () => submitContinueButtonRef.value?.$el.click();
+
+useEnterKeyboardListener(onSubmitPressed);
+useShiftEnterKeyboardListener(onSubmitAndContinuePressed);
+useShiftBackspaceKeyboardListener(goBack);
+
+const handleError = (errors) => {
+  const validationErrors = processGraphQLErrors(errors, t);
+  fieldErrors.value = validationErrors;
+  if (validationErrors['__all__']) {
+    Toast.error(validationErrors['__all__']);
+  }
+};
+
+const loadStore = async () => {
+  if (!props.storeId) {
+    formData.value = null;
+    return;
+  }
+  isLoading.value = true;
+  fieldErrors.value = {};
+  try {
+    const { data } = await apolloClient.query({
+      query: getEbaySalesChannelViewQuery,
+      variables: { id: props.storeId },
+      fetchPolicy: 'network-only',
+    });
+    const storeView = data?.ebaySalesChannelView;
+    if (!storeView) {
+      formData.value = null;
+      Toast.error(t('shared.alert.toast.unexpectedResult'));
+      return;
+    }
+    formData.value = withDefaults(storeView);
+  } catch (errors) {
+    formData.value = null;
+    Toast.error(t('shared.alert.toast.unexpectedResult'));
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const buildPayload = () => {
+  if (!formData.value) {
+    return null;
+  }
+  const {
+    fulfillmentPolicyChoices,
+    paymentPolicyChoices,
+    returnPolicyChoices,
+    merchantLocationChoices,
+    lengthUnitChoices,
+    weightUnitChoices,
+    ...payload
+  } = formData.value;
+
+  return {
+    ...payload,
+    url: payload.url === '' ? null : payload.url,
+  };
+};
+
+const mutateStore = async () => {
+  const payload = buildPayload();
+  if (!payload) {
+    return null;
+  }
+  fieldErrors.value = {};
+  try {
+    const { data } = await apolloClient.mutate({
+      mutation: updateEbaySalesChannelViewMutation,
+      variables: { data: payload },
+    });
+    const result = data?.updateEbaySalesChannelView;
+    if (!result) {
+      Toast.error(t('shared.alert.toast.unexpectedResult'));
+      return null;
+    }
+    formData.value = withDefaults(result);
+    return result;
+  } catch (errors) {
+    handleError(errors);
+    return null;
+  }
+};
+
+const handleSaveAndContinue = async () => {
+  isSavingAndContinue.value = true;
+  const result = await mutateStore();
+  isSavingAndContinue.value = false;
+  if (result) {
+    Toast.success(t('shared.alert.toast.submitSuccessUpdate'));
+  }
+};
+
+const handleSave = async () => {
+  isSaving.value = true;
+  const result = await mutateStore();
+  isSaving.value = false;
+  if (result) {
+    Toast.success(t('shared.alert.toast.submitSuccessUpdate'));
+    goBack();
+  }
+};
+
+onMounted(loadStore);
+
+watch(() => props.storeId, (newId, oldId) => {
+  if (newId && newId !== oldId) {
+    loadStore();
+  }
+});
+</script>
+
+<template>
+  <div class="space-y-6">
+    <div v-if="isLoading" class="flex justify-center py-10">
+      <span class="animate-spin border-2 border-black dark:border-white !border-l-transparent rounded-full w-6 h-6 inline-flex"></span>
+    </div>
+
+    <div v-else-if="formData" class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl">
+      <div class="px-4 py-6 sm:p-8 space-y-8">
+        <div class="grid grid-cols-12 gap-4">
+          <div class="md:col-span-6 col-span-12">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+              {{ t('shared.labels.name') }}
+            </Label>
+            <TextInput v-model="formData.name" :placeholder="t('shared.placeholders.name')" class="w-full" />
+            <p v-if="fieldErrors.name" class="mt-1 text-sm text-red-500">{{ fieldErrors.name }}</p>
+          </div>
+
+          <div class="md:col-span-6 col-span-12">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+              {{ t('shared.labels.url') }}
+            </Label>
+            <TextInput v-model="formData.url" class="w-full" />
+            <p v-if="fieldErrors.url" class="mt-1 text-sm text-red-500">{{ fieldErrors.url }}</p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-12 gap-4">
+          <div class="md:col-span-4 col-span-12">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+              {{ t('integrations.labels.fulfillmentPolicy') }}
+            </Label>
+            <Selector
+              v-model="formData.fulfillmentPolicyId"
+              :options="formData.fulfillmentPolicyChoices || []"
+              label-by="label"
+              value-by="value"
+              :placeholder="t('shared.components.molecules.selector.defaultPlaceholder')"
+            />
+            <p v-if="fieldErrors.fulfillmentPolicyId" class="mt-1 text-sm text-red-500">{{ fieldErrors.fulfillmentPolicyId }}</p>
+          </div>
+
+          <div class="md:col-span-4 col-span-12">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+              {{ t('integrations.labels.paymentPolicy') }}
+            </Label>
+            <Selector
+              v-model="formData.paymentPolicyId"
+              :options="formData.paymentPolicyChoices || []"
+              label-by="label"
+              value-by="value"
+              :placeholder="t('shared.components.molecules.selector.defaultPlaceholder')"
+            />
+            <p v-if="fieldErrors.paymentPolicyId" class="mt-1 text-sm text-red-500">{{ fieldErrors.paymentPolicyId }}</p>
+          </div>
+
+          <div class="md:col-span-4 col-span-12">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+              {{ t('integrations.labels.returnPolicy') }}
+            </Label>
+            <Selector
+              v-model="formData.returnPolicyId"
+              :options="formData.returnPolicyChoices || []"
+              label-by="label"
+              value-by="value"
+              :placeholder="t('shared.components.molecules.selector.defaultPlaceholder')"
+            />
+            <p v-if="fieldErrors.returnPolicyId" class="mt-1 text-sm text-red-500">{{ fieldErrors.returnPolicyId }}</p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-12 gap-4">
+          <div class="md:col-span-4 col-span-12">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+              {{ t('integrations.labels.merchantLocation') }}
+            </Label>
+            <Selector
+              v-model="formData.merchantLocationKey"
+              :options="formData.merchantLocationChoices || []"
+              label-by="label"
+              value-by="value"
+              :placeholder="t('shared.components.molecules.selector.defaultPlaceholder')"
+            />
+            <p v-if="fieldErrors.merchantLocationKey" class="mt-1 text-sm text-red-500">{{ fieldErrors.merchantLocationKey }}</p>
+          </div>
+
+          <div class="md:col-span-4 col-span-12">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+              {{ t('integrations.labels.lengthUnit') }}
+            </Label>
+            <Selector
+              v-model="formData.lengthUnit"
+              :options="lengthUnitOptions"
+              label-by="label"
+              value-by="value"
+              :placeholder="t('shared.components.molecules.selector.defaultPlaceholder')"
+            />
+            <p v-if="fieldErrors.lengthUnit" class="mt-1 text-sm text-red-500">{{ fieldErrors.lengthUnit }}</p>
+          </div>
+
+          <div class="md:col-span-4 col-span-12">
+            <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-1">
+              {{ t('integrations.labels.weightUnit') }}
+            </Label>
+            <Selector
+              v-model="formData.weightUnit"
+              :options="weightUnitOptions"
+              label-by="label"
+              value-by="value"
+              :placeholder="t('shared.components.molecules.selector.defaultPlaceholder')"
+            />
+            <p v-if="fieldErrors.weightUnit" class="mt-1 text-sm text-red-500">{{ fieldErrors.weightUnit }}</p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-12 gap-4">
+          <div class="md:col-span-4 col-span-12">
+            <Flex class="mt-8" gap="2">
+              <FlexCell>
+                <Label class="font-semibold text-sm text-gray-900 mb-1">
+                  {{ t('integrations.labels.isDefaultMarketplace') }}
+                </Label>
+              </FlexCell>
+              <FlexCell>
+                <Toggle v-model="formData.isDefault" />
+              </FlexCell>
+            </Flex>
+            <p v-if="fieldErrors.isDefault" class="mt-1 text-sm text-red-500">{{ fieldErrors.isDefault }}</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex items-center justify-end gap-x-3 border-t border-gray-900/10 px-4 py-4 sm:px-8">
+        <RouterLink :to="storesRoute">
+          <CancelButton>
+            {{ t('shared.button.back') }}
+          </CancelButton>
+        </RouterLink>
+
+        <SecondaryButton
+          ref="submitContinueButtonRef"
+          :disabled="isSavingAndContinue"
+          @click="handleSaveAndContinue"
+        >
+          {{ t('shared.button.saveAndContinue') }}
+        </SecondaryButton>
+
+        <PrimaryButton
+          ref="submitButtonRef"
+          :disabled="isSaving"
+          @click="handleSave"
+        >
+          {{ t('shared.button.save') }}
+        </PrimaryButton>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/stores/containers/IntegrationsStoreEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/stores/containers/IntegrationsStoreEditController.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
 import { useRoute } from "vue-router";
 import {Breadcrumbs} from "../../../../../../../shared/components/molecules/breadcrumbs";
 import {storeEditFormConfigConstructor} from "../configs";
 import {GeneralForm} from "../../../../../../../shared/components/organisms/general-form";
+import { IntegrationTypes } from "../../../../integrations";
+import EbayStoreEditView from "./EbayStoreEditView.vue";
 
 const route = useRoute();
 
@@ -14,8 +16,8 @@ const id = ref(String(route.params.id));
 const type = ref(String(route.params.type));
 const integrationId = route.query.integrationId ? route.query.integrationId.toString() : '';
 
-
-const formConfig = storeEditFormConfigConstructor(t, type.value, id.value, integrationId);
+const formConfig = computed(() => storeEditFormConfigConstructor(t, type.value, id.value, integrationId));
+const isEbayIntegration = computed(() => type.value === IntegrationTypes.Ebay);
 </script>
 
 <template>
@@ -28,7 +30,13 @@ const formConfig = storeEditFormConfigConstructor(t, type.value, id.value, integ
       ]" />
     </template>
     <template v-slot:content>
-      <GeneralForm :config="formConfig" />
+      <EbayStoreEditView
+        v-if="isEbayIntegration"
+        :store-id="id"
+        :integration-id="integrationId"
+        :integration-type="type"
+      />
+      <GeneralForm v-else :config="formConfig" />
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/integrations/integrations/integrations.ts
+++ b/src/core/integrations/integrations/integrations.ts
@@ -163,6 +163,14 @@ export function getAmazonDefaultFields(): AmazonChannelInfo {
   };
 }
 
+export function getEbayDefaultFields(): EbayChannelInfo {
+  return {
+    region: null,
+    country: null,
+    listingOwner: false,
+  };
+}
+
 export function getWebhookDefaultFields(): WebhookChannelInfo {
   return {
     topic: '',

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -161,6 +161,15 @@
       "amazon": "Amazon",
       "webhook": "Webhook"
     },
+    "labels": {
+      "fulfillmentPolicy": "Versandrichtlinie",
+      "paymentPolicy": "Zahlungsrichtlinie",
+      "returnPolicy": "Rückgaberichtlinie",
+      "merchantLocation": "Lagerort",
+      "lengthUnit": "Längeneinheit",
+      "weightUnit": "Gewichtseinheit",
+      "isDefaultMarketplace": "Standardmarktplatz"
+    },
     "show": {
       "tabs": {
         "reports": "Berichte"
@@ -177,6 +186,20 @@
           "NAME_TOO_LONG": "Name too long",
           "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
+      }
+    },
+    "ebay": {
+      "lengthUnits": {
+        "centimeter": "Zentimeter",
+        "meter": "Meter",
+        "inch": "Zoll",
+        "foot": "Fuß"
+      },
+      "weightUnits": {
+        "gram": "Gramm",
+        "kilogram": "Kilogramm",
+        "ounce": "Unze",
+        "pound": "Pfund"
       }
     }
   },

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2657,6 +2657,13 @@
       "accessToken": "Access Token",
       "region": "Region",
       "country": "Country",
+      "fulfillmentPolicy": "Fulfillment policy",
+      "paymentPolicy": "Payment policy",
+      "returnPolicy": "Return policy",
+      "merchantLocation": "Inventory location",
+      "lengthUnit": "Length unit",
+      "weightUnit": "Weight unit",
+      "isDefaultMarketplace": "Default marketplace",
       "expirationDate": "Access Token Expiration",
       "pullData": "Pull Data",
       "defaultUnits": "Default Units",
@@ -2714,6 +2721,20 @@
       "singapore": "Singapore",
       "australia": "Australia",
       "japan": "Japan"
+    },
+    "ebay": {
+      "lengthUnits": {
+        "centimeter": "Centimeter",
+        "meter": "Meter",
+        "inch": "Inch",
+        "foot": "Foot"
+      },
+      "weightUnits": {
+        "gram": "Gram",
+        "kilogram": "Kilogram",
+        "ounce": "Ounce",
+        "pound": "Pound"
+      }
     },
     "amazon": {
       "installed": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -156,6 +156,15 @@
       "amazon": "Amazon",
       "webhook": "Webhook"
     },
+    "labels": {
+      "fulfillmentPolicy": "Politique d'expédition",
+      "paymentPolicy": "Politique de paiement",
+      "returnPolicy": "Politique de retour",
+      "merchantLocation": "Lieu d'inventaire",
+      "lengthUnit": "Unité de longueur",
+      "weightUnit": "Unité de poids",
+      "isDefaultMarketplace": "Marketplace par défaut"
+    },
     "show": {
       "tabs": {
         "reports": "Rapports"
@@ -173,7 +182,21 @@
           "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
       }
-    }
+    },
+    "ebay": {
+        "lengthUnits": {
+          "centimeter": "Centimètre",
+          "meter": "Mètre",
+          "inch": "Pouce",
+          "foot": "Pied"
+        },
+        "weightUnits": {
+          "gram": "Gramme",
+          "kilogram": "Kilogramme",
+          "ounce": "Once",
+          "pound": "Livre"
+        }
+      }
   },
   "webhooks": {
     "monitor": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1986,10 +1986,33 @@
       "amazon": "Amazon",
       "webhook": "Webhook"
     },
+    "labels": {
+      "fulfillmentPolicy": "Verzendbeleid",
+      "paymentPolicy": "Betaalbeleid",
+      "returnPolicy": "Retourbeleid",
+      "merchantLocation": "Voorraadlocatie",
+      "lengthUnit": "Lengte-eenheid",
+      "weightUnit": "Gewichtseenheid",
+      "isDefaultMarketplace": "Standaardmarktplaats"
+    },
     "salesChannel": {
       "labels": {
         "assignedToSalesChannelView": "Toegewezen aan winkel",
         "notAssignedToSalesChannelView": "Niet toegewezen aan winkel"
+      }
+    },
+    "ebay": {
+      "lengthUnits": {
+        "centimeter": "Centimeter",
+        "meter": "Meter",
+        "inch": "Inch",
+        "foot": "Voet"
+      },
+      "weightUnits": {
+        "gram": "Gram",
+        "kilogram": "Kilogram",
+        "ounce": "Ons",
+        "pound": "Pond"
       }
     }
   },

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -318,6 +318,29 @@ export const updateAmazonSalesChannelViewMutation = gql`
   }
 `;
 
+export const updateEbaySalesChannelViewMutation = gql`
+  mutation updateEbaySalesChannelView($data: EbaySalesChannelViewPartialInput!) {
+    updateEbaySalesChannelView(data: $data) {
+      id
+      name
+      url
+      fulfillmentPolicyId
+      fulfillmentPolicyChoices
+      paymentPolicyId
+      paymentPolicyChoices
+      returnPolicyId
+      returnPolicyChoices
+      merchantLocationKey
+      merchantLocationChoices
+      lengthUnit
+      lengthUnitChoices
+      weightUnit
+      weightUnitChoices
+      isDefault
+    }
+  }
+`;
+
 export const updateRemoteLanguageMutation = gql`
   mutation updateRemoteLanguage($data: RemoteLanguagePartialInput!) {
     updateRemoteLanguage(data: $data) {

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -296,6 +296,19 @@ export const getEbayChannelQuery = gql`
       syncEanCodes
       syncPrices
       importOrders
+      fulfillmentPolicyId
+      fulfillmentPolicyChoices
+      paymentPolicyId
+      paymentPolicyChoices
+      returnPolicyId
+      returnPolicyChoices
+      merchantLocationKey
+      merchantLocationChoices
+      lengthUnit
+      lengthUnitChoices
+      weightUnit
+      weightUnitChoices
+      isDefault
       firstImportComplete
       isImporting
       accessToken
@@ -667,6 +680,29 @@ export const getAmazonChannelViewQuery = gql`
         id
         hostname
       }
+    }
+  }
+`;
+
+export const getEbaySalesChannelViewQuery = gql`
+  query getEbaySalesChannelView($id: GlobalID!) {
+    ebaySalesChannelView(id: $id) {
+      id
+      name
+      url
+      fulfillmentPolicyId
+      fulfillmentPolicyChoices
+      paymentPolicyId
+      paymentPolicyChoices
+      returnPolicyId
+      returnPolicyChoices
+      merchantLocationKey
+      merchantLocationChoices
+      lengthUnit
+      lengthUnitChoices
+      weightUnit
+      weightUnitChoices
+      isDefault
     }
   }
 `;


### PR DESCRIPTION
## Summary
- revert the changes to the eBay integration general tab so it continues editing the sales channel data instead of store metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc4b60eb90832eafba2035c92b35b6

## Summary by Sourcery

Reinstate the eBay integration general tab to edit sales channel data by reintroducing eBay-specific GraphQL operations and a dedicated edit view.

New Features:
- Add GraphQL query and mutation for eBay sales channel view and updates
- Implement EbayStoreEditView component for editing eBay channel settings
- Show the eBay general tab in the store edit controller based on integration type
- Add default eBay channel field definitions in integration defaults