### PR TITLE
Enhance bulk edit AI tools for variation content

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -373,7 +373,8 @@
       "change": "Change",
       "leaveTab": "Leave tab",
       "createAnyway": "Create anyway",
-      "abort": "Abort"
+      "abort": "Abort",
+      "useAi": "Use AI"
     },
     "colors": {
       "red": "Red",
@@ -1039,6 +1040,9 @@
           },
           "toast": {
             "saveSuccess": "Variation content updated successfully."
+          },
+          "ai": {
+            "missingSource": "Add source content before using AI."
           }
         },
         "prices": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -188,7 +188,8 @@
       "fullUpdate": "Full Update",
       "validate": "Validate",
       "fetchIssues": "Fetch Issues",
-      "import": "Import"
+      "import": "Import",
+      "useAi": "Gebruik AI"
     },
     "colors": {
       "red": "Rood",
@@ -684,6 +685,11 @@
           "editProperties": "Eigenschappen bewerken",
           "editPrices": "Prijzen",
           "images": "Afbeeldingen"
+        },
+        "content": {
+          "ai": {
+            "missingSource": "Voeg broninhoud toe voordat je AI gebruikt."
+          }
         },
         "images": {
           "columns": {

--- a/src/shared/components/organisms/ai-bullet-points-generator/AiBulletPointsGenerator.vue
+++ b/src/shared/components/organisms/ai-bullet-points-generator/AiBulletPointsGenerator.vue
@@ -7,9 +7,20 @@ import { AiProcess } from "../ai-process";
 interface Props {
   productId: string | number;
   languageCode: string | null;
+  returnOne?: boolean;
+  btnClass?: string;
+  small?: boolean;
+  iconClass?: string;
+  label?: string;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  returnOne: false,
+  btnClass: 'btn-outline-primary',
+  small: true,
+  iconClass: 'text-purple-600',
+  label: 'shared.button.generate',
+});
 const emit = defineEmits<{
   (e: 'generated', bulletPoints: any[]): void;
 }>();
@@ -20,6 +31,7 @@ const mutationVariables = computed(() => ({
   data: {
     id: props.productId,
     languageCode: props.languageCode,
+    returnOne: props.returnOne,
   },
 }));
 
@@ -38,6 +50,10 @@ const steps = computed(() => [
     mutationKey="generateProductBulletPointsAi"
     modal-title="shared.components.organisms.aiBulletPointsGenerator.title"
     successToastKey="shared.components.organisms.aiBulletPointsGenerator.success"
+    :btn-class="props.btnClass"
+    :small="props.small"
+    :icon-class="props.iconClass"
+    :label="props.label"
     @bullet-points-processed="points => emit('generated', points)"
   />
 </template>

--- a/src/shared/components/organisms/ai-content-generator/AiContentGenerator.vue
+++ b/src/shared/components/organisms/ai-content-generator/AiContentGenerator.vue
@@ -9,11 +9,20 @@ interface Props {
   languageCode: string | null;
   contentAiGenerateType: string;
   salesChannelType?: string;
+  btnClass?: string;
+  small?: boolean;
+  iconClass?: string;
+  label?: string;
 }
 
 const { t } = useI18n();
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  btnClass: 'btn-outline-primary',
+  small: true,
+  iconClass: 'text-purple-600',
+  label: 'shared.button.generate',
+});
 const emit = defineEmits<{
   (e: 'generated', content: string): void;
 }>();
@@ -48,6 +57,10 @@ const steps = computed(() => [
     mutationKey="generateProductAiContent"
     modal-title="shared.components.organisms.aiContentGenerator.title"
     successToastKey="shared.components.organisms.aiContentGenerator.success"
+    :btn-class="props.btnClass"
+    :small="props.small"
+    :icon-class="props.iconClass"
+    :label="props.label"
     @processed="content => emit('generated', content)"
   />
 </template>

--- a/src/shared/components/organisms/ai-content-translator/AiContentTranslator.vue
+++ b/src/shared/components/organisms/ai-content-translator/AiContentTranslator.vue
@@ -12,9 +12,20 @@ interface Props {
   productContentType?: string;
   salesChannelId?: string;
   beforeStart?: () => Promise<boolean> | boolean;
+  btnClass?: string;
+  small?: boolean;
+  iconClass?: string;
+  label?: string;
+  returnOneBulletPoint?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  btnClass: 'btn-outline-success',
+  small: true,
+  iconClass: 'text-purple-600',
+  label: 'shared.button.translate',
+  returnOneBulletPoint: false,
+});
 const emit = defineEmits<{
   (e: 'translated', translatedText: string): void;
 }>();
@@ -40,6 +51,10 @@ const mutationVariables = computed(() => {
     data.salesChannel = { id: props.salesChannelId };
   }
 
+  if (props.returnOneBulletPoint) {
+    data.returnOneBulletPoint = props.returnOneBulletPoint;
+  }
+
   return { data };
 });
 
@@ -58,11 +73,13 @@ const steps = computed(() => [
     :variables="mutationVariables"
     :mutation="generateAiTranslationMutation"
     :steps="steps"
-    label="shared.button.translate"
+    :label="props.label"
     mutationKey="generateAiTranslation"
     modal-title="shared.components.organisms.aiContentTranslator.title"
     successToastKey="shared.components.organisms.aiContentTranslator.success"
-    btn-class="btn-outline-success"
+    :btn-class="props.btnClass"
+    :small="props.small"
+    :icon-class="props.iconClass"
     :before-start="props.beforeStart"
     @processed="text => emit('translated', text)"
   />

--- a/src/shared/components/organisms/ai-process/AiProcess.vue
+++ b/src/shared/components/organisms/ai-process/AiProcess.vue
@@ -18,11 +18,13 @@ const props = withDefaults(
     label?: string;
     small?: boolean;
     beforeStart?: () => Promise<boolean> | boolean;
+    iconClass?: string;
   }>(),
   {
     btnClass: 'btn-outline-primary',
     label: 'shared.button.generate',
     small: true,
+    iconClass: 'text-purple-600',
   }
 );
 
@@ -128,7 +130,7 @@ const handleClick = async (mutate: Function) => {
             <span class="spinner" />
           </template>
           <template v-else>
-            <Icon name="gem" size="lg" class="text-purple-600 mr-2"/>
+            <Icon name="gem" size="lg" :class="`${props.iconClass} mr-2`"/>
             {{ t(props.label) }}
           </template>
         </Button>


### PR DESCRIPTION
## Summary
- add AI action menus to variation content bulk edit cells with generate and translate options
- extend shared AI components to support custom styling and single bullet point handling
- provide translations and validation messaging for the new AI workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ca026004832e8288ae6938809013