### PR TITLE
feat: add variation price bulk edit tab

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
@@ -7,6 +7,7 @@ import type { MatrixColumn, MatrixEditorExpose } from "../../../../../../../../.
 import { TextInput } from "../../../../../../../../../shared/components/atoms/input-text";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
+import { processGraphQLErrors } from "../../../../../../../../../shared/utils";
 import apolloClient from "../../../../../../../../../../apollo-client";
 import { currenciesQuery } from "../../../../../../../../../shared/api/queries/currencies.js";
 import { bundleVariationsWithPricesQuery, configurableVariationsWithPricesQuery } from "../../../../../../../../../shared/api/queries/products.js";
@@ -374,7 +375,13 @@ const save = async () => {
     }
   } catch (error) {
     console.error('Failed to save variation prices', error);
-    Toast.error(t('shared.messages.somethingWentWrong'));
+    const validationErrors = processGraphQLErrors(error, t);
+    const messages = Object.values(validationErrors).filter(Boolean);
+    if (messages.length) {
+      Toast.error(messages.join('<br>'));
+    } else {
+      Toast.error(t('shared.messages.somethingWentWrong'));
+    }
   } finally {
     saving.value = false;
   }

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
@@ -1,0 +1,507 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { gql } from 'graphql-tag';
+import type { FetchPolicy } from '@apollo/client';
+import MatrixEditor from "../../../../../../../../../shared/components/organisms/matrix-editor/MatrixEditor.vue";
+import type { MatrixColumn, MatrixEditorExpose } from "../../../../../../../../../shared/components/organisms/matrix-editor/types";
+import { TextInput } from "../../../../../../../../../shared/components/atoms/input-text";
+import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
+import { Toast } from "../../../../../../../../../shared/modules/toast";
+import apolloClient from "../../../../../../../../../../apollo-client";
+import { currenciesQuery } from "../../../../../../../../../shared/api/queries/currencies.js";
+import { createSalesPricesMutation, updateSalesPriceMutation } from "../../../../../../../../../shared/api/mutations/salesPrices.js";
+import { Product } from "../../../../configs";
+import { ProductType } from "../../../../../../../../../shared/utils/constants";
+
+interface CurrencyInfo {
+  id: string;
+  isoCode: string;
+  name: string;
+  symbol: string;
+  readonly: boolean;
+}
+
+interface VariationPriceInfo {
+  id: string | null;
+  price: string;
+  rrp: string;
+  currencyId: string;
+  readonly: boolean;
+}
+
+interface VariationRow {
+  id: string;
+  variation: {
+    id: string;
+    sku: string;
+    name: string;
+    active: boolean;
+  };
+  prices: Record<string, VariationPriceInfo>;
+}
+
+const PRICE_COLUMN_SEPARATOR = '__';
+
+type PriceField = 'price' | 'rrp';
+
+type ParsedPriceColumn = {
+  isoCode: string;
+  field: PriceField;
+};
+
+const props = defineProps<{ product: Product }>();
+
+const { t } = useI18n();
+
+const currencies = ref<CurrencyInfo[]>([]);
+const variations = ref<VariationRow[]>([]);
+const originalVariations = ref<VariationRow[]>([]);
+const loading = ref(false);
+const saving = ref(false);
+const matrixRef = ref<MatrixEditorExpose | null>(null);
+
+const isAlias = computed(() => props.product.type === ProductType.Alias);
+const parentProduct = computed(() => (isAlias.value ? props.product.aliasParentProduct : props.product));
+const parentProductType = computed(() => parentProduct.value.type);
+
+const baseColumns = computed<MatrixColumn[]>(() => [
+  { key: 'sku', label: t('shared.labels.sku'), sticky: true, editable: false },
+  { key: 'name', label: t('shared.labels.name'), editable: false },
+  { key: 'active', label: t('shared.labels.active'), editable: false, initialWidth: 60 },
+]);
+
+const priceColumns = computed<MatrixColumn[]>(() =>
+  currencies.value.flatMap((currency) => {
+    const labelCurrency = currency.name || currency.isoCode;
+    return [
+      {
+        key: `${currency.isoCode}${PRICE_COLUMN_SEPARATOR}rrp`,
+        label: t('products.products.variations.prices.columns.rrp', { currency: labelCurrency }),
+        editable: !currency.readonly,
+        valueType: 'float',
+      },
+      {
+        key: `${currency.isoCode}${PRICE_COLUMN_SEPARATOR}price`,
+        label: t('products.products.variations.prices.columns.price', { currency: labelCurrency }),
+        editable: !currency.readonly,
+        valueType: 'float',
+      },
+    ];
+  })
+);
+
+const columns = computed<MatrixColumn[]>(() => [...baseColumns.value, ...priceColumns.value]);
+
+const hasChanges = computed(
+  () => JSON.stringify(variations.value) !== JSON.stringify(originalVariations.value)
+);
+
+const hasUnsavedChanges = hasChanges;
+
+const configurableVariationsWithPricesQuery = gql`
+  query ConfigurableVariationsWithPrices($first: Int, $after: String, $filter: ConfigurableVariationFilter) {
+    configurableVariations(first: $first, after: $after, filters: $filter) {
+      edges {
+        node {
+          id
+          variation {
+            id
+            sku
+            name
+            active
+            salespriceSet {
+              id
+              price
+              rrp
+              currency {
+                id
+                isoCode
+              }
+            }
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+const bundleVariationsWithPricesQuery = gql`
+  query BundleVariationsWithPrices($first: Int, $after: String, $filter: BundleVariationFilter) {
+    bundleVariations(first: $first, after: $after, filters: $filter) {
+      edges {
+        node {
+          id
+          variation {
+            id
+            sku
+            name
+            active
+            salespriceSet {
+              id
+              price
+              rrp
+              currency {
+                id
+                isoCode
+              }
+            }
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+const parsePriceColumnKey = (key: string): ParsedPriceColumn | null => {
+  const [isoCode, field] = key.split(PRICE_COLUMN_SEPARATOR);
+  if (!isoCode || (field !== 'price' && field !== 'rrp')) {
+    return null;
+  }
+  return { isoCode, field: field as PriceField };
+};
+
+const isPriceColumn = (key: string) => Boolean(parsePriceColumnKey(key));
+
+const isColumnEditable = (key: string) => {
+  const parsed = parsePriceColumnKey(key);
+  if (!parsed) {
+    return false;
+  }
+  const currency = currencies.value.find((item) => item.isoCode === parsed.isoCode);
+  return currency ? !currency.readonly : false;
+};
+
+const ensurePriceEntry = (row: VariationRow, isoCode: string) => {
+  if (!row.prices[isoCode]) {
+    const currency = currencies.value.find((item) => item.isoCode === isoCode);
+    if (!currency) {
+      return null;
+    }
+    row.prices[isoCode] = {
+      id: null,
+      price: '',
+      rrp: '',
+      currencyId: currency.id,
+      readonly: currency.readonly,
+    };
+  }
+  return row.prices[isoCode];
+};
+
+const getMatrixCellValue = (rowIndex: number, columnKey: string) => {
+  const row = variations.value[rowIndex];
+  if (!row) return '';
+  if (columnKey === 'sku') {
+    return row.variation.sku;
+  }
+  if (columnKey === 'name') {
+    return row.variation.name;
+  }
+  if (columnKey === 'active') {
+    return row.variation.active ? t('shared.labels.yes') : t('shared.labels.no');
+  }
+  const parsed = parsePriceColumnKey(columnKey);
+  if (!parsed) return '';
+  const priceInfo = row.prices[parsed.isoCode];
+  if (!priceInfo) return '';
+  return priceInfo[parsed.field] ?? '';
+};
+
+const setPriceValue = (rowIndex: number, columnKey: string, rawValue: any) => {
+  if (!isColumnEditable(columnKey)) return;
+  const parsed = parsePriceColumnKey(columnKey);
+  if (!parsed) return;
+  const row = variations.value[rowIndex];
+  if (!row) return;
+  const entry = ensurePriceEntry(row, parsed.isoCode);
+  if (!entry) return;
+  const value = rawValue === null || rawValue === undefined ? '' : String(rawValue);
+  entry[parsed.field] = value;
+};
+
+const updatePriceFromInput = (rowIndex: number, columnKey: string, value: string | number | null) => {
+  setPriceValue(rowIndex, columnKey, value);
+};
+
+const setMatrixCellValue = (rowIndex: number, columnKey: string, value: any) => {
+  setPriceValue(rowIndex, columnKey, value);
+};
+
+const cloneMatrixCellValue = (fromRow: number, toRow: number, columnKey: string) => {
+  if (!isColumnEditable(columnKey)) return;
+  const value = getMatrixCellValue(fromRow, columnKey);
+  setPriceValue(toRow, columnKey, value);
+};
+
+const clearMatrixCellValue = (rowIndex: number, columnKey: string) => {
+  setPriceValue(rowIndex, columnKey, '');
+};
+
+const loadCurrencies = async (policy: FetchPolicy = 'cache-first') => {
+  const { data } = await apolloClient.query({
+    query: currenciesQuery,
+    variables: { first: 100 },
+    fetchPolicy: policy,
+  });
+  const edges = data?.currencies?.edges ?? [];
+  currencies.value = edges.map((edge: any) => {
+    const node = edge.node;
+    return {
+      id: node.id,
+      isoCode: node.isoCode,
+      name: node.name,
+      symbol: node.symbol,
+      readonly: !node.isDefaultCurrency && !!node.inheritsFrom,
+    };
+  });
+};
+
+const fetchVariations = async (policy: FetchPolicy = 'cache-first') => {
+  const isBundle = parentProductType.value === ProductType.Bundle;
+  const query = isBundle ? bundleVariationsWithPricesQuery : configurableVariationsWithPricesQuery;
+  const key = isBundle ? 'bundleVariations' : 'configurableVariations';
+  const pageSize = 100;
+  let after: string | null = null;
+  const nodes: any[] = [];
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const { data } = await apolloClient.query({
+      query,
+      variables: {
+        first: pageSize,
+        after,
+        filter: { parent: { id: { exact: parentProduct.value.id } } },
+      },
+      fetchPolicy: policy,
+    });
+    const connection = data?.[key];
+    if (!connection) break;
+    const edges = connection.edges ?? [];
+    edges.forEach((edge: any) => nodes.push(edge.node));
+    hasNextPage = connection.pageInfo?.hasNextPage ?? false;
+    after = connection.pageInfo?.endCursor ?? null;
+    if (!after) break;
+  }
+
+  variations.value = nodes.map((node: any) => {
+    const variationProduct = node.variation;
+    const priceMap: Record<string, VariationPriceInfo> = {};
+    currencies.value.forEach((currency) => {
+      const priceEntry = (variationProduct.salespriceSet ?? []).find(
+        (price: any) => price.currency?.isoCode === currency.isoCode
+      );
+      priceMap[currency.isoCode] = {
+        id: priceEntry?.id ?? null,
+        price: priceEntry?.price != null ? String(priceEntry.price) : '',
+        rrp: priceEntry?.rrp != null ? String(priceEntry.rrp) : '',
+        currencyId: currency.id,
+        readonly: currency.readonly,
+      };
+    });
+    return {
+      id: variationProduct.id,
+      variation: {
+        id: variationProduct.id,
+        sku: variationProduct.sku,
+        name: variationProduct.name,
+        active: variationProduct.active,
+      },
+      prices: priceMap,
+    };
+  });
+  originalVariations.value = JSON.parse(JSON.stringify(variations.value));
+  matrixRef.value?.resetHistory(variations.value);
+};
+
+const loadData = async (policy: FetchPolicy = 'cache-first') => {
+  loading.value = true;
+  try {
+    if (!currencies.value.length || policy === 'network-only') {
+      await loadCurrencies(policy);
+    }
+    await fetchVariations(policy);
+  } finally {
+    loading.value = false;
+  }
+};
+
+const parsePriceValue = (value: string) => {
+  if (value === '' || value === null || value === undefined) {
+    return null;
+  }
+  const parsed = parseFloat(value);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+  return parsed;
+};
+
+const save = async () => {
+  if (!hasChanges.value) return;
+  saving.value = true;
+  try {
+    const originalMap = new Map<string, VariationRow>();
+    originalVariations.value.forEach((item) => {
+      originalMap.set(item.variation.id, item);
+    });
+
+    const toCreate: any[] = [];
+    const toUpdate: any[] = [];
+
+    variations.value.forEach((row) => {
+      const original = originalMap.get(row.variation.id);
+      currencies.value.forEach((currency) => {
+        const current = row.prices[currency.isoCode];
+        const previous = original?.prices?.[currency.isoCode];
+        if (!current || currency.readonly) {
+          return;
+        }
+        const currentPrice = current.price ?? '';
+        const currentRrp = current.rrp ?? '';
+        const previousPrice = previous?.price ?? '';
+        const previousRrp = previous?.rrp ?? '';
+        if (currentPrice === previousPrice && currentRrp === previousRrp) {
+          return;
+        }
+        if (current.id) {
+          const updateData: Record<string, any> = { id: current.id };
+          if (currentPrice !== previousPrice) {
+            updateData.price = parsePriceValue(current.price);
+          }
+          if (currentRrp !== previousRrp) {
+            updateData.rrp = parsePriceValue(current.rrp);
+          }
+          toUpdate.push(updateData);
+        } else {
+          const priceValue = parsePriceValue(current.price);
+          const rrpValue = parsePriceValue(current.rrp);
+          if (priceValue === null && rrpValue === null) {
+            return;
+          }
+          toCreate.push({
+            product: { id: row.variation.id },
+            currency: { id: current.currencyId },
+            price: priceValue,
+            rrp: rrpValue,
+          });
+        }
+      });
+    });
+
+    const createdCount = toCreate.length;
+    const updatedCount = toUpdate.length;
+
+    if (!createdCount && !updatedCount) {
+      saving.value = false;
+      return;
+    }
+
+    if (createdCount) {
+      await apolloClient.mutate({
+        mutation: createSalesPricesMutation,
+        variables: { data: toCreate },
+      });
+    }
+
+    if (updatedCount) {
+      for (const item of toUpdate) {
+        await apolloClient.mutate({
+          mutation: updateSalesPriceMutation,
+          variables: { data: item },
+        });
+      }
+    }
+
+    await loadData('network-only');
+
+    const messages: string[] = [];
+    if (createdCount) {
+      messages.push(t('products.products.variations.prices.toast.created', { count: createdCount }));
+    }
+    if (updatedCount) {
+      messages.push(t('products.products.variations.prices.toast.updated', { count: updatedCount }));
+    }
+    if (messages.length) {
+      Toast.success(messages.join('<br>'));
+    }
+  } catch (error) {
+    console.error('Failed to save variation prices', error);
+    Toast.error(t('shared.messages.somethingWentWrong'));
+  } finally {
+    saving.value = false;
+  }
+};
+
+onMounted(() => {
+  loadData();
+});
+
+defineExpose({ save, hasUnsavedChanges });
+</script>
+
+<template>
+  <div class="relative w-full min-w-0">
+    <MatrixEditor
+      ref="matrixRef"
+      v-model:rows="variations"
+      :columns="columns"
+      :loading="loading || saving"
+      :has-changes="hasChanges"
+      row-key="id"
+      :get-cell-value="getMatrixCellValue"
+      :set-cell-value="setMatrixCellValue"
+      :clone-cell-value="cloneMatrixCellValue"
+      :clear-cell-value="clearMatrixCellValue"
+      @save="save"
+    >
+      <template #cell="{ row, column, rowIndex }">
+        <template v-if="column.key === 'name'">
+          <span class="block truncate" :title="row.variation.name">
+            {{ row.variation.name }}
+          </span>
+        </template>
+        <template v-else-if="column.key === 'sku'">
+          <span class="block truncate" :title="row.variation.sku">
+            {{ row.variation.sku }}
+          </span>
+        </template>
+        <template v-else-if="column.key === 'active'">
+          <Icon
+            v-if="row.variation.active"
+            name="check-circle"
+            class="text-green-500"
+          />
+          <Icon
+            v-else
+            name="times-circle"
+            class="text-red-500"
+          />
+        </template>
+        <template v-else-if="isPriceColumn(column.key)">
+          <TextInput
+            class="w-full"
+            :model-value="getMatrixCellValue(rowIndex, column.key)"
+            float
+            :disabled="!isColumnEditable(column.key) || loading || saving"
+            @update:modelValue="(value) => updatePriceFromInput(rowIndex, column.key, value)"
+          />
+        </template>
+        <template v-else>
+          <span class="block truncate">
+            {{ getMatrixCellValue(rowIndex, column.key) ?? '' }}
+          </span>
+        </template>
+      </template>
+    </MatrixEditor>
+  </div>
+</template>

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { gql } from 'graphql-tag';
 import type { FetchPolicy } from '@apollo/client';
 import MatrixEditor from "../../../../../../../../../shared/components/organisms/matrix-editor/MatrixEditor.vue";
 import type { MatrixColumn, MatrixEditorExpose } from "../../../../../../../../../shared/components/organisms/matrix-editor/types";
@@ -10,6 +9,7 @@ import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import apolloClient from "../../../../../../../../../../apollo-client";
 import { currenciesQuery } from "../../../../../../../../../shared/api/queries/currencies.js";
+import { bundleVariationsWithPricesQuery, configurableVariationsWithPricesQuery } from "../../../../../../../../../shared/api/queries/products.js";
 import { createSalesPricesMutation, updateSalesPriceMutation } from "../../../../../../../../../shared/api/mutations/salesPrices.js";
 import { Product } from "../../../../configs";
 import { ProductType } from "../../../../../../../../../shared/utils/constants";
@@ -98,68 +98,6 @@ const hasChanges = computed(
 );
 
 const hasUnsavedChanges = hasChanges;
-
-const configurableVariationsWithPricesQuery = gql`
-  query ConfigurableVariationsWithPrices($first: Int, $after: String, $filter: ConfigurableVariationFilter) {
-    configurableVariations(first: $first, after: $after, filters: $filter) {
-      edges {
-        node {
-          id
-          variation {
-            id
-            sku
-            name
-            active
-            salespriceSet {
-              id
-              price
-              rrp
-              currency {
-                id
-                isoCode
-              }
-            }
-          }
-        }
-      }
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-    }
-  }
-`;
-
-const bundleVariationsWithPricesQuery = gql`
-  query BundleVariationsWithPrices($first: Int, $after: String, $filter: BundleVariationFilter) {
-    bundleVariations(first: $first, after: $after, filters: $filter) {
-      edges {
-        node {
-          id
-          variation {
-            id
-            sku
-            name
-            active
-            salespriceSet {
-              id
-              price
-              rrp
-              currency {
-                id
-                isoCode
-              }
-            }
-          }
-        }
-      }
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-    }
-  }
-`;
 
 const parsePriceColumnKey = (key: string): ParsedPriceColumn | null => {
   const [isoCode, field] = key.split(PRICE_COLUMN_SEPARATOR);

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -995,6 +995,23 @@
         "hsCodes": "HS Codes",
         "eanCodes": "EAN Codes"
       },
+      "variations": {
+        "tabs": {
+          "list": "List",
+          "editProperties": "Edit Properties",
+          "editPrices": "Edit Prices"
+        },
+        "prices": {
+          "columns": {
+            "rrp": "RRP ({currency})",
+            "price": "Price ({currency})"
+          },
+          "toast": {
+            "created": "Created {count} sales prices.",
+            "updated": "Updated {count} sales prices."
+          }
+        }
+      },
         "properties": {
           "searchPlaceholder": "Search properties",
           "typePlaceholder": "Filter by type"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -999,7 +999,7 @@
         "tabs": {
           "list": "List",
           "editProperties": "Edit Properties",
-          "editPrices": "Edit Prices"
+          "editPrices": "Prices"
         },
         "prices": {
           "columns": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -682,7 +682,7 @@
         "tabs": {
           "list": "Lijst",
           "editProperties": "Eigenschappen bewerken",
-          "editPrices": "Prijzen bewerken"
+          "editPrices": "Prijzen"
         },
         "prices": {
           "columns": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -678,6 +678,23 @@
         "websites": "Verkoopskanalen",
         "amazon": "Amazon"
       },
+      "variations": {
+        "tabs": {
+          "list": "Lijst",
+          "editProperties": "Eigenschappen bewerken",
+          "editPrices": "Prijzen bewerken"
+        },
+        "prices": {
+          "columns": {
+            "rrp": "Adviesprijs ({currency})",
+            "price": "Prijs ({currency})"
+          },
+          "toast": {
+            "created": "{count} verkoopprijzen aangemaakt.",
+            "updated": "{count} verkoopprijzen bijgewerkt."
+          }
+        }
+      },
         "properties": {
           "searchPlaceholder": "Zoek eigenschappen",
           "typePlaceholder": "Filter op type"

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -315,6 +315,68 @@ export const bundleVariationsQuery = gql`
   }
 `;
 
+export const configurableVariationsWithPricesQuery = gql`
+  query ConfigurableVariationsWithPrices($first: Int, $after: String, $filter: ConfigurableVariationFilter) {
+    configurableVariations(first: $first, after: $after, filters: $filter) {
+      edges {
+        node {
+          id
+          variation {
+            id
+            sku
+            name
+            active
+            salespriceSet {
+              id
+              price
+              rrp
+              currency {
+                id
+                isoCode
+              }
+            }
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+export const bundleVariationsWithPricesQuery = gql`
+  query BundleVariationsWithPrices($first: Int, $after: String, $filter: BundleVariationFilter) {
+    bundleVariations(first: $first, after: $after, filters: $filter) {
+      edges {
+        node {
+          id
+          variation {
+            id
+            sku
+            name
+            active
+            salespriceSet {
+              id
+              price
+              rrp
+              currency {
+                id
+                isoCode
+              }
+            }
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
 export const getProductQuery = gql`
   query getProduct($id: GlobalID!) {
     product(id: $id) {

--- a/src/shared/plugins/font-awesome.ts
+++ b/src/shared/plugins/font-awesome.ts
@@ -157,7 +157,8 @@ import {
   faCommentDots,
   faArrowRight,
   faWaveSquare,
-  faChartSimple
+  faChartSimple,
+  faCoins
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(faBell as IconDefinition);
@@ -315,6 +316,7 @@ library.add(faCommentDots as IconDefinition);
 library.add(faArrowRight as IconDefinition);
 library.add(faWaveSquare as IconDefinition);
 library.add(faChartSimple as IconDefinition);
+library.add(faCoins as IconDefinition);
 
 
 export default {


### PR DESCRIPTION
## Summary
- add translation-backed mode selection for variations including price editing tab
- introduce matrix-based bulk editor for variation sales prices with currency-aware columns

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d06570b9f4832eb099d27043318c45

## Summary by Sourcery

Add a currency-aware bulk edit tab for variation sales prices and extend the variations view to support multiple edit modes with unsaved-change handling

New Features:
- Introduce an “editPrices” tab in VariationsView for bulk editing variation sales prices
- Add VariationsPricesBulkEdit component with a matrix-based editor that loads currencies and variations and persists price/RRP via GraphQL

Enhancements:
- Update VariationsView to manage separate property and price edit modes and globally track unsaved changes
- Localize the new tab labels and integrate translation-backed mode selection

Documentation:
- Add translation keys for the new price editing tab and matrix column labels in en.json and nl.json