### PR TITLE
Add UI for mapping eBay internal properties

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayProperties.vue
@@ -3,6 +3,12 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import RemoteProperties from "../remote-properties/RemoteProperties.vue";
 import { ebayPropertiesSearchConfigConstructor, ebayPropertiesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
+import {
+  ebayInternalPropertiesSearchConfigConstructor,
+  ebayInternalPropertiesListingConfigConstructor,
+  ebayInternalListingQuery,
+  ebayInternalListingQueryKey,
+} from './ebayInternalConfigs';
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const emit = defineEmits(['pull-data']);
@@ -10,23 +16,45 @@ const { t } = useI18n();
 
 const searchConfig = computed(() => ebayPropertiesSearchConfigConstructor(t, props.salesChannelId));
 const listingConfig = ebayPropertiesListingConfigConstructor(t, props.id);
+const internalSearchConfig = computed(() => ebayInternalPropertiesSearchConfigConstructor(t));
+const internalListingConfig = ebayInternalPropertiesListingConfigConstructor(t, props.id);
 
 const buildStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: string; integrationId: string; salesChannelId: string }) => ({
   name: 'integrations.ebayProperties.edit',
   params: { type: 'ebay', id },
   query: { integrationId, salesChannelId, wizard: '1' },
 });
+
+const buildInternalStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: string; integrationId: string; salesChannelId: string }) => ({
+  name: 'integrations.ebayInternalProperties.edit',
+  params: { type: 'ebay', id },
+  query: { integrationId, salesChannelId, wizard: '1' },
+});
 </script>
 
 <template>
