### PR TITLE
feat: extend variation price editor with price list overrides

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
@@ -11,7 +11,13 @@ import { processGraphQLErrors, shortenText } from "../../../../../../../../../sh
 import apolloClient from "../../../../../../../../../../apollo-client";
 import { currenciesQuery } from "../../../../../../../../../shared/api/queries/currencies.js";
 import { bundleVariationsWithPricesQuery, configurableVariationsWithPricesQuery } from "../../../../../../../../../shared/api/queries/products.js";
-import { createSalesPricesMutation, updateSalesPriceMutation } from "../../../../../../../../../shared/api/mutations/salesPrices.js";
+import {
+  createSalesPriceListItemsMutation,
+  createSalesPricesMutation,
+  updateSalesPriceListItemMutation,
+  updateSalesPriceMutation,
+} from "../../../../../../../../../shared/api/mutations/salesPrices.js";
+import { salesPriceListItemsQuery } from "../../../../../../../../../shared/api/queries/salesPrices.js";
 import { Product } from "../../../../configs";
 import { ProductType } from "../../../../../../../../../shared/utils/constants";
 
@@ -31,6 +37,26 @@ interface VariationPriceInfo {
   readonly: boolean;
 }
 
+interface PriceListInfo {
+  id: string;
+  name: string;
+  currency: {
+    id: string;
+    isoCode: string;
+    symbol: string;
+  };
+}
+
+interface VariationPriceListInfo {
+  id: string | null;
+  priceAuto: string;
+  discountAuto: string;
+  priceOverride: string;
+  discountOverride: string;
+  salesPriceListId: string;
+  readonly: boolean;
+}
+
 interface VariationRow {
   id: string;
   variation: {
@@ -40,15 +66,23 @@ interface VariationRow {
     active: boolean;
   };
   prices: Record<string, VariationPriceInfo>;
+  priceLists: Record<string, VariationPriceListInfo>;
 }
 
 const PRICE_COLUMN_SEPARATOR = '__';
+const PRICE_LIST_COLUMN_PREFIX = 'pricelist';
 
 type PriceField = 'price' | 'rrp';
+type PriceListField = 'priceOverride' | 'discountOverride';
 
 type ParsedPriceColumn = {
   isoCode: string;
   field: PriceField;
+};
+
+type ParsedPriceListColumn = {
+  priceListId: string;
+  field: PriceListField;
 };
 
 const props = defineProps<{ product: Product }>();
@@ -56,6 +90,7 @@ const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 
 const currencies = ref<CurrencyInfo[]>([]);
+const priceLists = ref<PriceListInfo[]>([]);
 const variations = ref<VariationRow[]>([]);
 const originalVariations = ref<VariationRow[]>([]);
 const loading = ref(false);
@@ -81,18 +116,52 @@ const priceColumns = computed<MatrixColumn[]>(() =>
         label: t('products.products.variations.prices.columns.rrp', { currency: labelCurrency }),
         editable: !currency.readonly,
         valueType: 'float',
+        requireType: 'base-price',
+        iconColorClass: 'text-red-500',
       },
       {
         key: `${currency.isoCode}${PRICE_COLUMN_SEPARATOR}price`,
         label: t('products.products.variations.prices.columns.price', { currency: labelCurrency }),
         editable: !currency.readonly,
         valueType: 'float',
+        requireType: 'base-price',
+        iconColorClass: 'text-red-500',
       },
     ];
   })
 );
 
