### PR TITLE
Add Amazon product import action

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/AmazonView.vue
@@ -17,6 +17,7 @@ import { amazonProductsQuery } from '../../../../../../../shared/api/queries/ama
 import {
   resyncAmazonProductMutation,
   refreshAmazonProductIssuesMutation,
+  refreshAmazonProductFromRemoteMutation,
 } from '../../../../../../../shared/api/mutations/amazonProducts.js';
 import { Toast } from '../../../../../../../shared/modules/toast';
 import { displayApolloError } from '../../../../../../../shared/utils';
@@ -250,6 +251,12 @@ const onResyncSuccess = () => {
   fetchViews();
 };
 
+const onImportSuccess = () => {
+  Toast.success(t('integrations.salesChannel.toast.importSuccess'));
+  fetchAmazonProducts('network-only');
+  fetchViews();
+};
+
 const onValidateSuccess = () => {
   Toast.success(t('integrations.salesChannel.toast.validateSuccess'));
   fetchAmazonProducts('network-only');
@@ -303,7 +310,10 @@ const formatDate = (dateString?: string | null) => {
                 :selected-view="selectedView"
                 :resync-amazon-product-mutation="resyncAmazonProductMutation"
                 :refresh-amazon-product-issues-mutation="refreshAmazonProductIssuesMutation"
+                :refresh-amazon-product-from-remote-mutation="refreshAmazonProductFromRemoteMutation"
+                :product-id="props.product.id"
                 @resync-success="onResyncSuccess"
+                @import-success="onImportSuccess"
                 @validate-success="onValidateSuccess"
                 @fetch-issues-success="onFetchIssuesSuccess"
                 @error="onError"

--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonStatusSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonStatusSection.vue
@@ -12,10 +12,13 @@ const props = defineProps<{
   selectedView: any | null;
   resyncAmazonProductMutation: any;
   refreshAmazonProductIssuesMutation: any;
+  refreshAmazonProductFromRemoteMutation: any;
+  productId: string;
 }>();
 
 const emit = defineEmits<{
   (e: 'resync-success'): void;
+  (e: 'import-success'): void;
   (e: 'validate-success'): void;
   (e: 'fetch-issues-success'): void;
   (e: 'error', err: unknown): void;
@@ -50,6 +53,18 @@ const formatDate = (dateString?: string | null) => {
       </FlexCell>
       <FlexCell>
         <div class="flex gap-2 sm:ml-auto">
+        <ApolloMutation
+          :mutation="refreshAmazonProductFromRemoteMutation"
+          :variables="{ product: { id: productId }, view: { id: selectedView?.id } }"
+          @done="() => emit('import-success')"
+          @error="(e) => emit('error', e)"
+        >
+          <template #default="{ mutate, loading }">
+            <Button class="btn btn-sm btn-outline-primary" :disabled="loading" @click.stop="mutate">
+              {{ t('shared.button.import') }}
+            </Button>
+          </template>
+        </ApolloMutation>
         <ApolloMutation
           v-if="remoteProductId"
           :mutation="resyncAmazonProductMutation"

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -10,6 +10,7 @@
       "fullUpdate": "Full Update",
       "validate": "Validate",
       "fetchIssues": "Fetch Issues",
+      "import": "Import",
       "saveAll": "Alles speichern"
     },
     "colors": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -357,6 +357,7 @@
       "fullUpdate": "Full Update",
       "validate": "Validate",
       "fetchIssues": "Fetch Issues",
+      "import": "Import",
       "download": "Download",
       "downloadConfirmation": "Download Confirmation",
       "uploadNew": "Upload New",
@@ -2748,6 +2749,7 @@
       },
       "toast": {
         "resyncSuccess": "The product resync process has begun. Please come later to see the results.",
+        "importSuccess": "The product import process has begun. Please come later to see the results.",
         "fetchIssuesSuccess": "Product issues were refreshed from the remote server.",
         "validateSuccess": "The product validation process has begun. Please come later to see the results."
       },

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -10,6 +10,7 @@
       "fullUpdate": "Full Update",
       "validate": "Validate",
       "fetchIssues": "Fetch Issues",
+      "import": "Import",
       "saveAll": "Tout enregistrer"
     },
     "colors": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -187,7 +187,8 @@
       "resync": "Resync",
       "fullUpdate": "Full Update",
       "validate": "Validate",
-      "fetchIssues": "Fetch Issues"
+      "fetchIssues": "Fetch Issues",
+      "import": "Import"
     },
     "colors": {
       "red": "Rood",

--- a/src/shared/api/mutations/amazonProducts.js
+++ b/src/shared/api/mutations/amazonProducts.js
@@ -29,6 +29,17 @@ export const resyncAmazonProductMutation = gql`
   }
 `;
 
+export const refreshAmazonProductFromRemoteMutation = gql`
+  mutation refreshAmazonProductFromRemote(
+    $product: ProductPartialInput!
+    $view: AmazonSalesChannelViewPartialInput!
+  ) {
+    refreshAmazonProductFromRemote(product: $product, view: $view) {
+      id
+    }
+  }
+`;
+
 export const createAmazonProductBrowseNodeMutation = gql`
   mutation createAmazonProductBrowseNode($data: AmazonProductBrowseNodeInput!) {
     createAmazonProductBrowseNode(data: $data) {


### PR DESCRIPTION
## Summary
- add GraphQL mutation wrapper for the new refreshAmazonProductFromRemote backend mutation
- expose an Import button on the Amazon status section that triggers the new mutation and refreshes data
- extend translations with the new Import label and toast message

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cda9530c7c832eb75c53e31853d972

## Summary by Sourcery

Add an Import action for Amazon products to fetch and refresh remote data via a new GraphQL mutation, integrate it into the UI with a corresponding button and success handling, and include translation strings for the new functionality

New Features:
- Introduce refreshAmazonProductFromRemote GraphQL mutation to pull product data from the remote source
- Expose an Import button in the Amazon status section to trigger the remote import mutation
- Display a success toast and refetch products and views upon successful import

Documentation:
- Add translation entries for the Import button label and import success toast message in all supported locales