### PR TITLE
Fetch variation validation issues via dedicated queries

### DIFF
--- a/src/shared/api/queries/amazonProductIssues.js
+++ b/src/shared/api/queries/amazonProductIssues.js
@@ -1,0 +1,25 @@
+import { gql } from 'graphql-tag';
+
+export const amazonProductIssuesQuery = gql`
+  query AmazonProductIssues($filter: AmazonProductIssueFilter) {
+    amazonProductIssues(filters: $filter) {
+      edges {
+        node {
+          id
+          createdAt
+          code
+          message
+          severity
+          isValidationIssue
+          view {
+            remoteId
+            name
+          }
+          remoteProduct {
+            id
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/shared/api/queries/amazonProducts.js
+++ b/src/shared/api/queries/amazonProducts.js
@@ -77,3 +77,22 @@ export const amazonProductBrowseNodesQuery = gql`
   }
 `;
 
+export const amazonChildRemoteProductsQuery = gql`
+  query AmazonChildRemoteProducts($remoteParentProductId: GlobalID!) {
+    amazonProducts(
+      filters: { remoteParentProduct: { id: { exact: $remoteParentProductId } } }
+    ) {
+      edges {
+        node {
+          id
+          localInstance {
+            id
+            name
+            sku
+          }
+        }
+      }
+    }
+  }
+`;
+


### PR DESCRIPTION
## Summary
- add a query for fetching Amazon child remote products and load variation validation issues through it
- add a dedicated Amazon product issues query and use it to populate variation validation issues in the Amazon product tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d161d110d8832e8a0e251dc6af6328

## Summary by Sourcery

Fetch variation validation issues via dedicated GraphQL queries in the Amazon product tab

New Features:
- Add amazonChildRemoteProductsQuery to retrieve child remote products by parent ID
- Add amazonProductIssuesQuery to fetch Amazon product validation issues
- Update AmazonView to use the new queries to dynamically load variation validation issues

Enhancements:
- Replace computed filter logic with an asynchronous fetch function and reactive watcher for variation issues
- Introduce a request token mechanism to prevent race conditions and stale data