### PR TITLE
Add insertable image columns in variations matrix

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-images-bulk-edit/VariationsImagesBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-images-bulk-edit/VariationsImagesBulkEdit.vue
@@ -94,6 +94,8 @@ const imageColumns = computed<MatrixColumn[]>(() =>
     label: t('products.products.variations.images.columns.image', { index: index + 1 }),
     editable: true,
     initialWidth: 200,
+    beforeInsert: () => insertImageColumn(index),
+    afterInsert: () => insertImageColumn(index + 1),
   }))
 );
 
@@ -141,6 +143,18 @@ const ensureRowHasMainImage = (row: VariationRow) => {
   const firstImage = row.images[firstImageIndex];
   if (firstImage) {
     firstImage.isMainImage = true;
+  }
+};
+
+const insertImageColumn = (insertIndex: number) => {
+  variations.value.forEach((row) => {
+    while (row.images.length < insertIndex) {
+      row.images.push(null);
+    }
+    row.images.splice(insertIndex, 0, null);
+  });
+  if (expandedPlaceholder.value) {
+    closePlaceholder();
   }
 };
 

--- a/src/shared/components/organisms/matrix-editor/types.ts
+++ b/src/shared/components/organisms/matrix-editor/types.ts
@@ -7,6 +7,8 @@ export interface MatrixColumn {
   iconColorClass?: string
   initialWidth?: number
   valueType?: string
+  beforeInsert?: () => void
+  afterInsert?: () => void
 }
 
 export interface MatrixEditorExpose {


### PR DESCRIPTION
## Summary
- add insert-column hooks to MatrixEditor headers
- allow Variations images matrix to insert empty image columns between existing ones

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d18c1ee5e8832e93fffd4538a26fd3