### PR TITLE
Add eBay import creation wizard and listing

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/Imports.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/Imports.vue
@@ -2,15 +2,17 @@
 import { ref, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { IntegrationTypes } from "../../../integrations";
-import { AmazonImportsListing, GeneralImportsListing } from './components';
+import { AmazonImportsListing, EbayImportsListing, GeneralImportsListing } from './components';
 
 const route = useRoute();
 const props = defineProps<{ id: string; salesChannelId: string }>();
 const type = ref(String(route.params.type));
 const isAmazon = computed(() => type.value === IntegrationTypes.Amazon);
+const isEbay = computed(() => type.value === IntegrationTypes.Ebay);
 </script>
 
 <template>
   <AmazonImportsListing v-if="isAmazon" :id="id" :sales-channel-id="salesChannelId" />
+  <EbayImportsListing v-else-if="isEbay" :id="id" :sales-channel-id="salesChannelId" />
   <GeneralImportsListing v-else :id="id" :sales-channel-id="salesChannelId" />
 </template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/components/EbayImportsListing.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/components/EbayImportsListing.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+import { Link } from "../../../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../../../shared/components/atoms/button";
+import { ApolloSubscription } from "../../../../../../../shared/components/molecules/apollo-subscription";
+import { DiscreteLoader } from "../../../../../../../shared/components/atoms/discrete-loader";
+import { AssignProgressBar } from "../../../../../../../shared/components/molecules/assign-progress-bar";
+import { Badge } from "../../../../../../../shared/components/atoms/badge";
+import { Icon } from "../../../../../../../shared/components/atoms/icon";
+import { salesChannelSubscription } from "../../../../../../../shared/api/subscriptions/salesChannels.js";
+import { updateEbayImportProcessMutation } from "../../../../../../../shared/api/mutations/salesChannels";
+import { Toast } from "../../../../../../../shared/modules/toast";
+import { getStatusBadgeMap, SalesChannelSubscriptionResult } from "../configs";
+import apolloClient from "../../../../../../../../apollo-client";
+
+const props = defineProps<{ id: string; salesChannelId: string }>();
+const { t } = useI18n();
+const route = useRoute();
+
+const statusBadgeMap = getStatusBadgeMap(t);
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+};
+
+const isRetryEnabled = (importItem: any): boolean => {
+  const createdDate = new Date(importItem.createdAt);
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+  return ['success', 'failed'].includes(importItem.status) && createdDate >= oneWeekAgo;
+};
+
+const retryImport = async (importId: string) => {
+  try {
+    await apolloClient.mutate({
+      mutation: updateEbayImportProcessMutation,
+      variables: { data: { id: importId, status: 'pending' } },
+    });
+    Toast.success(t('integrations.imports.retry.success'));
+  } catch (error) {
+    Toast.error(t('integrations.imports.retry.error'));
+    console.error('Retry failed:', error);
+  }
+};
+</script>
+
+<template>
+  <ApolloSubscription :subscription="salesChannelSubscription" :variables="{ pk: props.salesChannelId }">
+    <template #default="{ result }">
+      <div v-if="result">
+        <div class="flex items-center justify-between flex-wrap gap-4 mb-4">
+          <div></div>
+          <div>
+            <Link :path="{ name: 'integrations.imports.create', params: { integrationId: id } }">
+              <Button type="button" class="btn btn-primary">
+                {{ t('integrations.imports.create.title') }}
+              </Button>
+            </Link>
+          </div>
+        </div>
+        <div class="mt-2 h-full">
+          <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+            <thead>
+              <tr>
+                <th class="p-2 text-left">{{ t('shared.labels.createdAt') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.type') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.status') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.progress') }}</th>
+                <th class="p-2 text-left">{{ t('shared.labels.actions') }}</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <tr
+                v-for="importItem in (result as SalesChannelSubscriptionResult).salesChannel.ebayImports"
+                :key="importItem.id"
+                class="border-b dark:border-[#191e3a]"
+              >
+                <td class="p-2">
+                  <Link :path="{ name: 'integrations.imports.show', params: { type: route.params.type, id: (importItem as any).proxyId } }">
+                    {{ formatDate(importItem.createdAt) }}
+                  </Link>
+                </td>
+                <td class="p-2">{{ t(`integrations.imports.types.${importItem.type}`) }}</td>
+                <td class="p-2">
+                  <Badge :color="statusBadgeMap[importItem.status]?.color" :text="statusBadgeMap[importItem.status]?.text" />
+                </td>
+                <td class="p-2">
+                  <AssignProgressBar :progress="importItem.percentage" :is-error="importItem.status === 'failed'" />
+                </td>
+                <td class="p-2 text-right">
+                  <Button :disabled="!isRetryEnabled(importItem)" @click="retryImport(importItem.id)">
+                    <Icon name="clock-rotate-left" size="lg" class="text-gray-500" />
+                  </Button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div v-else>
+        <DiscreteLoader :loading="true" />
+      </div>
+    </template>
+  </ApolloSubscription>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/components/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/components/index.ts
@@ -1,2 +1,3 @@
 export { default as AmazonImportsListing } from './AmazonImportsListing.vue';
+export { default as EbayImportsListing } from './EbayImportsListing.vue';
 export { default as GeneralImportsListing } from './GeneralImportsListing.vue';

--- a/src/core/integrations/integrations/integrations-show/containers/imports/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/configs.ts
@@ -27,6 +27,14 @@ export interface AmazonSalesChannelImportItem {
   createdAt: string;
 }
 
+export interface EbaySalesChannelImportItem {
+  id: string;
+  type: string;
+  status: 'new' | 'pending' | 'failed' | 'success' | 'processing';
+  percentage: number;
+  createdAt: string;
+}
+
 export interface SalesChannelSubscriptionResult {
   salesChannel: {
     id: string;
@@ -34,6 +42,7 @@ export interface SalesChannelSubscriptionResult {
     isImporting: boolean;
     saleschannelimportSet: SalesChannelImportItem[];
     amazonImports: AmazonSalesChannelImportItem[];
+    ebayImports: EbaySalesChannelImportItem[];
   };
 }
 

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/ImportCreateController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/ImportCreateController.vue
@@ -8,6 +8,7 @@ import { MagentoImporter } from "./containers/magento/magento-importer";
 import { ShopifyImporter } from "./containers/shopify/shopify-importer";
 import { WoocommerceImporter } from "./containers/woocommerce/woocommerce-importer";
 import { AmazonImporter } from "./containers/amazon/amazon-importer";
+import { EbayImporter } from "./containers/ebay/ebay-importer";
 import {IntegrationTypes} from "../../../../../integrations";
 
 
@@ -35,6 +36,7 @@ const type = ref(String(route.params.type));
       <MagentoImporter v-if="type == IntegrationTypes.Magento" :integration-id="integrationId" :type="type" />
       <ShopifyImporter v-else-if="type == IntegrationTypes.Shopify" :integration-id="integrationId" :type="type" />
       <AmazonImporter v-else-if="type == IntegrationTypes.Amazon" :integration-id="integrationId" :type="type" />
+      <EbayImporter v-else-if="type == IntegrationTypes.Ebay" :integration-id="integrationId" :type="type" />
       <WoocommerceImporter v-else-if="type == IntegrationTypes.Woocommerce" :integration-id="integrationId" :type="type" />
     </template>
   </GeneralTemplate>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/EbayImporter.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/EbayImporter.vue
@@ -1,0 +1,286 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import { Wizard } from "../../../../../../../../../../../shared/components/molecules/wizard";
+import { OptionSelector } from "../../../../../../../../../../../shared/components/molecules/option-selector";
+import { Icon } from "../../../../../../../../../../../shared/components/atoms/icon";
+import apolloClient from "../../../../../../../../../../../../apollo-client";
+import { Toast } from "../../../../../../../../../../../shared/modules/toast";
+import {
+  bulkUpdateRemoteCurrenciesMutation,
+  bulkUpdateRemoteLanguagesMutation,
+  createEbayImportProcessMutation,
+} from "../../../../../../../../../../../shared/api/mutations/salesChannels";
+import { ebayImportProcessesQuery } from "../../../../../../../../../../../shared/api/queries/salesChannels";
+import { processGraphQLErrors } from "../../../../../../../../../../../shared/utils";
+import type { RemoteCurrency, RemoteLanguage } from "../../../../../configs";
+import EbayLanguagesStep from "./components/EbayLanguagesStep.vue";
+import EbayCurrenciesStep from "./components/EbayCurrenciesStep.vue";
+
+const props = defineProps<{ integrationId: string; type: string }>();
+
+const { t } = useI18n();
+const router = useRouter();
+
+const importType = ref("schema");
+const hasFinishedSchema = ref(false);
+const loading = ref(false);
+const step = ref(0);
+const finishLoading = ref(false);
+const currentFinishStep = ref<number | null>(null);
+
+const mappedLanguages = ref<RemoteLanguage[]>([]);
+const mappedCurrencies = ref<RemoteCurrency[]>([]);
+
+const typeChoices = computed(() => [
+  { name: "schema" },
+  {
+    name: "products",
+    disabled: !hasFinishedSchema.value,
+    hideDisabledBanner: true,
+  },
+]);
+
+const wizardSteps = computed(() => [
+  { title: t("integrations.imports.create.ebay.wizard.steps.type"), name: "selectType" },
+  { title: t("integrations.imports.create.ebay.wizard.steps.languages"), name: "mapLanguages" },
+  { title: t("integrations.imports.create.ebay.wizard.steps.currencies"), name: "mapCurrencies" },
+]);
+
+const allowNextStep = computed(() => {
+  if (step.value === 0) {
+    return true;
+  }
+
+  if (step.value === 1) {
+    return (
+      mappedLanguages.value.length > 0 &&
+      mappedLanguages.value.every((language) => Boolean(language.localInstance))
+    );
+  }
+
+  if (step.value === 2) {
+    return (
+      mappedCurrencies.value.length > 0 &&
+      mappedCurrencies.value.every((currency) => Boolean(currency.localInstance))
+    );
+  }
+
+  return true;
+});
+
+const fetchImports = async () => {
+  loading.value = true;
+
+  try {
+    const { data } = await apolloClient.query({
+      query: ebayImportProcessesQuery,
+      variables: {
+        filter: {
+          salesChannel: { id: { exact: props.integrationId } },
+          type: { exact: "schema" },
+          status: { exact: "success" },
+        },
+      },
+      fetchPolicy: "cache-first",
+    });
+
+    const edges = data?.ebayImportProcesses?.edges || [];
+    hasFinishedSchema.value = edges.length > 0;
+  } catch (error) {
+    console.error(error);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchImports);
+
+const updateStep = (value: number) => {
+  step.value = value;
+};
+
+const updateLanguages = (languages: RemoteLanguage[]) => {
+  mappedLanguages.value = languages;
+};
+
+const updateCurrencies = (currencies: RemoteCurrency[]) => {
+  mappedCurrencies.value = currencies;
+};
+
+const bulkUpdateLanguages = async () => {
+  const data = mappedLanguages.value.map((language) => ({
+    id: language.id,
+    remoteCode: language.remoteCode,
+    localInstance: language.localInstance,
+  }));
+
+  await apolloClient.mutate({
+    mutation: bulkUpdateRemoteLanguagesMutation,
+    variables: { data },
+  });
+};
+
+const bulkUpdateCurrencies = async () => {
+  const data = mappedCurrencies.value.map((currency) => ({
+    id: currency.id,
+    remoteCode: currency.remoteCode,
+    localInstance: currency.localInstance ? { id: currency.localInstance } : null,
+  }));
+
+  await apolloClient.mutate({
+    mutation: bulkUpdateRemoteCurrenciesMutation,
+    variables: { data },
+  });
+};
+
+const createImport = async () => {
+  await apolloClient.mutate({
+    mutation: createEbayImportProcessMutation,
+    variables: {
+      data: {
+        salesChannel: { id: props.integrationId },
+        type: importType.value,
+        status: "pending",
+      },
+    },
+  });
+};
+
+const steps = [
+  { key: "languages", action: bulkUpdateLanguages },
+  { key: "currencies", action: bulkUpdateCurrencies },
+  { key: "import", action: createImport },
+];
+
+const currentFinishStepName = computed(() =>
+  currentFinishStep.value !== null
+    ? t(`integrations.imports.create.wizard.finish.steps.${steps[currentFinishStep.value].key}`)
+    : ""
+);
+
+const handleFinish = async () => {
+  finishLoading.value = true;
+  currentFinishStep.value = null;
+
+  try {
+    for (let index = 0; index < steps.length; index += 1) {
+      currentFinishStep.value = index;
+      await steps[index].action();
+    }
+
+    Toast.success(t("integrations.imports.create.success"));
+    router.push({
+      name: "integrations.integrations.show",
+      params: { id: props.integrationId, type: props.type },
+      query: { tab: "imports" },
+    });
+  } catch (error) {
+    console.error(`Error at step "${currentFinishStepName.value}":`, error);
+    const validationErrors = processGraphQLErrors(error, t);
+
+    if (validationErrors["__all__"]) {
+      Toast.error(validationErrors["__all__"]);
+    } else {
+      Toast.error(
+        t("integrations.imports.create.wizard.finish.errorMessage", {
+          step: currentFinishStepName.value,
+        }),
+      );
+    }
+  } finally {
+    finishLoading.value = false;
+    currentFinishStep.value = null;
+  }
+};
+</script>
+
+<template>
+  <div>
+    <div v-if="loading" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+      <div class="text-center">
+        <svg class="animate-spin h-10 w-10 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+        </svg>
+      </div>
+    </div>
+
+    <div v-if="finishLoading" class="fixed inset-0 z-50 flex items-center justify-center">
+      <div class="absolute inset-0 bg-black opacity-50"></div>
+      <div class="relative bg-white dark:bg-[#191e3a] rounded-lg p-6 w-96 shadow-lg z-50 flex flex-col items-center gap-4">
+        <h2 class="text-lg font-semibold text-center text-dark dark:text-white-light">
+          {{ t('integrations.imports.create.wizard.finish.title') }}
+        </h2>
+        <p class="text-sm text-gray-500 dark:text-white-light text-center">{{ currentFinishStepName }}</p>
+        <div class="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            class="h-full bg-primary transition-all"
+            :style="{ width: ((currentFinishStep !== null ? (currentFinishStep + 1) / steps.length : 0) * 100) + '%' }"
+          ></div>
+        </div>
+      </div>
+    </div>
+
+    <Wizard
+      :steps="wizardSteps"
+      :allow-next-step="allowNextStep"
+      :show-buttons="true"
+      @on-finish="handleFinish"
+      @update-current-step="updateStep"
+    >
+      <template #selectType>
+        <div class="flex flex-col gap-6">
+          <OptionSelector v-model="importType" :choices="typeChoices">
+            <template #schema>
+              <div class="flex flex-col gap-2">
+                <div class="flex items-center gap-2">
+                  <h3 class="text-lg font-bold">
+                    {{ t('integrations.imports.types.schema') }}
+                  </h3>
+                </div>
+                <p class="text-sm text-gray-500">
+                  {{ t('integrations.imports.types.schemaDescription') }}
+                </p>
+              </div>
+            </template>
+            <template #products>
+              <div class="flex flex-col gap-2">
+                <div class="flex items-center gap-2">
+                  <h3 class="text-lg font-bold">
+                    {{ t('integrations.imports.types.products') }}
+                  </h3>
+                </div>
+                <p class="text-sm text-gray-500">
+                  {{ t('integrations.imports.types.productsDescription') }}
+                </p>
+                <div
+                  v-if="!hasFinishedSchema"
+                  class="text-sm text-gray-400 flex items-center gap-1"
+                >
+                  <Icon name="exclamation-circle" class="text-gray-400" />
+                  <span>{{ t('integrations.imports.types.schemaRequired') }}</span>
+                </div>
+              </div>
+            </template>
+          </OptionSelector>
+        </div>
+      </template>
+
+      <template #mapLanguages>
+        <EbayLanguagesStep
+          :sales-channel-id="integrationId"
+          @update:languages="updateLanguages"
+        />
+      </template>
+
+      <template #mapCurrencies>
+        <EbayCurrenciesStep
+          :sales-channel-id="integrationId"
+          @update:currencies="updateCurrencies"
+        />
+      </template>
+    </Wizard>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayCurrenciesStep.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayCurrenciesStep.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { computed, defineEmits, defineExpose, defineProps, onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import apolloClient from "../../../../../../../../../../../../../apollo-client";
+import { DiscreteLoader } from "../../../../../../../../../../../../shared/components/atoms/discrete-loader";
+import {
+  FieldQuery,
+} from "../../../../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
+import { QueryFormField } from "../../../../../../../../../../../../shared/components/organisms/general-form/formConfig";
+import { FieldType } from "../../../../../../../../../../../../shared/utils/constants";
+import { remoteCurrenciesQuery } from "../../../../../../../../../../../../shared/api/queries/salesChannels.js";
+import { currenciesQuerySelector } from "../../../../../../../../../../../../shared/api/queries/currencies.js";
+import { currencyOnTheFlyConfig } from "../../../../../../../../../../../settings/currencies/configs";
+import type { RemoteCurrency } from "../../../../../../configs";
+
+const props = defineProps<{
+  salesChannelId: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:currencies", value: RemoteCurrency[]): void;
+}>();
+
+const { t } = useI18n();
+
+const currencies = ref<RemoteCurrency[]>([]);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+const currencyField = computed(() => ({
+  type: FieldType.Query,
+  name: "localInstance",
+  label: t("shared.labels.currency"),
+  labelBy: "isoCode",
+  valueBy: "id",
+  query: currenciesQuerySelector,
+  dataKey: "currencies",
+  isEdge: true,
+  multiple: false,
+  filterable: true,
+  removable: true,
+  optional: true,
+  formMapIdentifier: "id",
+  createOnFlyConfig: currencyOnTheFlyConfig(t),
+}));
+
+const fetchCurrencies = async () => {
+  loading.value = true;
+  error.value = null;
+
+  try {
+    const { data } = await apolloClient.query({
+      query: remoteCurrenciesQuery,
+      variables: {
+        filter: { salesChannel: { id: { exact: props.salesChannelId } } },
+      },
+      fetchPolicy: "cache-first",
+    });
+
+    currencies.value = data?.remoteCurrencies?.edges?.map((edge: any) => ({
+      id: edge.node.id,
+      remoteCode: edge.node.remoteCode,
+      name: edge.node.name,
+      localInstance: edge.node.localInstance ? edge.node.localInstance.id : null,
+    })) || [];
+
+    if (!currencies.value.length) {
+      error.value = t("integrations.imports.create.ebay.currencies.noData");
+    }
+  } catch (err) {
+    console.error(err);
+    error.value = t("integrations.imports.create.ebay.currencies.fetchError");
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchCurrencies);
+
+const isValid = computed(() =>
+  currencies.value.length > 0 && currencies.value.every((currency) => Boolean(currency.localInstance))
+);
+
+defineExpose({
+  isValid,
+  currencies,
+});
+
+watch(
+  currencies,
+  () => {
+    emit("update:currencies", currencies.value);
+  },
+  { deep: true },
+);
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 min-h-96">
+    <div class="text-center">
+      <h1 class="text-2xl mb-2">{{ t('integrations.imports.create.ebay.currencies.title') }}</h1>
+      <p class="text-sm text-gray-500">{{ t('integrations.imports.create.ebay.currencies.description') }}</p>
+    </div>
+    <hr />
+    <div v-if="loading" class="text-center py-4">
+      <DiscreteLoader :loading="loading" />
+    </div>
+    <div v-else-if="error" class="text-center text-red-500 py-4">{{ error }}</div>
+    <div v-else>
+      <h3 class="text-md font-medium mb-4">{{ t('integrations.imports.create.wizard.step1.currencies') }}</h3>
+      <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+        <thead class="bg-gray-100 dark:bg-gray-700 text-xs uppercase">
+          <tr>
+            <th class="p-3">{{ t('integrations.show.currencies.labels.remoteCode') }}</th>
+            <th class="p-3">{{ t('shared.labels.currency') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <tr v-for="currency in currencies" :key="currency.id" class="border-t">
+            <td class="p-3">{{ currency.name }}</td>
+            <td class="p-3 w-96">
+              <FieldQuery
+                v-model="currency.localInstance"
+                :field="currencyField as QueryFormField"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayLanguagesStep.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayLanguagesStep.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { computed, defineEmits, defineExpose, defineProps, onMounted, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import apolloClient from "../../../../../../../../../../../../../apollo-client";
+import { DiscreteLoader } from "../../../../../../../../../../../../shared/components/atoms/discrete-loader";
+import {
+  FieldQuery,
+} from "../../../../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
+import { QueryFormField } from "../../../../../../../../../../../../shared/components/organisms/general-form/formConfig";
+import { FieldType } from "../../../../../../../../../../../../shared/utils/constants";
+import { remoteLanguagesQuery } from "../../../../../../../../../../../../shared/api/queries/salesChannels.js";
+import { companyLanguagesQuery } from "../../../../../../../../../../../../shared/api/queries/languages.js";
+import type { RemoteLanguage } from "../../../../../../configs";
+
+const props = defineProps<{
+  salesChannelId: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:languages", value: RemoteLanguage[]): void;
+}>();
+
+const { t } = useI18n();
+
+const languages = ref<RemoteLanguage[]>([]);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+const languageField = computed(() => ({
+  type: FieldType.Query,
+  name: "localInstance",
+  label: t("shared.placeholders.language"),
+  labelBy: "name",
+  valueBy: "code",
+  query: companyLanguagesQuery,
+  dataKey: "companyLanguages",
+  isEdge: false,
+  multiple: false,
+  filterable: true,
+}));
+
+const fetchLanguages = async () => {
+  loading.value = true;
+  error.value = null;
+
+  try {
+    const { data } = await apolloClient.query({
+      query: remoteLanguagesQuery,
+      variables: {
+        filter: { salesChannel: { id: { exact: props.salesChannelId } } },
+      },
+      fetchPolicy: "cache-first",
+    });
+
+    languages.value = data?.remoteLanguages?.edges?.map((edge: any) => ({
+      id: edge.node.id,
+      remoteCode: edge.node.remoteCode,
+      name: edge.node.name,
+      localInstance: edge.node.localInstance || null,
+    })) || [];
+
+    if (!languages.value.length) {
+      error.value = t("integrations.imports.create.ebay.languages.noData");
+    }
+  } catch (err) {
+    console.error(err);
+    error.value = t("integrations.imports.create.ebay.languages.fetchError");
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(fetchLanguages);
+
+const isValid = computed(() =>
+  languages.value.length > 0 && languages.value.every((language) => Boolean(language.localInstance))
+);
+
+defineExpose({
+  isValid,
+  languages,
+});
+
+watch(
+  languages,
+  () => {
+    emit("update:languages", languages.value);
+  },
+  { deep: true },
+);
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 min-h-96">
+    <div class="text-center">
+      <h1 class="text-2xl mb-2">{{ t('integrations.imports.create.ebay.languages.title') }}</h1>
+      <p class="text-sm text-gray-500">{{ t('integrations.imports.create.ebay.languages.description') }}</p>
+    </div>
+    <hr />
+    <div v-if="loading" class="text-center py-4">
+      <DiscreteLoader :loading="loading" />
+    </div>
+    <div v-else-if="error" class="text-center text-red-500 py-4">{{ error }}</div>
+    <div v-else>
+      <h3 class="text-md font-medium mb-4">{{ t('integrations.imports.create.wizard.step1.languages') }}</h3>
+      <table class="w-full min-w-max divide-y divide-gray-300 table-hover">
+        <thead class="bg-gray-100 dark:bg-gray-700 text-xs uppercase">
+          <tr>
+            <th class="p-3">{{ t('integrations.show.languages.labels.remoteCode') }}</th>
+            <th class="p-3">{{ t('shared.labels.language') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <tr v-for="language in languages" :key="language.id" class="border-t">
+            <td class="p-3">{{ language.name }}</td>
+            <td class="p-3 w-96">
+              <FieldQuery
+                v-model="language.localInstance"
+                :field="languageField as QueryFormField"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/index.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/index.ts
@@ -1,0 +1,1 @@
+export { default as EbayImporter } from './EbayImporter.vue';

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -272,6 +272,29 @@
           "NAME_TOO_LONG": "Name too long",
           "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
+      },
+      "create": {
+        "ebay": {
+          "wizard": {
+            "steps": {
+              "type": "",
+              "languages": "",
+              "currencies": ""
+            },
+            "languages": {
+              "title": "",
+              "description": "",
+              "noData": "",
+              "fetchError": ""
+            },
+            "currencies": {
+              "title": "",
+              "description": "",
+              "noData": "",
+              "fetchError": ""
+            }
+          }
+        }
       }
     },
     "ebay": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -3059,6 +3059,27 @@
             }
           }
         }
+      },
+      "ebay": {
+        "wizard": {
+          "steps": {
+            "type": "Select import type",
+            "languages": "Map languages",
+            "currencies": "Map currencies"
+          },
+          "languages": {
+            "title": "Map your remote languages",
+            "description": "Match every remote language with a local language to continue.",
+            "noData": "No languages available. Please try again later.",
+            "fetchError": "An error occurred while fetching remote languages."
+          },
+          "currencies": {
+            "title": "Map your remote currencies",
+            "description": "Match every remote currency with a local currency to continue.",
+            "noData": "No currencies available. Please try again later.",
+            "fetchError": "An error occurred while fetching remote currencies."
+          }
+        }
       }
     }
   },

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -267,6 +267,29 @@
           "NAME_TOO_LONG": "Name too long",
           "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
+      },
+      "create": {
+        "ebay": {
+          "wizard": {
+            "steps": {
+              "type": "",
+              "languages": "",
+              "currencies": ""
+            },
+            "languages": {
+              "title": "",
+              "description": "",
+              "noData": "",
+              "fetchError": ""
+            },
+            "currencies": {
+              "title": "",
+              "description": "",
+              "noData": "",
+              "fetchError": ""
+            }
+          }
+        }
       }
     },
     "ebay": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -2076,6 +2076,29 @@
           "NAME_TOO_LONG": "Name too long",
           "INVALID_VARIATION_THEME": "Invalid variation theme"
         }
+      },
+      "create": {
+        "ebay": {
+          "wizard": {
+            "steps": {
+              "type": "",
+              "languages": "",
+              "currencies": ""
+            },
+            "languages": {
+              "title": "",
+              "description": "",
+              "noData": "",
+              "fetchError": ""
+            },
+            "currencies": {
+              "title": "",
+              "description": "",
+              "noData": "",
+              "fetchError": ""
+            }
+          }
+        }
       }
     }
   }

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -738,6 +738,36 @@ export const updateAmazonImportProcessMutation = gql`
   }
 `;
 
