### PR TITLE
feat: add reusable remote properties container with ebay support

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/Properties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/Properties.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import { IntegrationTypes } from '../../../integrations';
 import { AmazonProperties } from './containers/amazon-properties';
+import { EbayProperties } from './containers/ebay-properties';
 
 const props = defineProps<{ id: string; salesChannelId: string; type: string }>();
 const emit = defineEmits(['pull-data']);
@@ -10,6 +11,8 @@ const currentComponent = computed(() => {
   switch (props.type) {
     case IntegrationTypes.Amazon:
       return AmazonProperties;
+    case IntegrationTypes.Ebay:
+      return EbayProperties;
     default:
       return null;
   }

--- a/src/core/integrations/integrations/integrations-show/containers/properties/components/RemotePropertiesContainer.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/components/RemotePropertiesContainer.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter, type RouteLocationRaw } from 'vue-router';
+import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
+import { GeneralListing } from "../../../../../../../shared/components/organisms/general-listing";
+import { Button } from "../../../../../../../shared/components/atoms/button";
+import apolloClient from "../../../../../../../../apollo-client";
+import type { ListingConfig } from "../../../../../../../shared/components/organisms/general-listing/listingConfig";
+import type { SearchConfig } from "../../../../../../../shared/components/organisms/general-search/searchConfig";
+
+type RouteBuilderContext = {
+  id: string;
+  integrationId: string;
+  salesChannelId: string;
+};
+
+type BaseFilterBuilderContext = {
+  salesChannelId: string;
+};
+
+const props = defineProps<{
+  id: string;
+  salesChannelId: string;
+  searchConfig: SearchConfig;
+  listingConfig: ListingConfig;
+  listingQuery: any;
+  listingQueryKey: string;
+  fixedFilterVariables?: Record<string, any>;
+  buildBaseFilter?: (context: BaseFilterBuilderContext) => Record<string, any>;
+  buildStartMappingRoute?: (context: RouteBuilderContext) => RouteLocationRaw;
+}>();
+
+const emit = defineEmits(['pull-data']);
+const { t } = useI18n();
+const router = useRouter();
+
+const canStartMapping = ref(false);
+
+const baseFilter = computed(() => {
+  if (props.buildBaseFilter) {
+    return props.buildBaseFilter({ salesChannelId: props.salesChannelId });
+  }
+
+  if (!props.salesChannelId) {
+    return {};
+  }
+
+  return { salesChannel: { id: { exact: props.salesChannelId } } };
+});
+
+const mergedFixedFilterVariables = computed(() => ({
+  ...baseFilter.value,
+  ...(props.fixedFilterVariables || {}),
+}));
+
+const hasStartMapping = computed(() => Boolean(props.buildStartMappingRoute));
+
+const fetchFirstUnmapped = async (): Promise<string | null> => {
+  if (!hasStartMapping.value) {
+    return null;
+  }
+
+  const { data } = await apolloClient.query({
+    query: props.listingQuery,
+    variables: {
+      first: 1,
+      filter: {
+        ...mergedFixedFilterVariables.value,
+        mappedLocally: false,
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+
+  const listingData = data?.[props.listingQueryKey] ?? {};
+  const edges = listingData?.edges || [];
+  canStartMapping.value = edges.length > 0;
+  return edges.length > 0 ? edges[0].node.id : null;
+};
+
+onMounted(() => {
+  if (hasStartMapping.value) {
+    fetchFirstUnmapped();
+  }
+});
+
+watch(
+  () => props.salesChannelId,
+  () => {
+    if (hasStartMapping.value) {
+      fetchFirstUnmapped();
+    }
+  }
+);
+
+watch(
+  () => props.fixedFilterVariables,
+  () => {
+    if (hasStartMapping.value) {
+      fetchFirstUnmapped();
+    }
+  },
+  { deep: true }
+);
+
+const startMapping = async () => {
+  if (!props.buildStartMappingRoute) {
+    return;
+  }
+
+  const id = await fetchFirstUnmapped();
+  if (!id) {
+    return;
+  }
+
+  router.push(
+    props.buildStartMappingRoute({
+      id,
+      integrationId: props.id,
+      salesChannelId: props.salesChannelId,
+    })
+  );
+};
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template v-if="hasStartMapping" #buttons>
+      <Button type="button" class="btn btn-secondary" :disabled="!canStartMapping" @click="startMapping">
+        {{ t('integrations.show.mapping.startMapping') }}
+      </Button>
+    </template>
+
+    <template #content>
+      <GeneralListing
+        :search-config="searchConfig"
+        :config="listingConfig"
+        :query="listingQuery"
+        :query-key="listingQueryKey"
+        :fixed-filter-variables="mergedFixedFilterVariables"
+        @pull-data="emit('pull-data')"
+      />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayProperties.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import RemotePropertiesContainer from "../../components/RemotePropertiesContainer.vue";
-import { amazonPropertiesSearchConfigConstructor, amazonPropertiesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
+import { ebayPropertiesSearchConfigConstructor, ebayPropertiesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const emit = defineEmits(['pull-data']);
 const { t } = useI18n();
 
-const searchConfig = amazonPropertiesSearchConfigConstructor(t);
-const listingConfig = amazonPropertiesListingConfigConstructor(t, props.id);
+const searchConfig = computed(() => ebayPropertiesSearchConfigConstructor(t, props.salesChannelId));
+const listingConfig = ebayPropertiesListingConfigConstructor(t, props.id);
 
 const buildStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: string; integrationId: string; salesChannelId: string }) => ({
-  name: 'integrations.amazonProperties.edit',
-  params: { type: 'amazon', id },
+  name: 'integrations.ebayProperties.edit',
+  params: { type: 'ebay', id },
   query: { integrationId, salesChannelId, wizard: '1' },
 });
 </script>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
@@ -1,0 +1,93 @@
+import { FieldType, getPropertyTypeOptions } from "../../../../../../../../shared/utils/constants";
+import { ebayPropertiesQuery, ebayChannelViewsQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
+import { propertiesQuerySelector } from "../../../../../../../../shared/api/queries/properties.js";
+import { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { SearchConfig } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
+
+export const ebayPropertiesSearchConfigConstructor = (t: Function, salesChannelId: string): SearchConfig => ({
+  search: true,
+  orderKey: "sort",
+  filters: [
+    { type: FieldType.Boolean, name: 'mappedLocally', label: t('integrations.show.mapping.mappedLocally'), strict: true },
+    { type: FieldType.Boolean, name: 'allowsUnmappedValues', label: t('integrations.show.properties.labels.allowsUnmappedValues'), addLookup: true, strict: true },
+    {
+      type: FieldType.Choice,
+      name: 'type',
+      label: t('products.products.labels.type.title'),
+      labelBy: 'name',
+      valueBy: 'code',
+      options: getPropertyTypeOptions(t),
+      addLookup: true,
+    },
+    {
+      type: FieldType.Query,
+      name: 'localInstance',
+      label: t('properties.properties.title'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: propertiesQuerySelector,
+      dataKey: 'properties',
+      filterable: true,
+      isEdge: true,
+      addLookup: true,
+      lookupKeys: ['id'],
+    },
+    {
+      type: FieldType.Query,
+      name: 'marketplace',
+      label: t('integrations.show.propertySelectValues.labels.marketplace'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: ebayChannelViewsQuery,
+      dataKey: 'ebaySalesChannelViews',
+      filterable: true,
+      isEdge: true,
+      addLookup: true,
+      lookupKeys: ['id'],
+      queryVariables: { filters: { salesChannel: { id: { exact: salesChannelId } } } },
+    },
+  ],
+  orders: [],
+});
+
+export const ebayPropertiesListingConfigConstructor = (t: Function, specificIntegrationId): ListingConfig => ({
+  headers: [
+    t('shared.labels.name'),
+    t('integrations.show.properties.labels.code'),
+    t('integrations.show.mapping.mappedLocally'),
+    t('properties.properties.title'),
+    t('integrations.show.propertySelectValues.labels.marketplace'),
+  ],
+  fields: [
+    { name: 'name', type: FieldType.Text },
+    { name: 'code', type: FieldType.Text },
+    { name: 'mappedLocally', type: FieldType.Boolean },
+    {
+      name: 'localInstance',
+      type: FieldType.NestedText,
+      keys: ['name'],
+      showLabel: true,
+      clickable: true,
+      clickIdentifiers: [{ id: ['id'] }],
+      clickUrl: { name: 'properties.properties.show' },
+    },
+    {
+      name: 'marketplace',
+      type: FieldType.NestedText,
+      keys: ['name'],
+      showLabel: true,
+    },
+  ],
+  identifierKey: 'id',
+  urlQueryParams: { integrationId: specificIntegrationId },
+  addActions: true,
+  addEdit: true,
+  addShow: true,
+  editUrlName: 'integrations.ebayProperties.edit',
+  showUrlName: 'integrations.ebayProperties.edit',
+  addDelete: false,
+  addPagination: true,
+});
+
+export const listingQueryKey = 'ebayProperties';
+export const listingQuery = ebayPropertiesQuery;

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/index.ts
@@ -1,0 +1,1 @@
+export { default as EbayProperties } from './EbayProperties.vue';

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -963,6 +963,55 @@ export const amazonPropertiesQuery = gql`
   }
 `;
 
+// eBay Property Queries
+export const ebayPropertiesQuery = gql`
+  query EbayProperties(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: EbayPropertyOrder
+    $filter: EbayPropertyFilter
+  ) {
+    ebayProperties(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filter
+    ) {
+      edges {
+        node {
+          id
+          mappedLocally
+          mappedRemotely
+          code
+          name
+          type
+          allowsUnmappedValues
+          marketplace {
+            id
+            name
+          }
+          localInstance {
+            id
+            name
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 export const getAmazonPropertyQuery = gql`
   query getAmazonProperty($id: GlobalID!) {
     amazonProperty(id: $id) {


### PR DESCRIPTION
## Summary
- extract a reusable remote properties container for marketplace property listings
- wire Amazon properties into the shared container and add a new eBay properties listing with configs
- extend the sales channel queries with the eBay properties connection

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd19760d9c832eb6021d164a132240

## Summary by Sourcery

Extract shared property listing functionality into a reusable container and add end-to-end eBay property listings support, refactoring AmazonProperties to leverage the new component and updating the properties switcher accordingly.

New Features:
- Add RemotePropertiesContainer component to centralize marketplace property listing logic
- Introduce eBay property listing support with GraphQL query, search/listing configs, and container

Enhancements:
- Refactor AmazonProperties to use the new RemotePropertiesContainer and eliminate duplicated code
- Extend the main Properties component to handle the eBay integration alongside Amazon