### PR TITLE
feat: move ebay inventory fields to dedicated tab

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -31,6 +31,7 @@ import { Currencies } from "./containers/currencies";
 import { PriceLists } from "./containers/price-lists";
 import { Rules } from "./containers/rules";
 import { Properties } from "./containers/properties";
+import { InventoryFields } from "./containers/inventory-fields";
 import { PropertySelectValues } from "./containers/property-select-values";
 import { DefaultUnitConfigurators } from "./containers/default-unit-configurators";
 import { Imports } from "./containers/imports";
@@ -77,6 +78,7 @@ if (type.value !== IntegrationTypes.Webhook) {
   } else if (type.value === IntegrationTypes.Ebay) {
     tabItems.value.push(
       { name: 'properties', label: t('properties.title'), icon: 'screwdriver-wrench' },
+      { name: 'inventoryFields', label: t('integrations.show.ebay.internalProperties.title'), icon: 'boxes-stacked' },
       { name: 'propertySelectValues', label: t('properties.values.title'), icon: 'sitemap' }
     );
   }
@@ -306,6 +308,17 @@ const pullData = async () => {
           <!-- Properties Tab -->
           <template #properties>
             <Properties v-if="salesChannelId" :id="id" :sales-channel-id="salesChannelId" :type="type" @pull-data="pullData()" />
+          </template>
+
+          <!-- Inventory Fields Tab -->
+          <template #inventoryFields>
+            <InventoryFields
+              v-if="salesChannelId"
+              :id="id"
+              :sales-channel-id="salesChannelId"
+              :type="type"
+              @pull-data="pullData()"
+            />
           </template>
 
           <!-- Property Select Values Tab -->

--- a/src/core/integrations/integrations/integrations-show/containers/inventory-fields/InventoryFields.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/inventory-fields/InventoryFields.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { IntegrationTypes } from '../../../integrations';
+import { EbayInventoryProperties } from '../properties/containers/ebay-properties';
+
+const props = defineProps<{ id: string; salesChannelId: string; type: string }>();
+const emit = defineEmits(['pull-data']);
+
+const currentComponent = computed(() => {
+  switch (props.type) {
+    case IntegrationTypes.Ebay:
+      return EbayInventoryProperties;
+    default:
+      return null;
+  }
+});
+</script>
+
+<template>
+  <component
+    v-if="currentComponent"
+    :is="currentComponent"
+    :id="id"
+    :sales-channel-id="salesChannelId"
+    @pull-data="emit('pull-data')"
+  />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/inventory-fields/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/inventory-fields/index.ts
@@ -1,0 +1,1 @@
+export { default as InventoryFields } from './InventoryFields.vue';

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayInventoryProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayInventoryProperties.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import RemoteProperties from "../remote-properties/RemoteProperties.vue";
+import {
+  ebayInternalPropertiesSearchConfigConstructor,
+  ebayInternalPropertiesListingConfigConstructor,
+  ebayInternalListingQuery,
+  ebayInternalListingQueryKey,
+} from './ebayInternalConfigs';
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const emit = defineEmits(['pull-data']);
+const { t } = useI18n();
+
+const internalSearchConfig = computed(() => ebayInternalPropertiesSearchConfigConstructor(t));
+const internalListingConfig = ebayInternalPropertiesListingConfigConstructor(t, props.id);
+
+const buildInternalStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: string; integrationId: string; salesChannelId: string }) => ({
+  name: 'integrations.ebayInternalProperties.edit',
+  params: { type: 'ebay', id },
+  query: { integrationId, salesChannelId, wizard: '1' },
+});
+</script>
+
+<template>
+  <RemoteProperties
+    :id="id"
+    :sales-channel-id="salesChannelId"
+    :search-config="internalSearchConfig"
+    :listing-config="internalListingConfig"
+    :listing-query="ebayInternalListingQuery"
+    :listing-query-key="ebayInternalListingQueryKey"
+    :build-start-mapping-route="buildInternalStartMappingRoute"
+    title-key="integrations.show.ebay.internalProperties.title"
+    @pull-data="emit('pull-data')"
+  />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayProperties.vue
@@ -3,12 +3,6 @@ import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import RemoteProperties from "../remote-properties/RemoteProperties.vue";
 import { ebayPropertiesSearchConfigConstructor, ebayPropertiesListingConfigConstructor, listingQuery, listingQueryKey } from './configs';
-import {
-  ebayInternalPropertiesSearchConfigConstructor,
-  ebayInternalPropertiesListingConfigConstructor,
-  ebayInternalListingQuery,
-  ebayInternalListingQueryKey,
-} from './ebayInternalConfigs';
 
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const emit = defineEmits(['pull-data']);
@@ -16,8 +10,6 @@ const { t } = useI18n();
 
 const searchConfig = computed(() => ebayPropertiesSearchConfigConstructor(t, props.salesChannelId));
 const listingConfig = ebayPropertiesListingConfigConstructor(t, props.id);
-const internalSearchConfig = computed(() => ebayInternalPropertiesSearchConfigConstructor(t));
-const internalListingConfig = ebayInternalPropertiesListingConfigConstructor(t, props.id);
 
 const buildStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: string; integrationId: string; salesChannelId: string }) => ({
   name: 'integrations.ebayProperties.edit',
@@ -25,11 +17,6 @@ const buildStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: str
   query: { integrationId, salesChannelId, wizard: '1' },
 });
 
-const buildInternalStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: string; integrationId: string; salesChannelId: string }) => ({
-  name: 'integrations.ebayInternalProperties.edit',
-  params: { type: 'ebay', id },
-  query: { integrationId, salesChannelId, wizard: '1' },
-});
 </script>
 
 <template>
@@ -43,17 +30,6 @@ const buildInternalStartMappingRoute = ({ id, integrationId, salesChannelId }: {
       :listing-query-key="listingQueryKey"
       :build-start-mapping-route="buildStartMappingRoute"
       title-key="integrations.show.ebay.properties.title"
-      @pull-data="emit('pull-data')"
-    />
-    <RemoteProperties
-      :id="id"
-      :sales-channel-id="salesChannelId"
-      :search-config="internalSearchConfig"
-      :listing-config="internalListingConfig"
-      :listing-query="ebayInternalListingQuery"
-      :listing-query-key="ebayInternalListingQueryKey"
-      :build-start-mapping-route="buildInternalStartMappingRoute"
-      title-key="integrations.show.ebay.internalProperties.title"
       @pull-data="emit('pull-data')"
     />
   </div>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/index.ts
@@ -1,1 +1,2 @@
 export { default as EbayProperties } from './EbayProperties.vue';
+export { default as EbayInventoryProperties } from './EbayInventoryProperties.vue';


### PR DESCRIPTION
## Summary
- add an Inventory Fields tab to the integrations show controller for eBay integrations
- extract the eBay inventory properties listing into its own component and reuse it through a new inventory fields container

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2504025d4832ea1a97b75e84af769

## Summary by Sourcery

Add a dedicated Inventory Fields tab for eBay integrations and extract inventory properties into reusable components.

New Features:
- Add an Inventory Fields tab to the IntegrationsShowController for eBay integrations
- Introduce InventoryFields container that dynamically renders integration-specific inventory components
- Extract eBay internal inventory properties into a standalone EbayInventoryProperties component

Enhancements:
- Remove internal inventory logic from the original EbayProperties component and delegate it to the new inventory components