-const columns = computed<MatrixColumn[]>(() => [...baseColumns.value, ...priceColumns.value]);
+const priceListColumns = computed<MatrixColumn[]>(() =>
+  priceLists.value.flatMap((priceList) => {
+    const labelCurrency =
+      priceList.currency?.isoCode || priceList.currency?.symbol || '';
+    const labelParams = { priceList: priceList.name, currency: labelCurrency };
+    return [
+      {
+        key: `${PRICE_LIST_COLUMN_PREFIX}${PRICE_COLUMN_SEPARATOR}${priceList.id}${PRICE_COLUMN_SEPARATOR}priceOverride`,
+        label: t('products.products.variations.prices.columns.priceListPrice', labelParams),
+        editable: true,
+        valueType: 'float',
+        requireType: 'price-list',
+        iconColorClass: 'text-orange-400',
+      },
+      {
+        key: `${PRICE_LIST_COLUMN_PREFIX}${PRICE_COLUMN_SEPARATOR}${priceList.id}${PRICE_COLUMN_SEPARATOR}discountOverride`,
+        label: t('products.products.variations.prices.columns.priceListDiscount', labelParams),
+        editable: true,
+        valueType: 'float',
+        requireType: 'price-list',
+        iconColorClass: 'text-orange-400',
+      },
+    ];
+  })
+);
+
+const columns = computed<MatrixColumn[]>(() => [
+  ...baseColumns.value,
+  ...priceColumns.value,
+  ...priceListColumns.value,
+]);
 
 const hasChanges = computed(
   () => JSON.stringify(variations.value) !== JSON.stringify(originalVariations.value)
@@ -108,9 +177,24 @@ const parsePriceColumnKey = (key: string): ParsedPriceColumn | null => {
   return { isoCode, field: field as PriceField };
 };
 
+const parsePriceListColumnKey = (key: string): ParsedPriceListColumn | null => {
+  const [prefix, priceListId, field] = key.split(PRICE_COLUMN_SEPARATOR);
+  if (prefix !== PRICE_LIST_COLUMN_PREFIX) {
+    return null;
+  }
+  if (field !== 'priceOverride' && field !== 'discountOverride') {
+    return null;
+  }
+  return { priceListId, field: field as PriceListField };
+};
+
 const isPriceColumn = (key: string) => Boolean(parsePriceColumnKey(key));
+const isPriceListColumn = (key: string) => Boolean(parsePriceListColumnKey(key));
 
 const isColumnEditable = (key: string) => {
+  if (parsePriceListColumnKey(key)) {
+    return true;
+  }
   const parsed = parsePriceColumnKey(key);
   if (!parsed) {
     return false;
@@ -136,6 +220,44 @@ const ensurePriceEntry = (row: VariationRow, isoCode: string) => {
   return row.prices[isoCode];
 };
 
+const getPriceListEntry = (row: VariationRow, priceListId: string) => {
+  if (!row.priceLists) {
+    row.priceLists = {};
+  }
+  if (!row.priceLists[priceListId]) {
+    row.priceLists[priceListId] = {
+      id: null,
+      priceAuto: '',
+      discountAuto: '',
+      priceOverride: '',
+      discountOverride: '',
+      salesPriceListId: priceListId,
+      readonly: true,
+    };
+  }
+  return row.priceLists[priceListId];
+};
+
+const isPriceListCellEditable = (rowIndex: number, columnKey: string) => {
+  const parsed = parsePriceListColumnKey(columnKey);
+  if (!parsed) return false;
+  const row = variations.value[rowIndex];
+  if (!row) return false;
+  const entry = row.priceLists?.[parsed.priceListId];
+  if (!entry) return false;
+  return !entry.readonly;
+};
+
+const isCellEditable = (rowIndex: number, columnKey: string) => {
+  if (parsePriceListColumnKey(columnKey)) {
+    return isPriceListCellEditable(rowIndex, columnKey);
+  }
+  if (parsePriceColumnKey(columnKey)) {
+    return isColumnEditable(columnKey);
+  }
+  return false;
+};
+
 const getMatrixCellValue = (rowIndex: number, columnKey: string) => {
   const row = variations.value[rowIndex];
   if (!row) return '';
@@ -148,11 +270,38 @@ const getMatrixCellValue = (rowIndex: number, columnKey: string) => {
   if (columnKey === 'active') {
     return row.variation.active ? t('shared.labels.yes') : t('shared.labels.no');
   }
+  const parsedPriceList = parsePriceListColumnKey(columnKey);
+  if (parsedPriceList) {
+    const priceListInfo = row.priceLists?.[parsedPriceList.priceListId];
+    if (!priceListInfo) return '';
+    return priceListInfo[parsedPriceList.field] ?? '';
+  }
   const parsed = parsePriceColumnKey(columnKey);
   if (!parsed) return '';
   const priceInfo = row.prices[parsed.isoCode];
   if (!priceInfo) return '';
   return priceInfo[parsed.field] ?? '';
+};
+
+const getPriceListAutoValue = (rowIndex: number, columnKey: string) => {
+  const parsed = parsePriceListColumnKey(columnKey);
+  if (!parsed) return '';
+  const row = variations.value[rowIndex];
+  if (!row) return '';
+  const entry = row.priceLists?.[parsed.priceListId];
+  if (!entry) return '';
+  if (parsed.field === 'priceOverride') {
+    return entry.priceAuto ?? '';
+  }
+  return entry.discountAuto ?? '';
+};
+
+const getPriceListAutoLabel = (rowIndex: number, columnKey: string) => {
+  const value = getPriceListAutoValue(rowIndex, columnKey);
+  if (value === '') {
+    return t('products.products.variations.prices.labels.autoValueEmpty');
+  }
+  return t('products.products.variations.prices.labels.autoValue', { value });
 };
 
 const setPriceValue = (rowIndex: number, columnKey: string, rawValue: any) => {
@@ -176,21 +325,59 @@ const setPriceValue = (rowIndex: number, columnKey: string, rawValue: any) => {
   entry[parsed.field] = value.toString();
 };
 
-const updatePriceFromInput = (rowIndex: number, columnKey: string, value: string | number | null) => {
+const setPriceListValue = (rowIndex: number, columnKey: string, rawValue: any) => {
+  const parsed = parsePriceListColumnKey(columnKey);
+  if (!parsed) return;
+  const row = variations.value[rowIndex];
+  if (!row) return;
+  const entry = getPriceListEntry(row, parsed.priceListId);
+  if (!entry || entry.readonly) return;
+  let value = rawValue;
+  if (value === null || value === undefined || value === '') {
+    entry[parsed.field] = '';
+    return;
+  }
+  const numericValue = Number(value);
+  if (Number.isNaN(numericValue) || numericValue < 0) {
+    entry[parsed.field] = '';
+    return;
+  }
+  entry[parsed.field] = value.toString();
+};
+
+const updateCellFromInput = (rowIndex: number, columnKey: string, value: string | number | null) => {
+  if (parsePriceListColumnKey(columnKey)) {
+    setPriceListValue(rowIndex, columnKey, value);
+    return;
+  }
   setPriceValue(rowIndex, columnKey, value);
 };
 
 const setMatrixCellValue = (rowIndex: number, columnKey: string, value: any) => {
+  if (parsePriceListColumnKey(columnKey)) {
+    setPriceListValue(rowIndex, columnKey, value);
+    return;
+  }
   setPriceValue(rowIndex, columnKey, value);
 };
 
 const cloneMatrixCellValue = (fromRow: number, toRow: number, columnKey: string) => {
+  if (parsePriceListColumnKey(columnKey)) {
+    if (!isPriceListCellEditable(fromRow, columnKey)) return;
+    const value = getMatrixCellValue(fromRow, columnKey);
+    setPriceListValue(toRow, columnKey, value);
+    return;
+  }
   if (!isColumnEditable(columnKey)) return;
   const value = getMatrixCellValue(fromRow, columnKey);
   setPriceValue(toRow, columnKey, value);
 };
 
 const clearMatrixCellValue = (rowIndex: number, columnKey: string) => {
+  if (parsePriceListColumnKey(columnKey)) {
+    setPriceListValue(rowIndex, columnKey, '');
+    return;
+  }
   setPriceValue(rowIndex, columnKey, '');
 };
 
@@ -241,7 +428,7 @@ const fetchVariations = async (policy: FetchPolicy = 'cache-first') => {
     if (!after) break;
   }
 
-  variations.value = nodes.map((node: any) => {
+  return nodes.map((node: any) => {
     const variationProduct = node.variation;
     const priceMap: Record<string, VariationPriceInfo> = {};
     currencies.value.forEach((currency) => {
@@ -265,10 +452,108 @@ const fetchVariations = async (policy: FetchPolicy = 'cache-first') => {
         active: variationProduct.active,
       },
       prices: priceMap,
+      priceLists: {},
     };
   });
-  originalVariations.value = JSON.parse(JSON.stringify(variations.value));
-  matrixRef.value?.resetHistory(variations.value);
+};
+
+const loadPriceListItems = async (
+  variationIds: string[],
+  policy: FetchPolicy = 'cache-first'
+) => {
+  priceLists.value = [];
+  if (!variationIds.length) {
+    variations.value.forEach((row) => {
+      row.priceLists = {};
+    });
+    return;
+  }
+  const pageSize = 100;
+  let after: string | null = null;
+  const nodes: any[] = [];
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const { data } = await apolloClient.query({
+      query: salesPriceListItemsQuery,
+      variables: {
+        first: pageSize,
+        after,
+        filter: { product: { id: { inList: variationIds } } },
+      },
+      fetchPolicy: policy,
+    });
+    const connection = data?.salesPriceListItems;
+    if (!connection) break;
+    const edges = connection.edges ?? [];
+    edges.forEach((edge: any) => nodes.push(edge.node));
+    hasNextPage = connection.pageInfo?.hasNextPage ?? false;
+    after = connection.pageInfo?.endCursor ?? null;
+    if (!after) break;
+  }
+
+  const priceListMap = new Map<string, PriceListInfo>();
+  const itemsByProduct = new Map<string, any[]>();
+
+  nodes.forEach((node: any) => {
+    const productId = node.product?.id;
+    const priceListNode = node.salespricelist;
+    if (!productId || !priceListNode) return;
+    priceListMap.set(priceListNode.id, {
+      id: priceListNode.id,
+      name: priceListNode.name,
+      currency: {
+        id: priceListNode.currency?.id,
+        isoCode: priceListNode.currency?.isoCode,
+        symbol: priceListNode.currency?.symbol,
+      },
+    });
+    if (!itemsByProduct.has(productId)) {
+      itemsByProduct.set(productId, []);
+    }
+    itemsByProduct.get(productId)!.push(node);
+  });
+
+  priceLists.value = Array.from(priceListMap.values());
+
+  variations.value.forEach((row) => {
+    row.priceLists = {};
+    const rowItems = itemsByProduct.get(row.variation.id) ?? [];
+    rowItems.forEach((item: any) => {
+      const priceListId = item.salespricelist?.id;
+      if (!priceListId) return;
+      row.priceLists[priceListId] = {
+        id: item.id ?? null,
+        priceAuto: item.priceAuto != null ? String(item.priceAuto) : '',
+        discountAuto: item.discountAuto != null ? String(item.discountAuto) : '',
+        priceOverride: item.priceOverride != null ? String(item.priceOverride) : '',
+        discountOverride:
+          item.discountOverride != null ? String(item.discountOverride) : '',
+        salesPriceListId: priceListId,
+        readonly: false,
+      };
+    });
+  });
+
+  if (!priceLists.value.length) {
+    return;
+  }
+
+  variations.value.forEach((row) => {
+    priceLists.value.forEach((priceList) => {
+      if (!row.priceLists[priceList.id]) {
+        row.priceLists[priceList.id] = {
+          id: null,
+          priceAuto: '',
+          discountAuto: '',
+          priceOverride: '',
+          discountOverride: '',
+          salesPriceListId: priceList.id,
+          readonly: true,
+        };
+      }
+    });
+  });
 };
 
 const loadData = async (policy: FetchPolicy = 'cache-first') => {
@@ -277,7 +562,15 @@ const loadData = async (policy: FetchPolicy = 'cache-first') => {
     if (!currencies.value.length || policy === 'network-only') {
       await loadCurrencies(policy);
     }
-    await fetchVariations(policy);
+    const variationRows = await fetchVariations(policy);
+    variations.value = variationRows;
+    await loadPriceListItems(
+      variationRows.map((item) => item.variation.id),
+      policy
+    );
+    variations.value = JSON.parse(JSON.stringify(variations.value));
+    originalVariations.value = JSON.parse(JSON.stringify(variations.value));
+    matrixRef.value?.resetHistory(variations.value);
   } finally {
     loading.value = false;
   }
@@ -305,6 +598,8 @@ const save = async () => {
 
     const toCreate: any[] = [];
     const toUpdate: any[] = [];
+    const priceListToCreate: any[] = [];
+    const priceListToUpdate: any[] = [];
 
     variations.value.forEach((row) => {
       const original = originalMap.get(row.variation.id);
@@ -344,12 +639,54 @@ const save = async () => {
           });
         }
       });
+
+      priceLists.value.forEach((priceList) => {
+        const current = row.priceLists?.[priceList.id];
+        const previous = original?.priceLists?.[priceList.id];
+        if (!current || current.readonly) {
+          return;
+        }
+        const currentPriceOverride = current.priceOverride ?? '';
+        const currentDiscountOverride = current.discountOverride ?? '';
+        const previousPriceOverride = previous?.priceOverride ?? '';
+        const previousDiscountOverride = previous?.discountOverride ?? '';
+        if (
+          currentPriceOverride === previousPriceOverride &&
+          currentDiscountOverride === previousDiscountOverride
+        ) {
+          return;
+        }
+        if (current.id) {
+          const updateData: Record<string, any> = { id: current.id };
+          if (currentPriceOverride !== previousPriceOverride) {
+            updateData.priceOverride = parsePriceValue(current.priceOverride);
+          }
+          if (currentDiscountOverride !== previousDiscountOverride) {
+            updateData.discountOverride = parsePriceValue(current.discountOverride);
+          }
+          priceListToUpdate.push(updateData);
+        } else {
+          const priceOverrideValue = parsePriceValue(current.priceOverride);
+          const discountOverrideValue = parsePriceValue(current.discountOverride);
+          if (priceOverrideValue === null && discountOverrideValue === null) {
+            return;
+          }
+          priceListToCreate.push({
+            salespricelist: { id: priceList.id },
+            product: { id: row.variation.id },
+            priceOverride: priceOverrideValue,
+            discountOverride: discountOverrideValue,
+          });
+        }
+      });
     });
 
     const createdCount = toCreate.length;
     const updatedCount = toUpdate.length;
+    const createdPriceListCount = priceListToCreate.length;
+    const updatedPriceListCount = priceListToUpdate.length;
 
-    if (!createdCount && !updatedCount) {
+    if (!createdCount && !updatedCount && !createdPriceListCount && !updatedPriceListCount) {
       saving.value = false;
       return;
     }
@@ -370,6 +707,22 @@ const save = async () => {
       }
     }
 
+    if (createdPriceListCount) {
+      await apolloClient.mutate({
+        mutation: createSalesPriceListItemsMutation,
+        variables: { data: priceListToCreate },
+      });
+    }
+
+    if (updatedPriceListCount) {
+      for (const item of priceListToUpdate) {
+        await apolloClient.mutate({
+          mutation: updateSalesPriceListItemMutation,
+          variables: { data: item },
+        });
+      }
+    }
+
     await loadData('network-only');
 
     const messages: string[] = [];
@@ -378,6 +731,20 @@ const save = async () => {
     }
     if (updatedCount) {
       messages.push(t('products.products.variations.prices.toast.updated', { count: updatedCount }));
+    }
+    if (createdPriceListCount) {
+      messages.push(
+        t('products.products.variations.prices.toast.priceListCreated', {
+          count: createdPriceListCount,
+        })
+      );
+    }
+    if (updatedPriceListCount) {
+      messages.push(
+        t('products.products.variations.prices.toast.priceListUpdated', {
+          count: updatedPriceListCount,
+        })
+      );
     }
     if (messages.length) {
       Toast.success(messages.join('<br>'));
@@ -446,9 +813,23 @@ defineExpose({ save, hasUnsavedChanges });
             class="w-full"
             :model-value="getMatrixCellValue(rowIndex, column.key)"
             float
-            :disabled="!isColumnEditable(column.key) || loading || saving"
-            @update:modelValue="(value) => updatePriceFromInput(rowIndex, column.key, value)"
+            :disabled="!isCellEditable(rowIndex, column.key) || loading || saving"
+            @update:modelValue="(value) => updateCellFromInput(rowIndex, column.key, value)"
           />
+        </template>
+        <template v-else-if="isPriceListColumn(column.key)">
+          <div class="flex flex-col gap-1">
+            <TextInput
+              class="w-full"
+              :model-value="getMatrixCellValue(rowIndex, column.key)"
+              float
+              :disabled="!isCellEditable(rowIndex, column.key) || loading || saving"
+              @update:modelValue="(value) => updateCellFromInput(rowIndex, column.key, value)"
+            />
+            <span class="text-xs text-gray-500">
+              {{ getPriceListAutoLabel(rowIndex, column.key) }}
+            </span>
+          </div>
         </template>
         <template v-else>
           <span class="block truncate">

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -103,6 +103,26 @@
       "tabs": {
         "amazon": "Amazon"
       },
+      "variations": {
+        "prices": {
+          "columns": {
+            "rrp": "RRP ({currency})",
+            "price": "Price ({currency})",
+            "priceListPrice": "{priceList} ({currency}) price override",
+            "priceListDiscount": "{priceList} ({currency}) discount override"
+          },
+          "toast": {
+            "created": "Created {count} sales prices.",
+            "updated": "Updated {count} sales prices.",
+            "priceListCreated": "Created {count} price list overrides.",
+            "priceListUpdated": "Updated {count} price list overrides."
+          },
+          "labels": {
+            "autoValue": "Auto: {value}",
+            "autoValueEmpty": "Auto: —"
+          }
+        }
+      },
       "properties": {
         "searchPlaceholder": "Eigenschaften suchen",
         "typePlaceholder": "Nach Typ filtern"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1002,11 +1002,19 @@
         "prices": {
           "columns": {
             "rrp": "RRP ({currency})",
-            "price": "Price ({currency})"
+            "price": "Price ({currency})",
+            "priceListPrice": "{priceList} ({currency}) price override",
+            "priceListDiscount": "{priceList} ({currency}) discount override"
           },
           "toast": {
             "created": "Created {count} sales prices.",
-            "updated": "Updated {count} sales prices."
+            "updated": "Updated {count} sales prices.",
+            "priceListCreated": "Created {count} price list overrides.",
+            "priceListUpdated": "Updated {count} price list overrides."
+          },
+          "labels": {
+            "autoValue": "Auto: {value}",
+            "autoValueEmpty": "Auto: —"
           }
         }
       },

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -98,10 +98,30 @@
       "tabs": {
         "amazon": "Amazon"
       },
-        "properties": {
-          "searchPlaceholder": "Rechercher des propriétés",
-          "typePlaceholder": "Filtrer par type"
-        },
+      "variations": {
+        "prices": {
+          "columns": {
+            "rrp": "RRP ({currency})",
+            "price": "Price ({currency})",
+            "priceListPrice": "{priceList} ({currency}) price override",
+            "priceListDiscount": "{priceList} ({currency}) discount override"
+          },
+          "toast": {
+            "created": "Created {count} sales prices.",
+            "updated": "Updated {count} sales prices.",
+            "priceListCreated": "Created {count} price list overrides.",
+            "priceListUpdated": "Updated {count} price list overrides."
+          },
+          "labels": {
+            "autoValue": "Auto: {value}",
+            "autoValueEmpty": "Auto: —"
+          }
+        }
+      },
+      "properties": {
+        "searchPlaceholder": "Rechercher des propriétés",
+        "typePlaceholder": "Filtrer par type"
+      },
       "labels": {
         "configuratorValue": ""
       },

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -687,11 +687,19 @@
         "prices": {
           "columns": {
             "rrp": "Adviesprijs ({currency})",
-            "price": "Prijs ({currency})"
+            "price": "Prijs ({currency})",
+            "priceListPrice": "{priceList} ({currency}) price override",
+            "priceListDiscount": "{priceList} ({currency}) discount override"
           },
           "toast": {
             "created": "{count} verkoopprijzen aangemaakt.",
-            "updated": "{count} verkoopprijzen bijgewerkt."
+            "updated": "{count} verkoopprijzen bijgewerkt.",
+            "priceListCreated": "Created {count} price list overrides.",
+            "priceListUpdated": "Updated {count} price list overrides."
+          },
+          "labels": {
+            "autoValue": "Auto: {value}",
+            "autoValueEmpty": "Auto: —"
           }
         }
       },

--- a/src/shared/api/queries/salesPrices.js
+++ b/src/shared/api/queries/salesPrices.js
@@ -123,6 +123,11 @@ export const salesPriceListItemsQuery = gql`
             id
             name
             discountPcnt
+            currency {
+              id
+              isoCode
+              symbol
+            }
           }
           product {
             id


### PR DESCRIPTION
## Summary
- add price list override columns to the variation price bulk editor with auto value hints
- load sales price list items for each variation and support creating/updating overrides
- extend translations and queries to surface price list metadata in the matrix

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d13662bb80832ea6c120db2693af4b

## Summary by Sourcery

Add support for price list overrides in the variation price bulk editor by extending the UI, data loading, and save logic.

New Features:
- Add price list override columns with auto-value hints to the variation price bulk editor
- Load and display sales price list items for each variation
- Support creating and updating price list override entries via new GraphQL mutations

Enhancements:
- Extend loadData flow to fetch price list items and synchronize them with the matrix
- Include price list metadata and currency fields in GraphQL queries and map them into the component state

Documentation:
- Add translation keys for price list column labels and auto-value hints