### PR TITLE
Show parent SKU in parents tab

### DIFF
--- a/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
+++ b/src/core/products/products/product-show/containers/product-type/product-bundle/ProductBundle.vue
@@ -14,6 +14,7 @@ import MediaView from "../../tabs/media/MediaView.vue";
 import ProductSalePriceView from "../../tabs/sales-price/ProductSalePriceView.vue";
 import PropertiesView from "../../tabs/properties/PropertiesView.vue";
 import WebsitesView from "../../tabs/websites/WebsitesView.vue";
+import ParentsView from "../../tabs/parents/ParentsView.vue";
 import AliasProductsView from "../../tabs/alias-parents/AliasProductsView.vue";
 import AmazonView from "../../tabs/amazon/AmazonView.vue";
 import { injectAuth } from "../../../../../../../shared/modules/auth";
@@ -67,6 +68,14 @@ const tabItems = computed(() => {
     { name: 'properties', label: t('products.products.tabs.properties'), icon: 'screwdriver-wrench' },
   ];
 
+  if (props.product.hasParents) {
+    items.push({
+      name: 'parents',
+      label: t('products.products.tabs.parents'),
+      icon: 'sitemap',
+    });
+  }
+
   if (props.product.aliasProducts?.length > 0) {
     items.push({
       name: 'aliasProducts',
@@ -106,6 +115,9 @@ const tabItems = computed(() => {
       </template>
       <template v-slot:media>
         <MediaView :product="product" />
+      </template>
+      <template v-if="product.hasParents" v-slot:parents>
+        <ParentsView :product="product" />
       </template>
       <template v-slot:properties>
         <PropertiesView ref="propertiesRef" :product="product" />

--- a/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/parents/containers/parents-list/ParentsList.vue
@@ -132,6 +132,7 @@ onMounted(async () => {
         <thead>
           <tr>
             <th class="px-3 py-2 text-left">{{ t('shared.labels.name') }}</th>
+            <th class="px-3 py-2 text-left">{{ t('shared.labels.sku') }}</th>
             <th class="px-3 py-2 text-left">{{ t('shared.labels.type') }}</th>
             <th class="px-3 py-2 text-left">{{ t('shared.labels.active') }}</th>
             <th class="px-3 py-2 text-left">{{ t('products.products.labels.inspectorStatus') }}</th>
@@ -156,6 +157,9 @@ onMounted(async () => {
                   <span :title="parent.name">{{ shortenText(parent.name, 64) }}</span>
                 </div>
               </Link>
+            </td>
+            <td>
+              {{ parent.sku }}
             </td>
             <td>
               <Badge


### PR DESCRIPTION
## Summary
- add a SKU column to the parents list shown for bundle/configurable parents

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd76bc7f60832e89adbc607256ab9e

## Summary by Sourcery

Add a "Parents" tab in the product view for bundle/configurable products and include a SKU column in the parents list

New Features:
- Introduce a "Parents" tab in the product show view when a product has parent relationships

Enhancements:
- Add a SKU column to the parents list in the ParentsView