### PR TITLE
Show company name in profile dropdown

### DIFF
--- a/src/shared/components/organisms/user-profile-dropdown/UserProfileDropdown.vue
+++ b/src/shared/components/organisms/user-profile-dropdown/UserProfileDropdown.vue
@@ -52,6 +52,12 @@ const handleSubscriptionResult = (data: any) => {
                               <h4 class="text-base">
                                 {{ user.firstName }} {{ user.lastName }}
                               </h4>
+                              <p
+                                v-if="user.company?.name"
+                                class="text-sm text-slate-500 dark:text-white-dark/70"
+                              >
+                                {{ user.company?.name }}
+                              </p>
                               <a class="text-black/60 hover:text-primary dark:text-dark-light/60 dark:hover:text-white" href="javascript:;">{{ user.username }}</a>
                           </div>
                       </div>


### PR DESCRIPTION
## Summary
- show the authenticated user's multi-tenant company name above the email in the profile dropdown for clearer context

## Testing
- npm run build *(fails: Cannot find module '../../../../configs' referenced from VariationsPricesBulkEdit.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68d12df25a34832e96fdbfb804e8bcfa

## Summary by Sourcery

New Features:
- Display the multi-tenant company name in the user profile dropdown if available