### PR TITLE
Add ctrl+arrow shortcut for variation image navigation

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-images-bulk-edit/VariationsImagesBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-images-bulk-edit/VariationsImagesBulkEdit.vue
@@ -227,6 +227,19 @@ const moveImage = (rowIndex: number, columnIndex: number, direction: -1 | 1) => 
   ensureRowHasMainImage(row);
 };
 
+const handleImageCtrlArrow = (
+  rowIndex: number,
+  columnKey: string,
+  direction: 'left' | 'right'
+) => {
+  const columnIndex = parseImageColumnKey(columnKey);
+  if (columnIndex === null) {
+    return false;
+  }
+  moveImage(rowIndex, columnIndex, direction === 'left' ? -1 : 1);
+  return true;
+};
+
 const fetchVariations = async (policy: FetchPolicy = 'cache-first') => {
   const isBundle = parentProductType.value === ProductType.Bundle;
   const query = isBundle ? bundleVariationsQuery : configurableVariationsQuery;
@@ -478,6 +491,7 @@ defineExpose({ hasUnsavedChanges });
       :set-cell-value="setMatrixCellValue"
       :clone-cell-value="cloneMatrixCellValue"
       :clear-cell-value="clearMatrixCellValue"
+      :on-ctrl-arrow="handleImageCtrlArrow"
       @save="save"
     >
       <template #cell="{ row, column, rowIndex }">

--- a/src/shared/components/organisms/matrix-editor/MatrixEditor.vue
+++ b/src/shared/components/organisms/matrix-editor/MatrixEditor.vue
@@ -26,6 +26,7 @@ const props = withDefaults(
     setCellValue: (rowIndex: number, columnKey: string, value: any) => void
     cloneCellValue: (fromRow: number, toRow: number, columnKey: string) => void
     clearCellValue: (rowIndex: number, columnKey: string) => void
+    onCtrlArrow?: (rowIndex: number, columnKey: string, direction: 'left' | 'right') => boolean | void
   }>(),
   {
     rowKey: 'id',
@@ -403,6 +404,20 @@ const handleKeydown = (event: KeyboardEvent) => {
   const { row, col } = selectedCell.value
   if (row === null || col === null) return
   if (!rows.value[row]) return
+
+  if (
+    (event.ctrlKey || event.metaKey) &&
+    (event.key === 'ArrowLeft' || event.key === 'ArrowRight')
+  ) {
+    if (props.onCtrlArrow) {
+      const direction = event.key === 'ArrowLeft' ? 'left' : 'right'
+      const handled = props.onCtrlArrow(row, col, direction)
+      if (handled) {
+        event.preventDefault()
+        return
+      }
+    }
+  }
 
   if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c') {
     if (isEditableColumn(col)) {


### PR DESCRIPTION
## Summary
- add optional ctrl+arrow handler support to MatrixEditor so individual consumers can react to the shortcut
- wire variations images bulk editor to move images left or right when ctrl+arrow is pressed on an image cell

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d16eb0c568832ebb55e6afd894eb18