### PR TITLE
Add eBay property select values tab to integration show

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -75,7 +75,10 @@ if (type.value !== IntegrationTypes.Webhook) {
       { name: 'defaultUnits', label: t('integrations.show.sections.defaultUnits'), icon: 'weight-hanging' }
     );
   } else if (type.value === IntegrationTypes.Ebay) {
-    tabItems.value.push({ name: 'properties', label: t('properties.title'), icon: 'screwdriver-wrench' });
+    tabItems.value.push(
+      { name: 'properties', label: t('properties.title'), icon: 'screwdriver-wrench' },
+      { name: 'propertySelectValues', label: t('properties.values.title'), icon: 'sitemap' }
+    );
   }
 
   tabItems.value.push({ name: 'imports', label: t('shared.tabs.imports'), icon: 'file-import' });


### PR DESCRIPTION
## Summary
- include the new eBay property select values management view in the integration show tabs so it can be reached from the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d24d6e2ed0832ea1b1dea23254a5f1

## Summary by Sourcery

New Features:
- Include a "Property Select Values" tab alongside existing tabs for eBay integrations