### PR TITLE
feat: allow copying content when creating alias product

### DIFF
--- a/src/core/products/products/product-create/ProductCreateController.vue
+++ b/src/core/products/products/product-create/ProductCreateController.vue
@@ -51,6 +51,7 @@ const form: FormType = reactive({
   name: '',
   active: true,
   aliasCopyImages: true,
+  aliasCopyContent: true,
   aliasCopyProductProperties: true,
   vatRate: {
     id: null

--- a/src/core/products/products/product-create/containers/alias-options-step/AliasOptionsStep.vue
+++ b/src/core/products/products/product-create/containers/alias-options-step/AliasOptionsStep.vue
@@ -86,6 +86,24 @@ onMounted(() => {
         <Flex class="gap-2">
           <FlexCell>
             <Label class="font-semibold block text-sm leading-6 text-gray-900">
+              {{ t('products.products.create.wizard.stepAlias.labels.copyContent') }}
+            </Label>
+          </FlexCell>
+          <FlexCell>
+            <Toggle v-model="form.aliasCopyContent" />
+          </FlexCell>
+        </Flex>
+        <div class="mt-1 text-sm leading-6 text-gray-400 w-96">
+          <p>{{ t('products.products.create.wizard.stepAlias.helpText.copyContent') }}</p>
+        </div>
+      </FlexCell>
+    </Flex>
+
+    <Flex class="mt-4 gap-4" center>
+      <FlexCell center>
+        <Flex class="gap-2">
+          <FlexCell>
+            <Label class="font-semibold block text-sm leading-6 text-gray-900">
               {{ t('products.products.create.wizard.stepAlias.labels.copyProperties') }}
             </Label>
           </FlexCell>

--- a/src/core/products/products/product-create/containers/product.ts
+++ b/src/core/products/products/product-create/containers/product.ts
@@ -3,6 +3,7 @@ export interface FormType {
   sku: string;
   name: string;
   aliasCopyImages: boolean;
+  aliasCopyContent: boolean;
   aliasCopyProductProperties: boolean;
   vatRate: {
     id: string | null;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1174,10 +1174,12 @@
             "labels": {
               "aliasParent": "Clone from product (alias target)",
               "copyImages": "Copy images from original product",
+              "copyContent": "Copy content from original product",
               "copyProperties": "Copy properties from original product"
             },
             "helpText": {
               "copyImages": "If enabled, all images from the original product will be copied to this alias product.",
+              "copyContent": "If enabled, default content from the original product will be copied to this alias product.",
               "copyProperties": "If enabled, product attributes (e.g. color, material) from the original product will be cloned."
             }
           },


### PR DESCRIPTION
## Summary
- add a toggle to control copying content from the original product when creating an alias
- default the alias copy content option to true and expose the new copyContent translation strings

## Testing
- npm run build *(fails: command hung without completing)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8fb56fa8832e99ec02c5f70f3388

## Summary by Sourcery

New Features:
- Add a toggle in the alias creation step to control copying content from the original product, defaulting to enabled