### PR TITLE
Add eBay store view support and static unit options

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/stores/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/stores/configs.ts
@@ -4,10 +4,13 @@ import {
   salesChannelViewsQuery,
   amazonChannelViewsQuery,
   getAmazonChannelViewQuery,
+  ebayChannelViewsQuery,
+  getEbaySalesChannelViewQuery,
 } from "../../../../../../shared/api/queries/salesChannels.js";
 import {
   updateSalesChannelViewMutation,
   updateAmazonSalesChannelViewMutation,
+  updateEbaySalesChannelViewMutation,
 } from "../../../../../../shared/api/mutations/salesChannels.js";
 import { IntegrationTypes } from "../../../integrations";
 import { ListingConfig } from "../../../../../../shared/components/organisms/general-listing/listingConfig";
@@ -23,11 +26,31 @@ export const storeEditFormConfigConstructor = (
 ): FormConfig => ({
   cols: 1,
   type: FormType.EDIT,
-  mutation: type === IntegrationTypes.Amazon ? updateAmazonSalesChannelViewMutation : updateSalesChannelViewMutation,
-  mutationKey: type === IntegrationTypes.Amazon ? 'updateAmazonSalesChannelView' : 'updateSalesChannelView',
-  query: type === IntegrationTypes.Amazon ? getAmazonChannelViewQuery : getSalesChannelViewQuery,
+  mutation:
+    type === IntegrationTypes.Amazon
+      ? updateAmazonSalesChannelViewMutation
+      : type === IntegrationTypes.Ebay
+        ? updateEbaySalesChannelViewMutation
+        : updateSalesChannelViewMutation,
+  mutationKey:
+    type === IntegrationTypes.Amazon
+      ? 'updateAmazonSalesChannelView'
+      : type === IntegrationTypes.Ebay
+        ? 'updateEbaySalesChannelView'
+        : 'updateSalesChannelView',
+  query:
+    type === IntegrationTypes.Amazon
+      ? getAmazonChannelViewQuery
+      : type === IntegrationTypes.Ebay
+        ? getEbaySalesChannelViewQuery
+        : getSalesChannelViewQuery,
   queryVariables: { id: storeId },
-  queryDataKey: type === IntegrationTypes.Amazon ? 'amazonChannelView' : 'salesChannelView',
+  queryDataKey:
+    type === IntegrationTypes.Amazon
+      ? 'amazonChannelView'
+      : type === IntegrationTypes.Ebay
+        ? 'ebaySalesChannelView'
+        : 'salesChannelView',
   submitUrl: { name: 'integrations.integrations.show', params: { type: type, id: integrationId }, query: { tab: 'stores' } },
   fields: (() => {
     const baseFields: FormField[] = [
@@ -51,7 +74,7 @@ export const storeEditFormConfigConstructor = (
       },
     ];
 
-    if (type === IntegrationTypes.Amazon) {
+    if (type === IntegrationTypes.Amazon || type === IntegrationTypes.Ebay) {
       baseFields.push({
         type: FieldType.Checkbox,
         name: 'isDefault',
@@ -91,7 +114,7 @@ export const storesListingConfigConstructor = (t: Function, specificIntegrationI
     { name: 'active', type: FieldType.Boolean },
   ];
 
-  if (type === IntegrationTypes.Amazon) {
+  if (type === IntegrationTypes.Amazon || type === IntegrationTypes.Ebay) {
     headers.push(t('integrations.show.stores.labels.isDefault'));
     fields.push({ name: 'isDefault', type: FieldType.Boolean });
   }
@@ -113,8 +136,22 @@ export const storesListingConfigConstructor = (t: Function, specificIntegrationI
   };
 };
 
-export const listingQueryConstructor = (type: string) =>
-  type === IntegrationTypes.Amazon ? amazonChannelViewsQuery : salesChannelViewsQuery;
+export const listingQueryConstructor = (type: string) => {
+  if (type === IntegrationTypes.Amazon) {
+    return amazonChannelViewsQuery;
+  }
+  if (type === IntegrationTypes.Ebay) {
+    return ebayChannelViewsQuery;
+  }
+  return salesChannelViewsQuery;
+};
 
-export const listingQueryKeyConstructor = (type: string) =>
-  type === IntegrationTypes.Amazon ? 'amazonChannelViews' : 'salesChannelViews';
+export const listingQueryKeyConstructor = (type: string) => {
+  if (type === IntegrationTypes.Amazon) {
+    return 'amazonChannelViews';
+  }
+  if (type === IntegrationTypes.Ebay) {
+    return 'ebaySalesChannelViews';
+  }
+  return 'salesChannelViews';
+};

--- a/src/core/integrations/integrations/integrations-show/containers/stores/containers/EbayStoreEditView.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/stores/containers/EbayStoreEditView.vue
@@ -35,9 +35,7 @@ interface EbayStoreForm {
   merchantLocationKey: string | null;
   merchantLocationChoices?: EbayChoiceOption[];
   lengthUnit: string | null;
-  lengthUnitChoices?: EbayChoiceOption[];
   weightUnit: string | null;
-  weightUnitChoices?: EbayChoiceOption[];
   isDefault: boolean;
 }
 
@@ -77,9 +75,7 @@ const withDefaults = (data: any): EbayStoreForm => ({
   merchantLocationKey: data.merchantLocationKey ?? null,
   merchantLocationChoices: data.merchantLocationChoices ?? [],
   lengthUnit: data.lengthUnit ?? null,
-  lengthUnitChoices: data.lengthUnitChoices ?? [],
   weightUnit: data.weightUnit ?? null,
-  weightUnitChoices: data.weightUnitChoices ?? [],
   isDefault: data.isDefault ?? false,
 });
 
@@ -87,7 +83,7 @@ const defaultLengthUnitOptions = computed<EbayChoiceOption[]>(() => [
   { value: 'CENTIMETER', label: t('integrations.ebay.lengthUnits.centimeter') },
   { value: 'METER', label: t('integrations.ebay.lengthUnits.meter') },
   { value: 'INCH', label: t('integrations.ebay.lengthUnits.inch') },
-  { value: 'FOOT', label: t('integrations.ebay.lengthUnits.foot') },
+  { value: 'FEET', label: t('integrations.ebay.lengthUnits.foot') },
 ]);
 
 const defaultWeightUnitOptions = computed<EbayChoiceOption[]>(() => [
@@ -97,15 +93,9 @@ const defaultWeightUnitOptions = computed<EbayChoiceOption[]>(() => [
   { value: 'POUND', label: t('integrations.ebay.weightUnits.pound') },
 ]);
 
-const lengthUnitOptions = computed(() => {
-  const choices = formData.value?.lengthUnitChoices ?? [];
-  return choices.length ? choices : defaultLengthUnitOptions.value;
-});
+const lengthUnitOptions = defaultLengthUnitOptions;
 
-const weightUnitOptions = computed(() => {
-  const choices = formData.value?.weightUnitChoices ?? [];
-  return choices.length ? choices : defaultWeightUnitOptions.value;
-});
+const weightUnitOptions = defaultWeightUnitOptions;
 
 const goBack = () => {
   router.push(storesRoute.value);
@@ -163,8 +153,6 @@ const buildPayload = () => {
     paymentPolicyChoices,
     returnPolicyChoices,
     merchantLocationChoices,
-    lengthUnitChoices,
-    weightUnitChoices,
     ...payload
   } = formData.value;
 

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -333,9 +333,7 @@ export const updateEbaySalesChannelViewMutation = gql`
       merchantLocationKey
       merchantLocationChoices
       lengthUnit
-      lengthUnitChoices
       weightUnit
-      weightUnitChoices
       isDefault
     }
   }

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -655,6 +655,33 @@ export const amazonChannelViewsQuery = gql`
   }
 `;
 
+export const ebayChannelViewsQuery = gql`
+  query EbayChannelViews($first: Int, $last: Int, $after: String, $before: String, $order: EbaySalesChannelViewOrder, $filter: EbaySalesChannelViewFilter) {
+    ebaySalesChannelViews(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          name
+          active
+          isDefault
+          salesChannel {
+            id
+            hostname
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 export const getAmazonChannelViewQuery = gql`
   query getAmazonChannelView($id: GlobalID!) {
     amazonChannelView(id: $id) {


### PR DESCRIPTION
## Summary
- add eBay-specific queries and mutations to the generic stores configuration
- provide static length and weight unit options for the eBay store editor
- expose the eBay store listing query to show default marketplace status

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc58d55bc0832e9e3491b432f56c0e

## Summary by Sourcery

Extend the store edit and listing configurations to support eBay integrations and simplify the eBay store form by using static unit option lists.

New Features:
- Add eBay-specific queries and mutations to the generic store configuration for editing and listing
- Expose eBay store listing query and key constructors to surface marketplace status and pagination

Enhancements:
- Enable the default-store checkbox and column for eBay alongside Amazon
- Replace dynamic length and weight unit choices with static options in the eBay store editor