### PR TITLE
Improve variation image bulk edit UX

### DIFF
--- a/src/shared/api/mutations/media.js
+++ b/src/shared/api/mutations/media.js
@@ -196,8 +196,8 @@ export const createMediaProductThroughMutation = gql`
 `;
 
 export const createMediaProductThroughsMutation = gql`
-  mutation createMediaProductThroughs($data: [MediaProductThroughInput!]!) {
-    createMediaProductThroughs(data: $data) {
+  mutation createMediaproducthroughs($data: [MediaProductThroughInput!]!) {
+    createMediaproducthroughs(data: $data) {
       id
       media {
         id


### PR DESCRIPTION
## Summary
- expand variation image placeholders with a toggleable action tray and larger, non-cropping previews
- highlight unsaved variation images and refine upload controls for a lighter footprint
- fix the create media product throughs mutation name to match the GraphQL schema

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d180c3af74832ebfe2f062150a7e2c