### PR TITLE
Make variation links open in new tabs and add SKU copy actions

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -15,6 +15,7 @@ import { shortenText } from "../../../../../../../../../shared/utils";
 import { Modal } from "../../../../../../../../../shared/components/atoms/modal";
 import { Card } from "../../../../../../../../../shared/components/atoms/card";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { FieldQuery } from "../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
 import { Selector } from "../../../../../../../../../shared/components/atoms/selector";
 import type { QueryFormField } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
@@ -89,6 +90,16 @@ const filteredProperties = computed(() => {
     return p.name.toLowerCase().includes(searchQuery.value.toLowerCase())
   })
 })
+
+const copySkuToClipboard = async (sku: string) => {
+  try {
+    await navigator.clipboard.writeText(sku)
+    Toast.success(t('shared.alert.toast.clipboardSuccess'))
+  } catch (err) {
+    console.error('Failed to copy:', err)
+    Toast.error(t('shared.alert.toast.clipboardFail'))
+  }
+}
 
 const columns = computed<MatrixColumn[]>(() => [
   ...baseColumns.value,
@@ -764,14 +775,25 @@ const updateDateTimeValue = (index: number, key: string, value: any) => {
       </template>
       <template #cell="{ row, column, rowIndex }">
         <template v-if="column.key === 'name'">
-          <span class="block truncate" :title="row.variation.name">
-            {{ shortenText(row.variation.name, 32) }}
-          </span>
+          <Link
+            :path="{ name: 'products.products.show', params: { id: row.variation.id } }"
+            target="_blank"
+            block
+          >
+            <span class="block truncate" :title="row.variation.name">
+              {{ shortenText(row.variation.name, 32) }}
+            </span>
+          </Link>
         </template>
         <template v-else-if="column.key === 'sku'">
-          <span class="block truncate" :title="row.variation.sku">
-            {{ row.variation.sku }}
-          </span>
+          <div class="flex items-center">
+            <span class="block truncate" :title="row.variation.sku">
+              {{ row.variation.sku }}
+            </span>
+            <Button class="ml-1" @click="copySkuToClipboard(row.variation.sku)">
+              <Icon name="clipboard" class="h-4 w-4 text-gray-500" aria-hidden="true" />
+            </Button>
+          </div>
         </template>
         <template v-else-if="column.key === 'active'">
           <Icon

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
@@ -157,7 +157,7 @@ const handleQuantityChanged = debounce(async (event, id) => {
                 <tbody class="divide-y divide-gray-200 bg-white">
                   <tr v-for="item in data[queryKey].edges" :key="item.node.id">
                   <td>
-                    <Link :path="{name: 'products.products.show', params: {id: item.node.variation.id}}">
+                    <Link :path="{name: 'products.products.show', params: {id: item.node.variation.id}}" target="_blank">
                       <Flex class="gap-4">
                         <FlexCell center>
                           <div v-if="item.node.variation.thumbnailUrl" class="w-8 h-8 overflow-hidden">

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
@@ -6,13 +6,15 @@ import MatrixEditor from "../../../../../../../../../shared/components/organisms
 import type { MatrixColumn, MatrixEditorExpose } from "../../../../../../../../../shared/components/organisms/matrix-editor/types";
 import { TextInput } from "../../../../../../../../../shared/components/atoms/input-text";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
+import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import { processGraphQLErrors, shortenText } from "../../../../../../../../../shared/utils";
 import apolloClient from "../../../../../../../../../../apollo-client";
 import { currenciesQuery } from "../../../../../../../../../shared/api/queries/currencies.js";
 import { bundleVariationsWithPricesQuery, configurableVariationsWithPricesQuery } from "../../../../../../../../../shared/api/queries/products.js";
 import { createSalesPricesMutation, updateSalesPriceMutation } from "../../../../../../../../../shared/api/mutations/salesPrices.js";
-import { Product } from "../../../../configs";
+import { Product } from "../../../../../../configs";
 import { ProductType } from "../../../../../../../../../shared/utils/constants";
 
 interface CurrencyInfo {
@@ -117,6 +119,16 @@ const isColumnEditable = (key: string) => {
   }
   const currency = currencies.value.find((item) => item.isoCode === parsed.isoCode);
   return currency ? !currency.readonly : false;
+};
+
+const copySkuToClipboard = async (sku: string) => {
+  try {
+    await navigator.clipboard.writeText(sku);
+    Toast.success(t('shared.alert.toast.clipboardSuccess'));
+  } catch (err) {
+    console.error('Failed to copy:', err);
+    Toast.error(t('shared.alert.toast.clipboardFail'));
+  }
 };
 
 const ensurePriceEntry = (row: VariationRow, isoCode: string) => {
@@ -420,14 +432,25 @@ defineExpose({ save, hasUnsavedChanges });
     >
       <template #cell="{ row, column, rowIndex }">
         <template v-if="column.key === 'name'">
-          <span class="block truncate" :title="row.variation.name">
-            {{ shortenText(row.variation.name, 32) }}
-          </span>
+          <Link
+            :path="{ name: 'products.products.show', params: { id: row.variation.id } }"
+            target="_blank"
+            block
+          >
+            <span class="block truncate" :title="row.variation.name">
+              {{ shortenText(row.variation.name, 32) }}
+            </span>
+          </Link>
         </template>
         <template v-else-if="column.key === 'sku'">
-          <span class="block truncate" :title="row.variation.sku">
-            {{ row.variation.sku }}
-          </span>
+          <div class="flex items-center">
+            <span class="block truncate" :title="row.variation.sku">
+              {{ row.variation.sku }}
+            </span>
+            <Button class="ml-1" @click="copySkuToClipboard(row.variation.sku)">
+              <Icon name="clipboard" class="h-4 w-4 text-gray-500" aria-hidden="true" />
+            </Button>
+          </div>
         </template>
         <template v-else-if="column.key === 'active'">
           <Icon


### PR DESCRIPTION
## Summary
- open variation detail links in a new tab from the variations list, properties, and prices tables
- add clipboard buttons beside variation SKUs in the properties and prices bulk editors
- reuse existing toast notifications when copying SKUs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d14371c608832e92f8048ccd8b466a