### PR TITLE
Pass bullet point index to AI translator

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-content-bulk-edit/VariationsContentBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-content-bulk-edit/VariationsContentBulkEdit.vue
@@ -1319,6 +1319,7 @@ defineExpose({ hasUnsavedChanges });
                   :icon-class="'text-gray-500'"
                   :small="false"
                   :return-one-bullet-point="true"
+                  :bullet-point-index="parseInt(column.key.split('-')[1], 10)"
                   @translated="(value) =>
                     handleTranslatedBulletPoint(rowIndex, parseInt(column.key.split('-')[1], 10), value)
                   "

--- a/src/shared/components/organisms/ai-content-translator/AiContentTranslator.vue
+++ b/src/shared/components/organisms/ai-content-translator/AiContentTranslator.vue
@@ -17,6 +17,7 @@ interface Props {
   iconClass?: string;
   label?: string;
   returnOneBulletPoint?: boolean;
+  bulletPointIndex?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -25,6 +26,7 @@ const props = withDefaults(defineProps<Props>(), {
   iconClass: 'text-purple-600',
   label: 'shared.button.translate',
   returnOneBulletPoint: false,
+  bulletPointIndex: undefined,
 });
 const emit = defineEmits<{
   (e: 'translated', translatedText: string): void;
@@ -53,6 +55,10 @@ const mutationVariables = computed(() => {
 
   if (props.returnOneBulletPoint) {
     data.returnOneBulletPoint = props.returnOneBulletPoint;
+  }
+
+  if (props.bulletPointIndex !== undefined && props.bulletPointIndex !== null) {
+    data.bulletPointIndex = props.bulletPointIndex;
   }
 
   return { data };


### PR DESCRIPTION
## Summary
- allow the AI content translator component to forward the bullet point index in its mutation variables
- pass the column bullet index from the variations content matrix when translating a single bullet

## Testing
- npm run build *(fails: command hung during vue-tsc step)*

------
https://chatgpt.com/codex/tasks/task_e_68d1de38d074832e93bc7641561d75ee

## Summary by Sourcery

Extend AI content translator to support translating individual bullet points by forwarding their index.

Enhancements:
- Add bulletPointIndex prop to AiContentTranslator to include the bullet point index in its mutation variables
- Pass parsed bullet point index from VariationsContentBulkEdit into the AI translator when translating a single bullet