### PR TITLE
Fix select paste and modal reset in variations bulk edit

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -590,6 +590,12 @@ const selectedIndex = ref<number | null>(null)
 const selectedColKey = ref('')
 const modalValue = ref('')
 
+const resetModalState = () => {
+  selectedIndex.value = null
+  selectedColKey.value = ''
+  modalValue.value = ''
+}
+
 const openTextModal = (index: number, key: string) => {
   selectedIndex.value = index
   selectedColKey.value = key
@@ -609,7 +615,26 @@ const openDescriptionModal = (index: number, key: string) => {
 const cancelModal = () => {
   showTextModal.value = false
   showDescriptionModal.value = false
+  resetModalState()
 }
+
+watch(
+  showTextModal,
+  (value, previousValue) => {
+    if (!value && previousValue) {
+      resetModalState()
+    }
+  }
+)
+
+watch(
+  showDescriptionModal,
+  (value, previousValue) => {
+    if (!value && previousValue) {
+      resetModalState()
+    }
+  }
+)
 
 const saveModal = () => {
   if (selectedIndex.value === null) return

--- a/src/shared/components/organisms/matrix-editor/MatrixEditor.vue
+++ b/src/shared/components/organisms/matrix-editor/MatrixEditor.vue
@@ -518,6 +518,7 @@ const handleKeydown = (event: KeyboardEvent) => {
 
 const canPasteToColumn = (clipboardValue: ClipboardValue, targetColumn: string) => {
   if (!isEditableColumn(targetColumn)) return false
+  if (clipboardValue.column === targetColumn) return true
   const fromType = clipboardValue.columnType
   const toType = getColumnType(targetColumn)
   return canPasteBetweenTypes(fromType, toType)
@@ -531,9 +532,9 @@ const canPasteBetweenTypes = (
   if (!fromType || !toType) return false
   const from = fromType.toUpperCase()
   const to = toType.toUpperCase()
+  if (from === to) return true
   if (from === PropertyTypes.SELECT || from === PropertyTypes.MULTISELECT) return false
   if (to === PropertyTypes.SELECT || to === PropertyTypes.MULTISELECT) return false
-  if (from === to) return true
   if (from === PropertyTypes.INT && to === PropertyTypes.FLOAT) return true
   if (from === PropertyTypes.TEXT && to === PropertyTypes.DESCRIPTION) return true
   if (from === PropertyTypes.DATE && to === PropertyTypes.DATETIME) return true


### PR DESCRIPTION
## Summary
- allow matrix editor to paste select and multiselect values back into their original column while still guarding incompatible targets
- reset variations bulk edit modal state when it closes, even on outside clicks, to keep modals reusable

## Testing
- npm run build *(fails: Cannot find module '../../../../configs' in variations-prices-bulk-edit type check)*

------
https://chatgpt.com/codex/tasks/task_e_68d0769bbc94832ea9ce579e1a7346f5