### PR TITLE
feat(products): add variations content bulk edit tab

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
@@ -9,6 +9,7 @@ import { Icon } from "../../../../../../../shared/components/atoms/icon";
 import VariationsList from "./containers/variations-list/VariationsList.vue";
 import VariationCreate from "./containers/variation-create/VariationCreate.vue";
 import VariationsBulkEdit from "./containers/variations-bulk-edit/VariationsBulkEdit.vue";
+import VariationsContentBulkEdit from "./containers/variations-content-bulk-edit/VariationsContentBulkEdit.vue";
 import VariationsPricesBulkEdit from "./containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue";
 import VariationsImagesBulkEdit from "./containers/variations-images-bulk-edit/VariationsImagesBulkEdit.vue";
 import { useI18n } from 'vue-i18n';
@@ -19,13 +20,17 @@ const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 const ids = ref([]);
 const refetchNeeded = ref(false);
-type Mode = 'list' | 'editProperties' | 'editPrices' | 'editImages';
+type Mode = 'list' | 'editContent' | 'editProperties' | 'editPrices' | 'editImages';
 const mode = ref<Mode>('list');
 const bulkEditRef = ref<InstanceType<typeof VariationsBulkEdit> | null>(null);
+const contentEditRef = ref<InstanceType<typeof VariationsContentBulkEdit> | null>(null);
 const priceEditRef = ref<InstanceType<typeof VariationsPricesBulkEdit> | null>(null);
 const imageEditRef = ref<InstanceType<typeof VariationsImagesBulkEdit> | null>(null);
 
 const getUnsavedChangesForMode = (currentMode: Mode) => {
+  if (currentMode === 'editContent') {
+    return contentEditRef.value?.hasUnsavedChanges ?? false;
+  }
   if (currentMode === 'editProperties') {
     return bulkEditRef.value?.hasUnsavedChanges ?? false;
   }
@@ -41,12 +46,14 @@ const getUnsavedChangesForMode = (currentMode: Mode) => {
 const hasUnsavedChanges = computed(
   () =>
     (bulkEditRef.value?.hasUnsavedChanges ?? false) ||
+    (contentEditRef.value?.hasUnsavedChanges ?? false) ||
     (priceEditRef.value?.hasUnsavedChanges ?? false) ||
     (imageEditRef.value?.hasUnsavedChanges ?? false)
 );
 
 const tabs = computed<{ key: Mode; label: string; icon: string }[]>(() => [
   { key: 'list', label: t('products.products.variations.tabs.list'), icon: 'list' },
+  { key: 'editContent', label: t('products.products.variations.tabs.content'), icon: 'file-lines' },
   { key: 'editProperties', label: t('products.products.tabs.properties'), icon: 'screwdriver-wrench' },
   { key: 'editPrices', label: t('products.products.tabs.prices'), icon: 'coins' },
   { key: 'editImages', label: t('products.products.variations.tabs.images'), icon: 'images' },
@@ -156,6 +163,9 @@ defineExpose({ hasUnsavedChanges });
             <div v-if="product.type !== ProductType.Alias" class="mt-2">
               <VariationCreate :product="product" :variation-ids="ids" @variation-added="handleVariationAdded" />
             </div>
+          </template>
+          <template v-else-if="mode === 'editContent'">
+            <VariationsContentBulkEdit ref="contentEditRef" :product="product" />
           </template>
           <template v-else-if="mode === 'editProperties'">
             <VariationsBulkEdit ref="bulkEditRef" :product="product" />

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-content-bulk-edit/VariationsContentBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-content-bulk-edit/VariationsContentBulkEdit.vue
@@ -1,0 +1,889 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch, nextTick } from 'vue';
+import { useI18n } from 'vue-i18n';
+import Swal from 'sweetalert2';
+import type { FetchPolicy } from '@apollo/client';
+import { Product } from '../../../../../../configs';
+import { Icon } from '../../../../../../../../../shared/components/atoms/icon';
+import { Button } from '../../../../../../../../../shared/components/atoms/button';
+import { TextInput } from '../../../../../../../../../shared/components/atoms/input-text';
+import { TextHtmlEditor } from '../../../../../../../../../shared/components/atoms/input-text-html-editor';
+import { Selector } from '../../../../../../../../../shared/components/atoms/selector';
+import { Modal } from '../../../../../../../../../shared/components/atoms/modal';
+import { Card } from '../../../../../../../../../shared/components/atoms/card';
+import MatrixEditor from '../../../../../../../../../shared/components/organisms/matrix-editor/MatrixEditor.vue';
+import type { MatrixColumn, MatrixEditorExpose } from '../../../../../../../../../shared/components/organisms/matrix-editor/types';
+import ProductContentPreview from '../../../content/ProductContentPreview.vue';
+import { Toast } from '../../../../../../../../../shared/modules/toast';
+import { shortenText } from '../../../../../../../../../shared/utils';
+import apolloClient from '../../../../../../../../../../apollo-client';
+import { ProductType } from '../../../../../../../../../shared/utils/constants';
+import {
+  bundleVariationsQuery,
+  configurableVariationsQuery,
+  getProductContentByLanguageAndChannelQuery,
+  getProductContentByLanguageAndDefaultQuery,
+  productTranslationBulletPointsQuery,
+} from '../../../../../../../../../shared/api/queries/products.js';
+import {
+  createProductTranslationMutation,
+  updateProductTranslationMutation,
+  createProductTranslationBulletPointsMutation,
+  updateProductTranslationBulletPointMutation,
+  deleteProductTranslationBulletPointsMutation,
+} from '../../../../../../../../../shared/api/mutations/products.js';
+import { translationLanguagesQuery } from '../../../../../../../../../shared/api/queries/languages.js';
+import { integrationsQuery } from '../../../../../../../../../shared/api/queries/integrations.js';
+
+interface VariationNode {
+  id: string;
+  variation: {
+    id: string;
+    sku: string;
+    name: string;
+    active: boolean;
+  };
+}
+
+interface TranslationData {
+  id: string | null;
+  name: string;
+  shortDescription: string;
+  description: string;
+  urlKey: string;
+}
+
+interface BulletPoint {
+  id: string | null;
+  text: string;
+  sortOrder: number;
+}
+
+interface VariationContentRow {
+  id: string;
+  variation: VariationNode['variation'];
+  translation: TranslationData;
+  defaultTranslation: TranslationData | null;
+  bulletPoints: BulletPoint[];
+  defaultBulletPoints: BulletPoint[];
+}
+
+const props = defineProps<{ product: Product }>();
+const { t } = useI18n();
+
+const matrixRef = ref<MatrixEditorExpose | null>(null);
+const variations = ref<VariationContentRow[]>([]);
+const originalVariations = ref<VariationContentRow[]>([]);
+const loading = ref(false);
+const saving = ref(false);
+const languages = ref<any[]>([]);
+const language = ref<string | null>(null);
+const previousLanguage = ref<string | null>(null);
+const salesChannels = ref<any[]>([]);
+const currentSalesChannel = ref<'default' | string>('default');
+const previousSalesChannel = ref<'default' | string>('default');
+const skipLanguageWatch = ref(false);
+const skipChannelWatch = ref(false);
+const previewRow = ref<VariationContentRow | null>(null);
+const previewVisible = ref(false);
+
+const htmlModal = reactive({
+  visible: false,
+  rowIndex: -1,
+  field: '' as 'shortDescription' | 'description',
+  value: '<p><br></p>',
+});
+
+const shortDescriptionToolbarOptions = [
+  ['bold', 'underline'],
+  [{ list: 'bullet' }],
+  ['clean'],
+];
+
+const emptyHtml = '<p><br></p>';
+
+const createEmptyTranslation = (): TranslationData => ({
+  id: null,
+  name: '',
+  shortDescription: emptyHtml,
+  description: emptyHtml,
+  urlKey: '',
+});
+
+const normalizedHtml = (value: string | null | undefined) => {
+  if (!value) return emptyHtml;
+  const trimmed = value.trim();
+  if (!trimmed) return emptyHtml;
+  return trimmed;
+};
+
+const isAlias = computed(() => props.product.type === ProductType.Alias);
+const parentProduct = computed(() => (isAlias.value ? props.product.aliasParentProduct : props.product));
+const parentProductType = computed(() => parentProduct.value.type);
+
+const matrixRefetch = async () => {
+  matrixRef.value?.resetHistory(variations.value);
+};
+
+const bulletColumnCount = computed(() => {
+  const maxColumns = variations.value.reduce((max, row) => Math.max(max, row.bulletPoints.length), 0);
+  return Math.max(maxColumns, 1);
+});
+
+const salesChannelOptions = computed(() => [
+  {
+    name: t('products.products.variations.content.selectors.defaultChannel'),
+    value: 'default',
+  },
+  ...salesChannels.value.map((channel: any) => ({
+    name: channel.name || channel.hostname || channel.type || '',
+    value: channel.id,
+  })),
+]);
+
+const baseColumns = computed<MatrixColumn[]>(() => [
+  { key: 'sku', label: t('shared.labels.sku'), sticky: true, editable: false },
+  { key: 'name', label: t('shared.labels.name'), editable: false },
+  { key: 'active', label: t('shared.labels.active'), editable: false, initialWidth: 60 },
+  { key: 'preview', label: t('products.products.variations.content.columns.preview'), editable: false, initialWidth: 80 },
+  { key: 'translationName', label: t('products.products.variations.content.columns.productName'), editable: true, initialWidth: 220 },
+  { key: 'shortDescription', label: t('products.products.variations.content.columns.shortDescription'), editable: true, initialWidth: 240 },
+  { key: 'description', label: t('products.products.variations.content.columns.description'), editable: true, initialWidth: 240 },
+  { key: 'urlKey', label: t('products.products.variations.content.columns.urlKey'), editable: true, initialWidth: 200 },
+]);
+
+const bulletColumns = computed<MatrixColumn[]>(() =>
+  Array.from({ length: bulletColumnCount.value }, (_, index) => ({
+    key: `bullet-${index}`,
+    label: t('products.products.variations.content.columns.bullet', { index: index + 1 }),
+    editable: true,
+    initialWidth: 220,
+    beforeInsert: () => insertBulletColumn(index),
+    afterInsert: () => insertBulletColumn(index + 1),
+  }))
+);
+
+const columns = computed<MatrixColumn[]>(() => [...baseColumns.value, ...bulletColumns.value]);
+
+const hasChanges = computed(
+  () => JSON.stringify(variations.value) !== JSON.stringify(originalVariations.value)
+);
+
+const hasUnsavedChanges = hasChanges;
+
+const askDiscardChanges = async () => {
+  if (!hasChanges.value) return true;
+  const res = await Swal.fire({
+    icon: 'warning',
+    text: t('products.products.messages.unsavedChanges'),
+    showCancelButton: true,
+    confirmButtonText: t('shared.button.cancel'),
+    cancelButtonText: t('shared.button.leaveTab'),
+  });
+  return res.dismiss === Swal.DismissReason.cancel;
+};
+
+const insertBulletColumn = (index: number) => {
+  variations.value.forEach((row) => {
+    const insertionIndex = Math.min(index + 1, row.bulletPoints.length);
+    row.bulletPoints.splice(insertionIndex, 0, { id: null, text: '', sortOrder: insertionIndex });
+    row.bulletPoints.forEach((bp, idx) => {
+      bp.sortOrder = idx;
+    });
+  });
+};
+
+const fetchLanguages = async () => {
+  const { data } = await apolloClient.query({ query: translationLanguagesQuery, fetchPolicy: 'cache-first' });
+  languages.value = data?.translationLanguages?.languages || [];
+  const defaultCode = data?.translationLanguages?.defaultLanguage?.code || null;
+  if (!language.value) {
+    language.value = defaultCode;
+    previousLanguage.value = defaultCode;
+  }
+};
+
+const loadSalesChannels = async () => {
+  try {
+    const { data } = await apolloClient.query({ query: integrationsQuery, fetchPolicy: 'cache-first' });
+    salesChannels.value = data?.integrations?.edges?.map((edge: any) => edge.node)?.filter((node: any) => node.type) || [];
+  } catch (error) {
+    console.error('Failed to load sales channels', error);
+    salesChannels.value = [];
+  }
+};
+
+const fetchBulletPoints = async (translationId: string | null, policy: FetchPolicy = 'cache-first') => {
+  if (!translationId) return [] as BulletPoint[];
+  const { data } = await apolloClient.query({
+    query: productTranslationBulletPointsQuery,
+    variables: { filter: { productTranslation: { id: { exact: translationId } } } },
+    fetchPolicy: policy,
+  });
+  return (
+    data?.productTranslationBulletPoints?.edges?.map((edge: any, idx: number) => ({
+      id: edge.node.id || null,
+      text: edge.node.text || '',
+      sortOrder: edge.node.sortOrder ?? idx,
+    })) || []
+  ).sort((a, b) => a.sortOrder - b.sortOrder);
+};
+
+const fetchTranslation = async (variationId: string, policy: FetchPolicy = 'network-only') => {
+  if (!language.value) {
+    return {
+      translation: createEmptyTranslation(),
+      defaultTranslation: null,
+      bulletPoints: [] as BulletPoint[],
+      defaultBulletPoints: [] as BulletPoint[],
+    };
+  }
+
+  const selectedChannel = currentSalesChannel.value;
+  let translationNode: any = null;
+  let defaultNode: any = null;
+
+  if (selectedChannel === 'default') {
+    const { data } = await apolloClient.query({
+      query: getProductContentByLanguageAndDefaultQuery,
+      variables: { productId: variationId, languageCode: language.value },
+      fetchPolicy: policy,
+    });
+    translationNode = data?.productTranslations?.edges?.[0]?.node || null;
+  } else {
+    const { data } = await apolloClient.query({
+      query: getProductContentByLanguageAndChannelQuery,
+      variables: {
+        productId: variationId,
+        languageCode: language.value,
+        salesChannelId: selectedChannel,
+      },
+      fetchPolicy: policy,
+    });
+    translationNode = data?.productTranslations?.edges?.[0]?.node || null;
+    const { data: defData } = await apolloClient.query({
+      query: getProductContentByLanguageAndDefaultQuery,
+      variables: { productId: variationId, languageCode: language.value },
+      fetchPolicy: policy,
+    });
+    defaultNode = defData?.productTranslations?.edges?.[0]?.node || null;
+  }
+
+  const translation: TranslationData = {
+    id: translationNode?.id ?? null,
+    name: translationNode?.name || '',
+    shortDescription: normalizedHtml(translationNode?.shortDescription),
+    description: normalizedHtml(translationNode?.description),
+    urlKey: translationNode?.urlKey || '',
+  };
+
+  const defaultTranslation = defaultNode
+    ? {
+        id: defaultNode.id ?? null,
+        name: defaultNode.name || '',
+        shortDescription: normalizedHtml(defaultNode.shortDescription),
+        description: normalizedHtml(defaultNode.description),
+        urlKey: defaultNode.urlKey || '',
+      }
+    : null;
+
+  const bulletPoints = await fetchBulletPoints(translation.id, policy);
+  const defaultBulletPoints = selectedChannel === 'default' ? bulletPoints : await fetchBulletPoints(defaultTranslation?.id ?? null, policy);
+
+  return {
+    translation,
+    defaultTranslation,
+    bulletPoints,
+    defaultBulletPoints,
+  };
+};
+
+const fetchVariations = async (policy: FetchPolicy = 'cache-first') => {
+  const isBundle = parentProductType.value === ProductType.Bundle;
+  const query = isBundle ? bundleVariationsQuery : configurableVariationsQuery;
+  const key = isBundle ? 'bundleVariations' : 'configurableVariations';
+  const pageSize = 100;
+  let after: string | null = null;
+  const nodes: VariationNode[] = [];
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const { data } = await apolloClient.query({
+      query,
+      variables: {
+        first: pageSize,
+        after,
+        filter: { parent: { id: { exact: parentProduct.value.id } } },
+      },
+      fetchPolicy: policy,
+    });
+    const connection = data?.[key];
+    const edges = connection?.edges ?? [];
+    edges.forEach((edge: any) => {
+      nodes.push({
+        id: edge.node.variation.id,
+        variation: {
+          id: edge.node.variation.id,
+          sku: edge.node.variation.sku,
+          name: edge.node.variation.name,
+          active: edge.node.variation.active,
+        },
+      });
+    });
+    hasNextPage = connection?.pageInfo?.hasNextPage ?? false;
+    after = connection?.pageInfo?.endCursor ?? null;
+    if (!after) break;
+  }
+
+  return nodes;
+};
+
+const loadData = async (policy: FetchPolicy = 'network-only') => {
+  if (!language.value) return;
+  loading.value = true;
+  try {
+    const variationNodes = await fetchVariations(policy);
+    const rows = await Promise.all(
+      variationNodes.map(async (node) => {
+        const { translation, defaultTranslation, bulletPoints, defaultBulletPoints } = await fetchTranslation(
+          node.variation.id,
+          policy
+        );
+        return {
+          id: node.variation.id,
+          variation: node.variation,
+          translation,
+          defaultTranslation,
+          bulletPoints,
+          defaultBulletPoints,
+        } as VariationContentRow;
+      })
+    );
+    variations.value = rows;
+    originalVariations.value = JSON.parse(JSON.stringify(rows));
+    await nextTick();
+    matrixRefetch();
+  } catch (error) {
+    console.error('Failed to load variation content', error);
+    Toast.error(t('shared.alert.toast.generalError'));
+  } finally {
+    loading.value = false;
+  }
+};
+
+const getMatrixCellValue = (rowIndex: number, key: string) => {
+  const row = variations.value[rowIndex];
+  if (!row) return null;
+  switch (key) {
+    case 'sku':
+      return row.variation.sku;
+    case 'name':
+      return row.variation.name;
+    case 'active':
+      return row.variation.active;
+    case 'preview':
+      return null;
+    case 'translationName':
+      return row.translation.name;
+    case 'shortDescription':
+      return row.translation.shortDescription;
+    case 'description':
+      return row.translation.description;
+    case 'urlKey':
+      return row.translation.urlKey;
+    default:
+      if (key.startsWith('bullet-')) {
+        const index = parseInt(key.split('-')[1], 10);
+        return row.bulletPoints[index]?.text || '';
+      }
+  }
+  return null;
+};
+
+const ensureBullet = (row: VariationContentRow, index: number) => {
+  while (row.bulletPoints.length <= index) {
+    row.bulletPoints.push({ id: null, text: '', sortOrder: row.bulletPoints.length });
+  }
+  return row.bulletPoints[index];
+};
+
+const setMatrixCellValue = (rowIndex: number, key: string, value: any) => {
+  const row = variations.value[rowIndex];
+  if (!row) return;
+  if (key === 'translationName') {
+    row.translation.name = value ?? '';
+    return;
+  }
+  if (key === 'shortDescription') {
+    row.translation.shortDescription = value ?? emptyHtml;
+    return;
+  }
+  if (key === 'description') {
+    row.translation.description = value ?? emptyHtml;
+    return;
+  }
+  if (key === 'urlKey') {
+    row.translation.urlKey = value ?? '';
+    return;
+  }
+  if (key.startsWith('bullet-')) {
+    const index = parseInt(key.split('-')[1], 10);
+    const bullet = ensureBullet(row, index);
+    bullet.text = value ?? '';
+    bullet.sortOrder = index;
+  }
+};
+
+const cloneMatrixCellValue = (from: number, to: number, key: string) => {
+  const source = variations.value[from];
+  const target = variations.value[to];
+  if (!source || !target) return;
+  if (key === 'translationName') {
+    target.translation.name = source.translation.name;
+    return;
+  }
+  if (key === 'shortDescription') {
+    target.translation.shortDescription = source.translation.shortDescription;
+    return;
+  }
+  if (key === 'description') {
+    target.translation.description = source.translation.description;
+    return;
+  }
+  if (key === 'urlKey') {
+    target.translation.urlKey = source.translation.urlKey;
+    return;
+  }
+  if (key.startsWith('bullet-')) {
+    const index = parseInt(key.split('-')[1], 10);
+    const value = source.bulletPoints[index]?.text || '';
+    const bullet = ensureBullet(target, index);
+    bullet.text = value;
+  }
+};
+
+const clearMatrixCellValue = (rowIndex: number, key: string) => {
+  const row = variations.value[rowIndex];
+  if (!row) return;
+  if (key === 'translationName') {
+    row.translation.name = '';
+    return;
+  }
+  if (key === 'shortDescription') {
+    row.translation.shortDescription = emptyHtml;
+    return;
+  }
+  if (key === 'description') {
+    row.translation.description = emptyHtml;
+    return;
+  }
+  if (key === 'urlKey') {
+    row.translation.urlKey = '';
+    return;
+  }
+  if (key.startsWith('bullet-')) {
+    const index = parseInt(key.split('-')[1], 10);
+    if (row.bulletPoints[index]) {
+      row.bulletPoints[index].text = '';
+    }
+  }
+};
+
+const openPreview = (row: VariationContentRow) => {
+  previewRow.value = row;
+  previewVisible.value = true;
+};
+
+const closePreview = () => {
+  previewVisible.value = false;
+  previewRow.value = null;
+};
+
+const openHtmlModal = (rowIndex: number, field: 'shortDescription' | 'description') => {
+  htmlModal.rowIndex = rowIndex;
+  htmlModal.field = field;
+  const row = variations.value[rowIndex];
+  if (!row) return;
+  htmlModal.value = field === 'shortDescription' ? row.translation.shortDescription : row.translation.description;
+  htmlModal.visible = true;
+};
+
+const closeHtmlModal = () => {
+  htmlModal.visible = false;
+  htmlModal.rowIndex = -1;
+  htmlModal.field = 'shortDescription';
+  htmlModal.value = emptyHtml;
+};
+
+const saveHtmlModal = () => {
+  if (htmlModal.rowIndex < 0) {
+    closeHtmlModal();
+    return;
+  }
+  setMatrixCellValue(htmlModal.rowIndex, htmlModal.field, htmlModal.value || emptyHtml);
+  closeHtmlModal();
+};
+
+const handleLanguageChange = async (newLang: string | null) => {
+  if (skipLanguageWatch.value) return;
+  if (!newLang) return;
+  if (!previousLanguage.value) {
+    previousLanguage.value = newLang;
+    return;
+  }
+  if (newLang === previousLanguage.value) return;
+  const proceed = await askDiscardChanges();
+  if (!proceed) {
+    skipLanguageWatch.value = true;
+    language.value = previousLanguage.value;
+    await nextTick();
+    skipLanguageWatch.value = false;
+    return;
+  }
+  previousLanguage.value = newLang;
+  await loadData('network-only');
+};
+
+const handleSalesChannelChange = async (newChannel: 'default' | string) => {
+  if (skipChannelWatch.value) return;
+  if (!previousSalesChannel.value) {
+    previousSalesChannel.value = newChannel;
+    return;
+  }
+  if (newChannel === previousSalesChannel.value) return;
+  const proceed = await askDiscardChanges();
+  if (!proceed) {
+    skipChannelWatch.value = true;
+    currentSalesChannel.value = previousSalesChannel.value;
+    await nextTick();
+    skipChannelWatch.value = false;
+    return;
+  }
+  previousSalesChannel.value = newChannel;
+  await loadData('network-only');
+};
+
+watch(language, handleLanguageChange);
+watch(currentSalesChannel, handleSalesChannelChange);
+
+const shouldCreateTranslation = (row: VariationContentRow) => {
+  const translation = row.translation;
+  const hasFields =
+    !!translation.name ||
+    normalizedHtml(translation.shortDescription) !== emptyHtml ||
+    normalizedHtml(translation.description) !== emptyHtml ||
+    !!translation.urlKey;
+  const hasBullets = row.bulletPoints.some((bp) => bp.text.trim());
+  return hasFields || hasBullets;
+};
+
+const computeBulletChanges = (current: BulletPoint[], original: BulletPoint[]) => {
+  const originalMap = new Map<string, BulletPoint>();
+  original
+    .filter((bp) => bp.id)
+    .forEach((bp) => {
+      if (bp.id) originalMap.set(bp.id, bp);
+    });
+
+  const toCreate = current
+    .filter((bp) => !bp.id && bp.text.trim())
+    .map((bp, index) => ({ text: bp.text, sortOrder: bp.sortOrder ?? index }));
+
+  const toUpdate = current
+    .filter((bp) => {
+      if (!bp.id) return false;
+      const orig = originalMap.get(bp.id);
+      if (!orig) return false;
+      const trimmed = bp.text.trim();
+      if (!trimmed) return false;
+      return trimmed !== orig.text || (bp.sortOrder ?? 0) !== (orig.sortOrder ?? 0);
+    })
+    .map((bp) => ({ id: bp.id!, text: bp.text, sortOrder: bp.sortOrder ?? 0 }));
+
+  const toDeleteIds = new Set<string>();
+  original
+    .filter((bp) => bp.id)
+    .forEach((bp) => {
+      const currentMatch = current.find((item) => item.id === bp.id);
+      if (!currentMatch || !currentMatch.text.trim()) {
+        if (bp.id) toDeleteIds.add(bp.id);
+      }
+    });
+
+  current
+    .filter((bp) => bp.id && !bp.text.trim())
+    .forEach((bp) => {
+      if (bp.id) toDeleteIds.add(bp.id);
+    });
+
+  const toDelete = Array.from(toDeleteIds).map((id) => ({ id }));
+
+  return { toCreate, toUpdate, toDelete };
+};
+
+const save = async () => {
+  if (!hasChanges.value || saving.value) return;
+  if (!language.value) return;
+  saving.value = true;
+  try {
+    const selectedChannel = currentSalesChannel.value;
+    const operations: (() => Promise<void>)[] = [];
+
+    variations.value.forEach((row) => {
+      const original = originalVariations.value.find((orig) => orig.id === row.id);
+      const translationInput = {
+        name: row.translation.name,
+        shortDescription: normalizedHtml(row.translation.shortDescription),
+        description: normalizedHtml(row.translation.description),
+        urlKey: row.translation.urlKey,
+        product: { id: row.variation.id },
+        language: language.value,
+        salesChannel: selectedChannel === 'default' ? null : { id: selectedChannel },
+      } as any;
+
+      const translationChanged = !original ||
+        row.translation.name !== original.translation.name ||
+        normalizedHtml(row.translation.shortDescription) !== normalizedHtml(original.translation.shortDescription) ||
+        normalizedHtml(row.translation.description) !== normalizedHtml(original.translation.description) ||
+        (row.translation.urlKey || '') !== (original.translation.urlKey || '');
+
+      let translationId = row.translation.id;
+
+      if (translationId) {
+        if (translationChanged) {
+          operations.push(async () => {
+            await apolloClient.mutate({
+              mutation: updateProductTranslationMutation,
+              variables: { data: { id: translationId, ...translationInput } },
+            });
+          });
+        }
+      } else if (shouldCreateTranslation(row)) {
+        operations.push(async () => {
+          const { data } = await apolloClient.mutate({
+            mutation: createProductTranslationMutation,
+            variables: { data: translationInput },
+          });
+          translationId = data?.createProductTranslation?.id ?? null;
+          row.translation.id = translationId;
+        });
+      }
+
+      operations.push(async () => {
+        if (!translationId) return;
+        const originalBullets = original?.bulletPoints ?? [];
+        row.bulletPoints.forEach((bp, idx) => {
+          bp.sortOrder = idx;
+        });
+        const { toCreate, toUpdate, toDelete } = computeBulletChanges(row.bulletPoints, originalBullets);
+
+        if (toCreate.length) {
+          await apolloClient.mutate({
+            mutation: createProductTranslationBulletPointsMutation,
+            variables: {
+              data: toCreate.map((bp) => ({ ...bp, productTranslation: { id: translationId } })),
+            },
+          });
+        }
+
+        for (const updateData of toUpdate) {
+          await apolloClient.mutate({
+            mutation: updateProductTranslationBulletPointMutation,
+            variables: { data: updateData },
+          });
+        }
+
+        if (toDelete.length) {
+          await apolloClient.mutate({
+            mutation: deleteProductTranslationBulletPointsMutation,
+            variables: { data: toDelete },
+          });
+        }
+      });
+    });
+
+    for (const operation of operations) {
+      await operation();
+    }
+
+    Toast.success(t('products.products.variations.content.toast.saveSuccess'));
+    await loadData('network-only');
+  } catch (error) {
+    console.error('Failed to save variation content', error);
+    Toast.error(t('shared.alert.toast.generalError'));
+  } finally {
+    saving.value = false;
+  }
+};
+
+onMounted(async () => {
+  await Promise.all([fetchLanguages(), loadSalesChannels()]);
+  previousSalesChannel.value = currentSalesChannel.value;
+  if (language.value) {
+    await loadData('network-only');
+  }
+});
+
+defineExpose({ hasUnsavedChanges });
+</script>
+
+<template>
+  <div class="relative w-full min-w-0 variations-content-bulk-edit">
+    <MatrixEditor
+      ref="matrixRef"
+      v-model:rows="variations"
+      :columns="columns"
+      :loading="loading || saving"
+      :has-changes="hasChanges"
+      row-key="id"
+      :get-cell-value="getMatrixCellValue"
+      :set-cell-value="setMatrixCellValue"
+      :clone-cell-value="cloneMatrixCellValue"
+      :clear-cell-value="clearMatrixCellValue"
+      @save="save"
+    >
+      <template #toolbar-right>
+        <Selector
+          v-if="salesChannelOptions.length"
+          v-model="currentSalesChannel"
+          :options="salesChannelOptions"
+          class="w-48 mr-2"
+          :placeholder="t('products.products.variations.content.selectors.salesChannel')"
+          :removable="false"
+          labelBy="name"
+          valueBy="value"
+          filterable
+        />
+        <Selector
+          v-if="languages.length"
+          v-model="language"
+          :options="languages"
+          class="w-32"
+          :placeholder="t('products.translation.placeholders.language')"
+          :removable="false"
+          labelBy="name"
+          valueBy="code"
+          mandatory
+          filterable
+        />
+      </template>
+      <template #cell="{ row, column, rowIndex }">
+        <template v-if="column.key === 'name'">
+          <span class="block truncate" :title="row.variation.name">
+            {{ shortenText(row.variation.name, 32) }}
+          </span>
+        </template>
+        <template v-else-if="column.key === 'sku'">
+          <span class="block truncate" :title="row.variation.sku">
+            {{ row.variation.sku }}
+          </span>
+        </template>
+        <template v-else-if="column.key === 'active'">
+          <Icon v-if="row.variation.active" name="check-circle" class="text-green-500" />
+          <Icon v-else name="times-circle" class="text-red-500" />
+        </template>
+        <template v-else-if="column.key === 'preview'">
+          <Button class="btn btn-outline-primary btn-sm" @click="openPreview(row)">
+            <Icon name="eye" class="h-4 w-4" />
+          </Button>
+        </template>
+        <template v-else-if="column.key === 'translationName'">
+          <TextInput
+            :model-value="row.translation.name"
+            class="w-full"
+            @update:modelValue="(value) => setMatrixCellValue(rowIndex, column.key, value)"
+          />
+        </template>
+        <template v-else-if="column.key === 'shortDescription'">
+          <div class="relative cursor-pointer" @dblclick="openHtmlModal(rowIndex, 'shortDescription')">
+            <div class="border border-gray-300 p-1 h-16 flex justify-between items-center gap-2">
+              <div class="overflow-hidden break-words text-sm pr-6">
+                {{ shortenText(row.translation.shortDescription?.replace(/<[^>]+>/g, '') || '', 48) }}
+              </div>
+              <div class="flex items-center gap-2">
+                <Icon name="code" class="text-primary" />
+                <Icon name="maximize" class="text-gray-400 cursor-pointer" @click.stop="openHtmlModal(rowIndex, 'shortDescription')" />
+              </div>
+            </div>
+          </div>
+        </template>
+        <template v-else-if="column.key === 'description'">
+          <div class="relative cursor-pointer" @dblclick="openHtmlModal(rowIndex, 'description')">
+            <div class="border border-gray-300 p-1 h-24 flex justify-between items-start gap-2">
+              <div class="overflow-hidden break-words text-sm pr-6">
+                {{ shortenText(row.translation.description?.replace(/<[^>]+>/g, '') || '', 64) }}
+              </div>
+              <Icon name="maximize" class="text-gray-400 cursor-pointer" @click.stop="openHtmlModal(rowIndex, 'description')" />
+            </div>
+          </div>
+        </template>
+        <template v-else-if="column.key === 'urlKey'">
+          <TextInput
+            :model-value="row.translation.urlKey"
+            class="w-full"
+            @update:modelValue="(value) => setMatrixCellValue(rowIndex, column.key, value)"
+          />
+        </template>
+        <template v-else>
+          <TextInput
+            :model-value="row.bulletPoints[parseInt(column.key.split('-')[1], 10)]?.text || ''"
+            class="w-full"
+            @update:modelValue="(value) => setMatrixCellValue(rowIndex, column.key, value)"
+          />
+        </template>
+      </template>
+    </MatrixEditor>
+
+    <Modal v-model="previewVisible" @closed="closePreview">
+      <Card class="modal-content w-3/4 max-w-5xl">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-semibold">
+            {{ t('products.products.variations.content.previewModal.title') }}
+          </h3>
+          <Button class="btn btn-outline-dark" @click="closePreview">
+            {{ t('shared.button.close') }}
+          </Button>
+        </div>
+        <ProductContentPreview
+          v-if="previewRow"
+          :content="previewRow.translation"
+          :default-content="previewRow.defaultTranslation"
+          :current-channel="currentSalesChannel"
+          :channels="salesChannels"
+          :bullet-points="(previewRow.bulletPoints.some((bp) => bp.text.trim()) ? previewRow.bulletPoints : previewRow.defaultBulletPoints).filter((bp) => bp.text.trim())"
+        />
+      </Card>
+    </Modal>
+
+    <Modal v-model="htmlModal.visible" @closed="closeHtmlModal">
+      <Card class="modal-content w-3/4 max-w-4xl">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-semibold">
+            {{ htmlModal.field === 'shortDescription'
+              ? t('products.products.variations.content.modals.shortDescriptionTitle')
+              : t('products.products.variations.content.modals.descriptionTitle') }}
+          </h3>
+          <div class="flex gap-2">
+            <Button class="btn btn-outline-dark" @click="closeHtmlModal">
+              {{ t('shared.button.cancel') }}
+            </Button>
+            <Button class="btn btn-primary" @click="saveHtmlModal">
+              {{ t('shared.button.save') }}
+            </Button>
+          </div>
+        </div>
+        <TextHtmlEditor
+          v-model="htmlModal.value"
+          :toolbar-options="htmlModal.field === 'shortDescription' ? shortDescriptionToolbarOptions : undefined"
+          class="min-h-[320px]"
+        />
+      </Card>
+    </Modal>
+  </div>
+</template>
+
+<style scoped>
+.variations-content-bulk-edit :deep(.ql-editor) {
+  min-height: 220px;
+}
+</style>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -998,6 +998,7 @@
       "variations": {
         "tabs": {
           "list": "List",
+          "content": "Content",
           "images": "Images"
         },
         "images": {
@@ -1014,6 +1015,30 @@
             "addExisting": "Add existing",
             "moveLeft": "Move image left",
             "moveRight": "Move image right"
+          }
+        },
+        "content": {
+          "columns": {
+            "preview": "Preview",
+            "productName": "Product name",
+            "shortDescription": "Short description",
+            "description": "Description",
+            "urlKey": "URL key",
+            "bullet": "Bullet #{index}"
+          },
+          "selectors": {
+            "salesChannel": "Sales channel",
+            "defaultChannel": "Default"
+          },
+          "previewModal": {
+            "title": "Content preview"
+          },
+          "modals": {
+            "shortDescriptionTitle": "Edit short description",
+            "descriptionTitle": "Edit description"
+          },
+          "toast": {
+            "saveSuccess": "Variation content updated successfully."
           }
         },
         "prices": {


### PR DESCRIPTION
## Summary
- add a dedicated content bulk edit matrix for product variations with language and channel selectors
- integrate the new content tab into the variations view navigation and unsaved-change handling
- localize new tab labels, column titles, and messaging for variation content editing

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d1b1d6bfb4832e9a8d2186a47b1c99