-  <RemoteProperties
-    :id="id"
-    :sales-channel-id="salesChannelId"
-    :search-config="searchConfig"
-    :listing-config="listingConfig"
-    :listing-query="listingQuery"
-    :listing-query-key="listingQueryKey"
-    :build-start-mapping-route="buildStartMappingRoute"
-    @pull-data="emit('pull-data')"
-  />
+  <div class="space-y-8">
+    <RemoteProperties
+      :id="id"
+      :sales-channel-id="salesChannelId"
+      :search-config="searchConfig"
+      :listing-config="listingConfig"
+      :listing-query="listingQuery"
+      :listing-query-key="listingQueryKey"
+      :build-start-mapping-route="buildStartMappingRoute"
+      title-key="integrations.show.ebay.properties.title"
+      @pull-data="emit('pull-data')"
+    />
+    <RemoteProperties
+      :id="id"
+      :sales-channel-id="salesChannelId"
+      :search-config="internalSearchConfig"
+      :listing-config="internalListingConfig"
+      :listing-query="ebayInternalListingQuery"
+      :listing-query-key="ebayInternalListingQueryKey"
+      :build-start-mapping-route="buildInternalStartMappingRoute"
+      title-key="integrations.show.ebay.internalProperties.title"
+      @pull-data="emit('pull-data')"
+    />
+  </div>
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/IntegrationsEbayInternalPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/IntegrationsEbayInternalPropertyEditController.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter, useRoute } from 'vue-router';
+import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
+import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
+import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
+import { ebayInternalPropertyEditFormConfigConstructor, ebayInternalListingQuery } from "../ebayInternalConfigs";
+import { FieldType } from "../../../../../../../../../shared/utils/constants";
+import { propertiesQuerySelector } from "../../../../../../../../../shared/api/queries/properties.js";
+import apolloClient from "../../../../../../../../../../apollo-client";
+import { Toast } from "../../../../../../../../../shared/modules/toast";
+import type { FormConfig } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
+
+const { t } = useI18n();
+const router = useRouter();
+const route = useRoute();
+
+const ebayInternalPropertyId = ref(String(route.params.id));
+const type = ref(String(route.params.type));
+const integrationId = route.query.integrationId?.toString() || '';
+const salesChannelId = route.query.salesChannelId?.toString() || '';
+const isWizard = route.query.wizard === '1';
+const propertyId = route.query.propertyId?.toString() || null;
+
+const formConfig = ref<FormConfig | null>(null);
+
+const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boolean }> => {
+  const { data } = await apolloClient.query({
+    query: ebayInternalListingQuery,
+    variables: {
+      first: 2,
+      filter: {
+        salesChannel: { id: { exact: salesChannelId } },
+        mappedLocally: false,
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+
+  const edges = data?.ebayInternalProperties?.edges || [];
+  let nextId: string | null = null;
+  for (const edge of edges) {
+    if (edge.node.id !== ebayInternalPropertyId.value) {
+      nextId = edge.node.id;
+      break;
+    }
+  }
+  const last = edges.length === 1 && edges[0].node.id === ebayInternalPropertyId.value;
+  return { nextId, last };
+};
+
+onMounted(async () => {
+  formConfig.value = ebayInternalPropertyEditFormConfigConstructor(t, type.value, ebayInternalPropertyId.value, integrationId);
+
+  if (!formConfig.value) {
+    return;
+  }
+
+  formConfig.value.cancelUrl = {
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: 'properties' },
+  };
+
+  if (!isWizard) {
+    return;
+  }
+
+  const { nextId, last } = await fetchNextUnmapped();
+
+  formConfig.value.addSubmitAndContinue = false;
+
+  if (nextId) {
+    formConfig.value.submitUrl = {
+      name: 'integrations.ebayInternalProperties.edit',
+      params: { type: type.value, id: nextId },
+      query: { integrationId, salesChannelId, wizard: '1' },
+    };
+    formConfig.value.submitLabel = t('integrations.show.mapping.saveAndMapNext');
+    return;
+  }
+
+  if (last) {
+    formConfig.value.submitUrl = {
+      name: 'integrations.integrations.show',
+      params: { type: type.value, id: integrationId },
+      query: { tab: 'properties' },
+    };
+    return;
+  }
+
+  Toast.success(t('integrations.show.mapping.allMappedSuccess'));
+  router.push({
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: 'properties' },
+  });
+});
+
+const handleSetData = (data: any) => {
+  if (!formConfig.value) {
+    return;
+  }
+
+  const propertyType = data?.ebayInternalProperty?.type;
+  if (!propertyType) {
+    return;
+  }
+
+  const defaultValue = propertyId || data?.ebayInternalProperty?.localInstance?.id || null;
+
+  const field = {
+    type: FieldType.Query,
+    name: 'localInstance',
+    label: t('integrations.show.properties.labels.property'),
+    help: t('integrations.show.properties.help.property'),
+    labelBy: 'name',
+    valueBy: 'id',
+    query: propertiesQuerySelector,
+    queryVariables: { filter: { type: { exact: propertyType } } },
+    dataKey: 'properties',
+    isEdge: true,
+    multiple: false,
+    filterable: true,
+    addLookup: true,
+    lookupKeys: ['id'],
+    formMapIdentifier: 'id',
+    ...(defaultValue ? { default: defaultValue } : {}),
+  };
+
+  const index = formConfig.value.fields.findIndex((f: any) => f.name === 'localInstance');
+  if (index === -1) {
+    formConfig.value.fields.push(field as any);
+  } else {
+    formConfig.value.fields[index] = field as any;
+  }
+};
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template #breadcrumbs>
+      <Breadcrumbs
+        :links="[
+          { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
+          { path: { name: 'integrations.integrations.show', params: { id: integrationId, type: type }, query: { tab: 'properties' } }, name: t('integrations.show.ebay.title') },
+          { name: t('integrations.show.mapProperty') },
+        ]"
+      />
+    </template>
+    <template #content>
+      <GeneralForm v-if="formConfig" :config="formConfig" @set-data="handleSetData" />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/ebayInternalConfigs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/ebayInternalConfigs.ts
@@ -1,0 +1,109 @@
+import { FieldType, getPropertyTypeOptions } from "../../../../../../../../shared/utils/constants";
+import { ebayInternalPropertiesQuery, getEbayInternalPropertyQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
+import { propertiesQuerySelector } from "../../../../../../../../shared/api/queries/properties.js";
+import { updateEbayInternalPropertyMutation } from "../../../../../../../../shared/api/mutations/salesChannels.js";
+import { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { SearchConfig } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
+import { FormConfig, FormType } from "../../../../../../../../shared/components/organisms/general-form/formConfig";
+
+export const ebayInternalPropertiesSearchConfigConstructor = (t: Function): SearchConfig => ({
+  search: true,
+  orderKey: "sort",
+  filters: [
+    { type: FieldType.Boolean, name: 'mappedLocally', label: t('integrations.show.mapping.mappedLocally'), strict: true },
+    { type: FieldType.Boolean, name: 'mappedRemotely', label: t('integrations.show.mapping.mappedRemotely'), strict: true },
+    {
+      type: FieldType.Choice,
+      name: 'type',
+      label: t('products.products.labels.type.title'),
+      labelBy: 'name',
+      valueBy: 'code',
+      options: getPropertyTypeOptions(t),
+      addLookup: true,
+    },
+    { type: FieldType.Boolean, name: 'isRoot', label: t('integrations.show.ebay.internalProperties.labels.isRoot'), strict: true },
+    {
+      type: FieldType.Query,
+      name: 'localInstance',
+      label: t('properties.properties.title'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: propertiesQuerySelector,
+      dataKey: 'properties',
+      filterable: true,
+      isEdge: true,
+      addLookup: true,
+      lookupKeys: ['id'],
+    },
+  ],
+  orders: [],
+});
+
+export const ebayInternalPropertiesListingConfigConstructor = (t: Function, specificIntegrationId): ListingConfig => ({
+  headers: [
+    t('shared.labels.name'),
+    t('integrations.show.properties.labels.code'),
+    t('integrations.show.mapping.mappedLocally'),
+    t('properties.properties.title'),
+    t('integrations.show.ebay.internalProperties.labels.isRoot'),
+  ],
+  fields: [
+    { name: 'name', type: FieldType.Text },
+    { name: 'code', type: FieldType.Text },
+    { name: 'mappedLocally', type: FieldType.Boolean },
+    {
+      name: 'localInstance',
+      type: FieldType.NestedText,
+      keys: ['name'],
+      showLabel: true,
+      clickable: true,
+      clickIdentifiers: [{ id: ['id'] }],
+      clickUrl: { name: 'properties.properties.show' },
+    },
+    { name: 'isRoot', type: FieldType.Boolean },
+  ],
+  identifierKey: 'id',
+  urlQueryParams: { integrationId: specificIntegrationId },
+  addActions: true,
+  addEdit: true,
+  addShow: true,
+  editUrlName: 'integrations.ebayInternalProperties.edit',
+  showUrlName: 'integrations.ebayInternalProperties.edit',
+  addDelete: false,
+  addPagination: true,
+});
+
+export const ebayInternalPropertyEditFormConfigConstructor = (
+  t: Function,
+  type: string,
+  propertyId: string,
+  integrationId: string
+): FormConfig => ({
+  cols: 1,
+  type: FormType.EDIT,
+  mutation: updateEbayInternalPropertyMutation,
+  mutationKey: "updateEbayInternalProperty",
+  query: getEbayInternalPropertyQuery,
+  queryVariables: { id: propertyId },
+  queryDataKey: "ebayInternalProperty",
+  submitUrl: { name: 'integrations.integrations.show', params: { type, id: integrationId }, query: { tab: 'properties' } },
+  fields: [
+    { type: FieldType.Hidden, name: 'id', value: propertyId },
+    { type: FieldType.Text, name: 'code', label: t('integrations.show.properties.labels.code'), disabled: true },
+    {
+      type: FieldType.Choice,
+      name: 'type',
+      label: t('products.products.labels.type.title'),
+      labelBy: 'name',
+      valueBy: 'code',
+      options: getPropertyTypeOptions(t),
+      disabled: true,
+      removable: false,
+    },
+    { type: FieldType.Boolean, name: 'isRoot', label: t('integrations.show.ebay.internalProperties.labels.isRoot'), disabled: true, strict: true },
+    { type: FieldType.Text, name: 'name', label: t('shared.labels.name'), help: t('integrations.show.properties.help.name') },
+  ],
+});
+
+export const ebayInternalListingQueryKey = 'ebayInternalProperties';
+export const ebayInternalListingQuery = ebayInternalPropertiesQuery;

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/RemoteProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/RemoteProperties.vue
@@ -5,6 +5,7 @@ import { useRouter, type RouteLocationRaw } from 'vue-router';
 import GeneralTemplate from "../../../../../../../../shared/templates/GeneralTemplate.vue";
 import { GeneralListing } from "../../../../../../../../shared/components/organisms/general-listing";
 import { Button } from "../../../../../../../../shared/components/atoms/button";
+import { Title } from "../../../../../../../../shared/components/atoms/title";
 import apolloClient from "../../../../../../../../../apollo-client";
 import type { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
 import type { SearchConfig } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
@@ -29,6 +30,7 @@ const props = defineProps<{
   fixedFilterVariables?: Record<string, any>;
   buildBaseFilter?: (context: BaseFilterBuilderContext) => Record<string, any>;
   buildStartMappingRoute?: (context: RouteBuilderContext) => RouteLocationRaw;
+  titleKey?: string;
 }>();
 
 const emit = defineEmits(['pull-data']);
@@ -55,6 +57,7 @@ const mergedFixedFilterVariables = computed(() => ({
 }));
 
 const hasStartMapping = computed(() => Boolean(props.buildStartMappingRoute));
+const hasTitle = computed(() => Boolean(props.titleKey));
 
 const fetchFirstUnmapped = async (): Promise<string | null> => {
   if (!hasStartMapping.value) {
@@ -133,14 +136,19 @@ const startMapping = async () => {
     </template>
 
     <template #content>
-      <GeneralListing
-        :search-config="searchConfig"
-        :config="listingConfig"
-        :query="listingQuery"
-        :query-key="listingQueryKey"
-        :fixed-filter-variables="mergedFixedFilterVariables"
-        @pull-data="emit('pull-data')"
-      />
+      <div class="space-y-4">
+        <Title v-if="hasTitle" level="3" semi-bold>
+          {{ t(props.titleKey as string) }}
+        </Title>
+        <GeneralListing
+          :search-config="searchConfig"
+          :config="listingConfig"
+          :query="listingQuery"
+          :query-key="listingQueryKey"
+          :fixed-filter-variables="mergedFixedFilterVariables"
+          @pull-data="emit('pull-data')"
+        />
+      </div>
     </template>
   </GeneralTemplate>
 </template>

--- a/src/core/integrations/routes.ts
+++ b/src/core/integrations/routes.ts
@@ -55,6 +55,12 @@ export const routes = [
     component: () => import('./integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue'),
   },
   {
+    path: '/integrations/:type/ebay-internal-property/:id',
+    name: 'integrations.ebayInternalProperties.edit',
+    meta: { title: 'integrations.show.ebay.internalProperties.title' },
+    component: () => import('./integrations/integrations-show/containers/properties/containers/ebay-properties/containers/IntegrationsEbayInternalPropertyEditController.vue'),
+  },
+  {
     path: '/integrations/:type/amazon-property-value/:id',
     name: 'integrations.amazonPropertySelectValues.edit',
     meta: { title: 'integrations.show.propertySelectValues.title' },

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -215,6 +215,18 @@
       "isDefaultMarketplace": "Standardmarktplatz"
     },
     "show": {
+      "ebay": {
+        "title": "",
+        "properties": {
+          "title": ""
+        },
+        "internalProperties": {
+          "title": "",
+          "labels": {
+            "isRoot": ""
+          }
+        }
+      },
       "tabs": {
         "reports": "Berichte"
       }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2448,6 +2448,18 @@
       "amazon": {
         "title": "Amazon Integration"
       },
+      "ebay": {
+        "title": "Ebay Integration",
+        "properties": {
+          "title": "Ebay Aspects"
+        },
+        "internalProperties": {
+          "title": "Ebay Inventory Fields",
+          "labels": {
+            "isRoot": "Is Inventory Item Field"
+          }
+        }
+      },
       "pullData": {
         "success": "Website, languages and currencies pulled successfully.",
         "error": "Failed to pull remote data. Please try again."

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -210,6 +210,18 @@
       "isDefaultMarketplace": "Marketplace par défaut"
     },
     "show": {
+      "ebay": {
+        "title": "",
+        "properties": {
+          "title": ""
+        },
+        "internalProperties": {
+          "title": "",
+          "labels": {
+            "isRoot": ""
+          }
+        }
+      },
       "tabs": {
         "reports": "Rapports"
       }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -2004,6 +2004,18 @@
   },
   "integrations": {
     "show": {
+      "ebay": {
+        "title": "",
+        "properties": {
+          "title": ""
+        },
+        "internalProperties": {
+          "title": "",
+          "labels": {
+            "isRoot": ""
+          }
+        }
+      },
       "products": {
         "labels": {
           "store": "Winkel",

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -339,6 +339,16 @@ export const updateEbaySalesChannelViewMutation = gql`
   }
 `;
 
+export const updateEbayInternalPropertyMutation = gql`
+  mutation updateEbayInternalProperty($data: EbayInternalPropertyPartialInput!) {
+    updateEbayInternalProperty(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
 export const updateRemoteLanguageMutation = gql`
   mutation updateRemoteLanguage($data: RemoteLanguagePartialInput!) {
     updateRemoteLanguage(data: $data) {

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -1012,6 +1012,68 @@ export const ebayPropertiesQuery = gql`
   }
 `;
 
+export const ebayInternalPropertiesQuery = gql`
+  query EbayInternalProperties(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: EbayInternalPropertyOrder
+    $filter: EbayInternalPropertyFilter
+  ) {
+    ebayInternalProperties(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filter
+    ) {
+      edges {
+        node {
+          id
+          code
+          name
+          type
+          isRoot
+          mappedLocally
+          mappedRemotely
+          localInstance {
+            id
+            name
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const getEbayInternalPropertyQuery = gql`
+  query getEbayInternalProperty($id: GlobalID!) {
+    ebayInternalProperty(id: $id) {
+      id
+      code
+      name
+      type
+      isRoot
+      mappedLocally
+      mappedRemotely
+      localInstance {
+        id
+        name
+      }
+    }
+  }
+`;
+
 export const getAmazonPropertyQuery = gql`
   query getAmazonProperty($id: GlobalID!) {
     amazonProperty(id: $id) {


### PR DESCRIPTION
## Summary
- reuse the remote properties container to list and map eBay internal properties
- add configs, GraphQL operations, and edit controller to update eBay internal property mappings
- extend translations for the new eBay internal property section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d243297eb0832ea8e1ad1adddd1250