### PR TITLE
Make variation links open in new tab and add SKU clipboard

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -15,6 +15,7 @@ import { shortenText } from "../../../../../../../../../shared/utils";
 import { Modal } from "../../../../../../../../../shared/components/atoms/modal";
 import { Card } from "../../../../../../../../../shared/components/atoms/card";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { FieldQuery } from "../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
 import { Selector } from "../../../../../../../../../shared/components/atoms/selector";
 import type { QueryFormField } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
@@ -62,6 +63,15 @@ const loading = ref(true)
 const skipHistory = ref(false)
 const matrixRef = ref<MatrixEditorExpose | null>(null)
 const readOnlyColumns = new Set(['sku', 'name', 'active'])
+
+const copySkuToClipboard = async (sku: string) => {
+  try {
+    await navigator.clipboard.writeText(sku)
+    Toast.success(t('shared.alert.toast.clipboardSuccess'))
+  } catch (error) {
+    Toast.error(t('shared.alert.toast.clipboardFail'))
+  }
+}
 
 const pageInfo = ref<any | null>(null)
 const limit = ref(20)
@@ -764,14 +774,21 @@ const updateDateTimeValue = (index: number, key: string, value: any) => {
       </template>
       <template #cell="{ row, column, rowIndex }">
         <template v-if="column.key === 'name'">
-          <span class="block truncate" :title="row.variation.name">
-            {{ shortenText(row.variation.name, 32) }}
-          </span>
+          <Link :path="{ name: 'products.products.show', params: { id: row.variation.id } }" target="_blank">
+            <span class="block truncate" :title="row.variation.name">
+              {{ shortenText(row.variation.name, 32) }}
+            </span>
+          </Link>
         </template>
         <template v-else-if="column.key === 'sku'">
-          <span class="block truncate" :title="row.variation.sku">
-            {{ row.variation.sku }}
-          </span>
+          <div class="flex items-center gap-1">
+            <span class="block truncate" :title="row.variation.sku">
+              {{ row.variation.sku }}
+            </span>
+            <Button class="p-0" @click="copySkuToClipboard(row.variation.sku)">
+              <Icon name="clipboard" class="h-4 w-4 text-gray-500" aria-hidden="true" />
+            </Button>
+          </div>
         </template>
         <template v-else-if="column.key === 'active'">
           <Icon

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-list/VariationsList.vue
@@ -157,7 +157,7 @@ const handleQuantityChanged = debounce(async (event, id) => {
                 <tbody class="divide-y divide-gray-200 bg-white">
                   <tr v-for="item in data[queryKey].edges" :key="item.node.id">
                   <td>
-                    <Link :path="{name: 'products.products.show', params: {id: item.node.variation.id}}">
+                    <Link :path="{name: 'products.products.show', params: {id: item.node.variation.id}}" target="_blank">
                       <Flex class="gap-4">
                         <FlexCell center>
                           <div v-if="item.node.variation.thumbnailUrl" class="w-8 h-8 overflow-hidden">

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue
@@ -5,6 +5,8 @@ import type { FetchPolicy } from '@apollo/client';
 import MatrixEditor from "../../../../../../../../../shared/components/organisms/matrix-editor/MatrixEditor.vue";
 import type { MatrixColumn, MatrixEditorExpose } from "../../../../../../../../../shared/components/organisms/matrix-editor/types";
 import { TextInput } from "../../../../../../../../../shared/components/atoms/input-text";
+import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Link } from "../../../../../../../../../shared/components/atoms/link";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import { processGraphQLErrors, shortenText } from "../../../../../../../../../shared/utils";
@@ -18,7 +20,7 @@ import {
   updateSalesPriceMutation,
 } from "../../../../../../../../../shared/api/mutations/salesPrices.js";
 import { salesPriceListItemsQuery } from "../../../../../../../../../shared/api/queries/salesPrices.js";
-import { Product } from "../../../../configs";
+import { Product } from "../../../../../../configs";
 import { ProductType } from "../../../../../../../../../shared/utils/constants";
 
 interface CurrencyInfo {
@@ -96,6 +98,15 @@ const originalVariations = ref<VariationRow[]>([]);
 const loading = ref(false);
 const saving = ref(false);
 const matrixRef = ref<MatrixEditorExpose | null>(null);
+
+const copySkuToClipboard = async (sku: string) => {
+  try {
+    await navigator.clipboard.writeText(sku);
+    Toast.success(t('shared.alert.toast.clipboardSuccess'));
+  } catch (error) {
+    Toast.error(t('shared.alert.toast.clipboardFail'));
+  }
+};
 
 const isAlias = computed(() => props.product.type === ProductType.Alias);
 const parentProduct = computed(() => (isAlias.value ? props.product.aliasParentProduct : props.product));
@@ -787,14 +798,21 @@ defineExpose({ save, hasUnsavedChanges });
     >
       <template #cell="{ row, column, rowIndex }">
         <template v-if="column.key === 'name'">
-          <span class="block truncate" :title="row.variation.name">
-            {{ shortenText(row.variation.name, 32) }}
-          </span>
+          <Link :path="{ name: 'products.products.show', params: { id: row.variation.id } }" target="_blank">
+            <span class="block truncate" :title="row.variation.name">
+              {{ shortenText(row.variation.name, 32) }}
+            </span>
+          </Link>
         </template>
         <template v-else-if="column.key === 'sku'">
-          <span class="block truncate" :title="row.variation.sku">
-            {{ row.variation.sku }}
-          </span>
+          <div class="flex items-center gap-1">
+            <span class="block truncate" :title="row.variation.sku">
+              {{ row.variation.sku }}
+            </span>
+            <Button class="p-0" @click="copySkuToClipboard(row.variation.sku)">
+              <Icon name="clipboard" class="h-4 w-4 text-gray-500" aria-hidden="true" />
+            </Button>
+          </div>
         </template>
         <template v-else-if="column.key === 'active'">
           <Icon


### PR DESCRIPTION
## Summary
- open variation links from the list tab in a new browser tab
- add clipboard copy buttons for SKU values in variation properties and prices tables
- link variation names in properties and prices tables to their detail pages in a new tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1466153a0832ea95a94584fc5fa5f

## Summary by Sourcery

Enable opening variation detail links in a new tab and add clipboard copy functionality for variation SKUs in variation tables

New Features:
- Open variation detail links in a new browser tab across list, bulk edit, and prices tables
- Add copy-to-clipboard buttons for variation SKU values in bulk edit and prices tables