### PR TITLE
Refactor remote product type mapping configuration

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/rules/IntegrationsRemoteProductTypeEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/IntegrationsRemoteProductTypeEditController.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import type { Component } from 'vue';
+import { useRoute } from 'vue-router';
+import apolloClient from '../../../../../../../apollo-client';
+import {
+  getProductTypeQuery,
+  getProductTypeQueryDataKey,
+} from './containers/remote-product-types/configs';
+import ImportedAmazonProductType from './containers/remote-product-types/containers/ImportedAmazonProductType.vue';
+import ImportedEbayProductType from './containers/remote-product-types/containers/ImportedEbayProductType.vue';
+import AmazonMappedRemoteProductType from './containers/remote-product-types/containers/AmazonMappedRemoteProductType.vue';
+import EbayMappedRemoteProductType from './containers/remote-product-types/containers/EbayMappedRemoteProductType.vue';
+import { IntegrationTypes } from '../../../integrations';
+
+const route = useRoute();
+const productTypeId = String(route.params.id);
+const type = computed(() => String(route.params.type));
+const productType = ref<any | null>(null);
+const loading = ref(true);
+
+const componentRegistry: Record<string, { imported: Component; mapped: Component }> = {
+  [IntegrationTypes.Amazon]: {
+    imported: ImportedAmazonProductType,
+    mapped: AmazonMappedRemoteProductType,
+  },
+  [IntegrationTypes.Ebay]: {
+    imported: ImportedEbayProductType,
+    mapped: EbayMappedRemoteProductType,
+  },
+};
+
+onMounted(async () => {
+  const query = getProductTypeQuery(type.value);
+  const dataKey = getProductTypeQueryDataKey(type.value);
+  const { data } = await apolloClient.query({
+    query,
+    variables: { id: productTypeId },
+    fetchPolicy: 'cache-first',
+  });
+  productType.value = data?.[dataKey] || null;
+  loading.value = false;
+});
+
+const registryEntry = computed(() => componentRegistry[type.value] ?? null);
+const imported = computed(() => Boolean(productType.value?.imported));
+const currentComponent = computed<Component | null>(() => {
+  const entry = registryEntry.value;
+  if (!entry) {
+    return null;
+  }
+  return imported.value ? entry.mapped : entry.imported;
+});
+</script>
+
+<template>
+  <component v-if="!loading && currentComponent" :is="currentComponent" :product-type="productType" />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/configTypes.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/configTypes.ts
@@ -1,0 +1,65 @@
+import type { DocumentNode } from 'graphql';
+import type { RouteLocationRaw } from 'vue-router';
+
+export type NormalizedSuggestion = {
+  code: string;
+  displayName: string;
+  secondary?: string;
+  raw: Record<string, any>;
+};
+
+export type ImportedRemoteProductTypeConfig<
+  TState extends Record<string, any> = Record<string, any>,
+> = {
+  integrationType: string;
+  listingQuery: DocumentNode;
+  listingQueryKey: string;
+  suggestMutation: DocumentNode;
+  getSuggestionVariables: (params: { name: string | null; marketplace: string }) => Record<string, any>;
+  mapSuggestions: (data: Record<string, any>, state: TState) => NormalizedSuggestion[];
+  createState: () => TState;
+  buildSaveInput: (params: {
+    productTypeId: string;
+    selectedSuggestion: NormalizedSuggestion | null;
+    selectedCode: string;
+    selectedName: string;
+    state: TState;
+  }) => { mutation: DocumentNode; variables: Record<string, any> } | null;
+  getIntegrationTitle: (t: (key: string, ...args: any[]) => string, type: string) => string;
+  editRouteName: string;
+};
+
+export type AdditionalButtonConfig = {
+  route: RouteLocationRaw;
+  labelKey: string;
+};
+
+export type MappedRemoteProductTypeConfig<
+  TState extends Record<string, any> = Record<string, any>,
+> = {
+  integrationType: string;
+  listingQuery: DocumentNode;
+  listingQueryKey: string;
+  productTypeQueryDataKey: string;
+  getIntegrationTitle: (t: (key: string, ...args: any[]) => string, type: string) => string;
+  editRouteName: string;
+  createState: () => TState;
+  extractItems: (data: any, state: TState) => any[];
+  getItemName: (item: any, state: TState) => string;
+  getItemCode?: (item: any, state: TState) => string;
+  isItemMappedLocally: (item: any, state: TState) => boolean;
+  getPropertyRoute?: (
+    item: any,
+    context: { type: string; integrationId: string; salesChannelId: string },
+    state: TState,
+  ) => RouteLocationRaw | null;
+  shouldShowAdditionalButton?: (context: { state: TState }) => boolean;
+  getAdditionalButtonConfig?: (context: {
+    productTypeId: string;
+    integrationId: string;
+    salesChannelId: string;
+    isWizard: boolean;
+    formData: Record<string, any>;
+    state: TState;
+  }) => AdditionalButtonConfig | null;
+};

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/AmazonMappedRemoteProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/AmazonMappedRemoteProductType.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import RemotelyMappedRemoteProductType from './RemotelyMappedRemoteProductType.vue';
+import { amazonMappedRemoteProductTypeConfig } from '../configs';
+
+defineProps<{ productType: any | null }>();
+</script>
+
+<template>
+  <RemotelyMappedRemoteProductType :product-type="productType" :config="amazonMappedRemoteProductTypeConfig" />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/EbayMappedRemoteProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/EbayMappedRemoteProductType.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import RemotelyMappedRemoteProductType from './RemotelyMappedRemoteProductType.vue';
+import { ebayMappedRemoteProductTypeConfig } from '../configs';
+
+defineProps<{ productType: any | null }>();
+</script>
+
+<template>
+  <RemotelyMappedRemoteProductType :product-type="productType" :config="ebayMappedRemoteProductTypeConfig" />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/ImportedAmazonProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/ImportedAmazonProductType.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import ImportedRemoteProductType from './ImportedRemoteProductType.vue';
+import { amazonImportedRemoteProductTypeConfig } from '../configs';
+
+defineProps<{ productType: any | null }>();
+</script>
+
+<template>
+  <ImportedRemoteProductType :product-type="productType" :config="amazonImportedRemoteProductTypeConfig" />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/ImportedEbayProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/ImportedEbayProductType.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import ImportedRemoteProductType from './ImportedRemoteProductType.vue';
+import { ebayImportedRemoteProductTypeConfig } from '../configs';
+
+defineProps<{ productType: any | null }>();
+</script>
+
+<template>
+  <ImportedRemoteProductType :product-type="productType" :config="ebayImportedRemoteProductTypeConfig" />
+</template>

--- a/src/core/integrations/routes.ts
+++ b/src/core/integrations/routes.ts
@@ -46,7 +46,7 @@ export const routes = [
     path: '/integrations/:type/product-type/:id',
     name: 'integrations.amazonProductTypes.edit',
     meta: { title: 'integrations.show.productRules.title' },
-    component: () => import('./integrations/integrations-show/containers/rules/containers/remote-product-types/containers/IntegrationsRemoteProductTypeEditController.vue'),
+    component: () => import('./integrations/integrations-show/containers/rules/IntegrationsRemoteProductTypeEditController.vue'),
   },
   {
     path: '/integrations/:type/amazon-property/:id',


### PR DESCRIPTION
## Summary
- introduce config type definitions and Amazon/Ebay config objects for remote product type flows
- update the generic import/mapping components to consume external configs and add vendor wrapper components
- move the edit controller to the rules directory and route through vendor-specific components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2f20b8a44832eb78515b5c65167f5