### PR TITLE
Move remote properties container and enable eBay properties tab

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -74,6 +74,8 @@ if (type.value !== IntegrationTypes.Webhook) {
       { name: 'propertySelectValues', label: t('properties.values.title'), icon: 'sitemap' },
       { name: 'defaultUnits', label: t('integrations.show.sections.defaultUnits'), icon: 'weight-hanging' }
     );
+  } else if (type.value === IntegrationTypes.Ebay) {
+    tabItems.value.push({ name: 'properties', label: t('properties.title'), icon: 'screwdriver-wrench' });
   }
 
   tabItems.value.push({ name: 'imports', label: t('shared.tabs.imports'), icon: 'file-import' });

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/AmazonProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/AmazonProperties.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import RemotePropertiesContainer from "../../components/RemotePropertiesContainer.vue";
+import RemoteProperties from "../remote-properties/RemoteProperties.vue";
 import { amazonPropertiesSearchConfigConstructor, amazonPropertiesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
@@ -18,7 +18,7 @@ const buildStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: str
 </script>
 
 <template>
-  <RemotePropertiesContainer
+  <RemoteProperties
     :id="id"
     :sales-channel-id="salesChannelId"
     :search-config="searchConfig"

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayProperties.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import RemotePropertiesContainer from "../../components/RemotePropertiesContainer.vue";
+import RemoteProperties from "../remote-properties/RemoteProperties.vue";
 import { ebayPropertiesSearchConfigConstructor, ebayPropertiesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
@@ -19,7 +19,7 @@ const buildStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: str
 </script>
 
 <template>
-  <RemotePropertiesContainer
+  <RemoteProperties
     :id="id"
     :sales-channel-id="salesChannelId"
     :search-config="searchConfig"

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/RemoteProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/RemoteProperties.vue
@@ -2,12 +2,12 @@
 import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter, type RouteLocationRaw } from 'vue-router';
-import GeneralTemplate from "../../../../../../../shared/templates/GeneralTemplate.vue";
-import { GeneralListing } from "../../../../../../../shared/components/organisms/general-listing";
-import { Button } from "../../../../../../../shared/components/atoms/button";
-import apolloClient from "../../../../../../../../apollo-client";
-import type { ListingConfig } from "../../../../../../../shared/components/organisms/general-listing/listingConfig";
-import type { SearchConfig } from "../../../../../../../shared/components/organisms/general-search/searchConfig";
+import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
+import { GeneralListing } from "../../../../../../../../shared/components/organisms/general-listing";
+import { Button } from "../../../../../../../../shared/components/atoms/button";
+import apolloClient from "../../../../../../../../../apollo-client";
+import type { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
+import type { SearchConfig } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
 
 type RouteBuilderContext = {
   id: string;


### PR DESCRIPTION
## Summary
- move the shared remote properties view into a remote-properties container alongside amazon and ebay implementations
- update amazon and ebay properties containers to consume the renamed RemoteProperties component
- expose the properties tab for eBay integrations so the new view is accessible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd1db263e4832ebee0a55cf6fa7b9e

## Summary by Sourcery

Relocate the shared remote properties component into a dedicated container and update Amazon and eBay integrations to use the renamed component while exposing the properties tab for eBay.

New Features:
- Enable properties tab for eBay integrations

Enhancements:
- Move shared remote properties view into a standalone remote-properties container
- Update Amazon and eBay property containers to import and use the relocated RemoteProperties component