### PR TITLE
Add bulk variation image upload controls

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/media/containers/upload-media-modal/UploadMediaModal.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/upload-media-modal/UploadMediaModal.vue
@@ -12,7 +12,13 @@ import { processGraphQLErrors } from "../../../../../../../../../shared/utils";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 
 
-const props = defineProps<{ modelValue: boolean; productId: string; ids: any[] }>();
+const props = withDefaults(
+  defineProps<{ modelValue: boolean; productId?: string; ids?: any[]; linkOnSelect?: boolean }>(),
+  {
+    ids: () => [],
+    linkOnSelect: true,
+  }
+);
 const emit = defineEmits(['update:modelValue', 'entries-created']);
 const localShowModal = ref(props.modelValue);
 
@@ -38,6 +44,11 @@ const closeModal = () => {
 };
 
 const handleMediaAssign = async (media) => {
+  if (!props.linkOnSelect || !props.productId) {
+    emit('entries-created', media);
+    closeModal();
+    return;
+  }
 
   const variables = {
     product: { id: props.productId},
@@ -48,7 +59,7 @@ const handleMediaAssign = async (media) => {
       mutation: createMediaProductThroughMutation,
       variables: { data: variables }
     });
-    emit('entries-created')
+    emit('entries-created', data?.createMediaProductThrough ?? media)
     console.log('Linking success:', data);
   } catch (error) {
     const validationErrors = processGraphQLErrors(error, t);

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1002,12 +1002,16 @@
         },
         "images": {
           "columns": {
+            "upload": "Upload",
             "image": "Image #{index}"
           },
           "labels": {
             "noImage": "No image"
           },
           "buttons": {
+            "openUploadMenu": "Add images",
+            "uploadNew": "Upload new",
+            "addExisting": "Add from existing",
             "moveLeft": "Move image left",
             "moveRight": "Move image right"
           }


### PR DESCRIPTION
## Summary
- add an upload column and modal-driven actions to the variations bulk image editor
- support deferred product linking and single-upload mode in shared media selection modals
- add translations for the new variation image controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1768679d8832e9ac05950f9c0fa99

## Summary by Sourcery

Improve the variations bulk image editor by adding an upload column with actions to upload or select existing images, support single- and multi-upload modes, show image type labels, and update media modals for deferred linking and single-upload behavior

New Features:
- Add an upload column with modal-driven actions to the variations bulk image editor
- Integrate media modals for inline uploading of new images and selecting existing media in the bulk editor
- Support assigning uploaded or selected images to specific or next-available variation slots in single- or multi-upload modes
- Display image type labels (pack shot and mood shot) within the bulk editor

Enhancements:
- Enable deferred product linking via a linkOnSelect flag in the media selection modal
- Extend the shared images modal to enforce single-upload behavior and restrict additional uploads or URL entries when in single-upload mode
- Track upload source and imageType in variation image slots to distinguish newly uploaded media from existing assets

Documentation:
- Add translations for the new variation image controls