+export const createEbayImportProcessMutation = gql`
+  mutation createEbayImportProcess($data: EbaySalesChannelImportInput!) {
+    createEbayImportProcess(data: $data) {
+      id
+      type
+      status
+      percentage
+      createdAt
+      salesChannel {
+        id
+      }
+    }
+  }
+`;
+
+export const updateEbayImportProcessMutation = gql`
+  mutation updateEbayImportProcess($data: EbaySalesChannelImportPartialInput!) {
+    updateEbayImportProcess(data: $data) {
+      id
+      type
+      status
+      percentage
+      createdAt
+      salesChannel {
+        id
+      }
+    }
+  }
+`;
+
 // Amazon Default Unit Configurator Mutation
 export const updateAmazonDefaultUnitConfiguratorMutation = gql`
   mutation updateAmazonDefaultUnitConfigurator($data: AmazonDefaultUnitConfiguratorPartialInput!) {

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -1443,6 +1443,40 @@ export const amazonImportProcessesQuery = gql`
   }
 `;
 
+export const ebayImportProcessesQuery = gql`
+  query EbayImportProcesses(
+    $first: Int,
+    $last: Int,
+    $after: String,
+    $before: String,
+    $order: EbaySalesChannelImportOrder,
+    $filter: EbaySalesChannelImportFilter
+  ) {
+    ebayImportProcesses(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          type
+          status
+          percentage
+          createdAt
+          salesChannel {
+            id
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
 // Amazon Default Unit Configurator Queries
 export const amazonDefaultUnitConfiguratorsQuery = gql`
   query AmazonDefaultUnitConfigurators(

--- a/src/shared/api/subscriptions/salesChannels.js
+++ b/src/shared/api/subscriptions/salesChannels.js
@@ -21,6 +21,14 @@ export const salesChannelSubscription = gql`
         percentage
         createdAt
       }
+      ebayImports {
+        id
+        proxyId
+        type
+        status
+        percentage
+        createdAt
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- add an eBay-specific import wizard with type selection, language mapping, and currency mapping before creating the process
- provide an eBay-only imports table and extend shared configs and subscriptions to surface eBay import jobs
- expose the required GraphQL operations and translation keys for eBay import flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2f66aa7d8832eafa7eb46eb9481d7