### PR TITLE
Enhance matrix editor selection and copy rules

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -98,6 +98,7 @@ const columns = computed<MatrixColumn[]>(() => [
     requireType: p.requireType,
     editable: true,
     iconColorClass: getIconColor(p.requireType),
+    valueType: p.type,
   })),
 ])
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -965,6 +965,7 @@
         "copied": "Copied",
         "pasted": "Pasted",
         "pasteDifferentColumn": "Cannot paste to different column",
+        "pasteIncompatibleColumn": "Cannot paste into column with incompatible type",
         "undo": "Undid last change",
         "redo": "Redid last change",
         "createdProductProperties": "Created {count} product properties.",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -653,6 +653,7 @@
           "copied": "Gekopieerd",
           "pasted": "Geplakt",
           "pasteDifferentColumn": "Kan niet plakken naar een andere kolom",
+          "pasteIncompatibleColumn": "Kan niet plakken in kolom met incompatibel type",
           "undo": "Laatste wijziging ongedaan gemaakt",
           "redo": "Laatste wijziging opnieuw toegepast",
           "createdProductProperties": "{count} producteigenschappen aangemaakt.",

--- a/src/shared/components/organisms/matrix-editor/types.ts
+++ b/src/shared/components/organisms/matrix-editor/types.ts
@@ -6,6 +6,7 @@ export interface MatrixColumn {
   editable?: boolean
   iconColorClass?: string
   initialWidth?: number
+  valueType?: string
 }
 
 export interface MatrixEditorExpose {


### PR DESCRIPTION
## Summary
- enable multi-column selection in the matrix editor and update drag-fill handling to clone values for the full selection
- adjust copy and paste validation to allow compatible property type conversions and improve shortcut support, including macOS command key combinations
- extend matrix column metadata with value types and add an error toast for incompatible paste attempts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d057043aac832e978b85019f700b7e

## Summary by Sourcery

Enhance the matrix editor to support multi-column selection and drag-fill across multiple columns, improve copy/paste to handle property type compatibility with conversions, add macOS command key shortcuts, and extend column metadata with valueType for validation.

New Features:
- Enable multi-column cell selection in the matrix editor with shift-click
- Allow drag-fill to clone values across all selected columns and rows
- Support type-aware copy/paste with automatic conversions and error handling
- Add macOS command key support for copy and paste shortcuts
- Extend matrix column metadata with valueType for paste compatibility checks

Enhancements:
- Refine keyboard navigation to preserve multi-cell selection on arrow moves
- Update cell and drag handle highlighting to reflect multi-column selection state