### PR TITLE
Ensure Amazon variation issues prop updates via ref

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonIssuesSection.vue
+++ b/src/core/products/products/product-show/containers/tabs/amazon/components/AmazonIssuesSection.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Icon } from '../../../../../../../../shared/components/atoms/icon';
 import { Link } from '../../../../../../../../shared/components/atoms/link';
@@ -28,6 +29,15 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+
+const variationValidationIssues = ref<VariationValidationIssues[]>(props.variationValidationIssues ?? []);
+
+watch(
+  () => props.variationValidationIssues,
+  (newVariationValidationIssues) => {
+    variationValidationIssues.value = newVariationValidationIssues ?? [];
+  }
+);
 
 const formatDate = (dateString?: string | null) => {
   if (!dateString) return '-';


### PR DESCRIPTION
## Summary
- wrap the variation validation issues prop in a local ref
- watch the prop to keep the local ref in sync when the prop changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d16abdd03c832ea5d26876ba27eedf

## Summary by Sourcery

Wrap the variationValidationIssues prop in a local ref and add a watcher to keep it in sync when the prop changes

Enhancements:
- Introduce a local ref for variationValidationIssues to enable reactivity
- Add a watch on the variationValidationIssues prop to update the local ref on prop changes