### PR TITLE
Restore Amazon property data handling

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/configs.ts
@@ -32,7 +32,7 @@ export const amazonPropertySelectValueEditFormConfigConstructor = (
     { type: FieldType.Text, name: 'amazonProperty', label: t('integrations.show.propertySelectValues.labels.amazonProperty'), disabled: true, help: t('integrations.show.propertySelectValues.help.amazonProperty') },
     { type: FieldType.Text, name: 'marketplace', label: t('integrations.show.propertySelectValues.labels.marketplace'), disabled: true, help: t('integrations.show.propertySelectValues.help.marketplace') },
     { type: FieldType.Text, name: 'remoteValue', label: t('integrations.show.propertySelectValues.labels.remoteValue'), disabled: true, help: t('integrations.show.propertySelectValues.help.remoteValue') },
-    { type: FieldType.Text, name: 'remoteName', label: t('shared.labels.name'), help: t('integrations.show.propertySelectValues.help.remoteName') },
+    { type: FieldType.Text, name: 'remoteName', label: t('integrations.show.propertySelectValues.labels.remoteName'), help: t('integrations.show.propertySelectValues.help.remoteName') },
     { type: FieldType.Text, name: 'translatedRemoteName', label: t('integrations.show.propertySelectValues.labels.translatedRemoteName'), help: t('integrations.show.propertySelectValues.help.translatedRemoteName') },
   ]
 });

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/containers/IntegrationsAmazonPropertySelectValueEditController.vue
@@ -337,7 +337,7 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
                 <div class="col-span-full">
                   <Flex vertical>
                     <FlexCell>
-                      <Label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('shared.labels.name') }}</Label>
+                      <Label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('integrations.show.propertySelectValues.labels.remoteName') }}</Label>
                     </FlexCell>
                     <FlexCell>
                       <TextInput v-model="form.remoteName" class="w-full" />

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2556,8 +2556,8 @@
       "propertySelectValues": {
         "title": "Amazon Property Values",
         "labels": {
-          "remoteName": "Remote Name",
-          "remoteValue": "Remote Value",
+          "remoteName": "Amazon Name",
+          "remoteValue": "Amazon Value",
           "amazonProperty": "Amazon Property",
           "ebayProperty": "eBay Property",
           "marketplace": "Marketplace",
@@ -2570,11 +2570,11 @@
         "help": {
           "amazonProperty": "Amazon property to which this value belongs.",
           "ebayProperty": "eBay property to which this value belongs.",
-          "marketplace": "Marketplace for this value.",
+          "marketplace": "Amazon marketplace for this value.",
           "localProperty": "OneSila property that this remote property maps to.",
-          "remoteValue": "Value exactly as defined remotely.",
-          "remoteName": "Name from the remote channel. You can change it.",
-          "selectValue": "Choose the OneSila value that matches this remote value.",
+          "remoteValue": "Value exactly as defined in Amazon.",
+          "remoteName": "Name from Amazon. You can change it.",
+          "selectValue": "Choose the OneSila value that matches this Amazon value.",
           "translatedRemoteName": "Translated name for this value.",
           "localizedValue": "Value as returned by the marketplace.",
           "translatedValue": "Translated value in the company language."

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -1080,7 +1080,8 @@ export const getAmazonPropertyQuery = gql`
       id
       mappedLocally
       mappedRemotely
-      localizedName
+      code
+      name
       type
       allowsUnmappedValues
       localInstance {
@@ -1117,6 +1118,8 @@ export const amazonPropertySelectValuesQuery = gql`
           amazonProperty {
             id
             name
+            code
+            type
             mappedLocally
             mappedRemotely
           }
@@ -1153,6 +1156,8 @@ export const getAmazonPropertySelectValueQuery = gql`
       amazonProperty {
         id
         name
+        code
+        type
       }
       marketplace {
         id


### PR DESCRIPTION
## Summary
- request amazon property name and code fields again so edit forms populate correctly
- expose amazon property metadata in select value queries and re-align labels with Amazon terminology
- update Amazon property select value UI to use the dedicated translation label

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d254a3aad0832e817fe0e6c786765d