### PR TITLE
Enhance variation image bulk editing controls

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1006,6 +1006,10 @@
           },
           "labels": {
             "noImage": "No image"
+          },
+          "buttons": {
+            "moveLeft": "Move image left",
+            "moveRight": "Move image right"
           }
         },
         "prices": {


### PR DESCRIPTION
## Summary
- ensure each variation row always keeps a main image by defaulting back to the first slot after edits
- add hover controls for reordering images and style empty slots with an add placeholder icon
- translate the new controls and keep main-image state consistent across load, edit, and delete actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d166083a70832e8ce48e452caaba3d

## Summary by Sourcery

Enhance variation image bulk editing by adding reorder controls, placeholder icons for empty slots, and automatic main-image assignment

New Features:
- Add hover controls for reordering variation images with move left/right buttons
- Style empty image slots with an add placeholder icon

Enhancements:
- Automatically reassign the main image to the first available slot after load, edits, deletes, and moves
- Centralize image column index parsing to keep main-image state consistent across interactions

Documentation:
- Add translation keys for new hover controls and move buttons