### PR TITLE
feat(products): add price list assignment in product show

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/sales-price-lists/SalesPricelistAdd.vue
+++ b/src/core/products/products/product-show/containers/tabs/sales-price-lists/SalesPricelistAdd.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import debounce from 'lodash.debounce';
+import { useI18n } from 'vue-i18n';
+import { Selector } from "../../../../../../../shared/components/atoms/selector";
+import { PrimaryButton } from "../../../../../../../shared/components/atoms/button-primary";
+import { DangerButton } from "../../../../../../../shared/components/atoms/button-danger";
+import { Product } from "../../../../configs";
+import apolloClient from "../../../../../../../../apollo-client";
+import { salesPriceListItemsQuery, salesPriceListsQuerySelector } from "../../../../../../../shared/api/queries/salesPrices.js";
+import { createSalesPriceListItemMutation } from "../../../../../../../shared/api/mutations/salesPrices.js";
+import { processGraphQLErrors } from "../../../../../../../shared/utils";
+import { Toast } from "../../../../../../../shared/modules/toast";
+
+interface PriceListOption {
+  id: string;
+  name: string;
+}
+
+const props = defineProps<{ product: Product }>();
+const emit = defineEmits<{ (event: 'added'): void }>();
+
+const { t } = useI18n();
+
+const isFormVisible = ref(false);
+const priceLists = ref<PriceListOption[]>([]);
+const existingPriceListIds = ref<string[]>([]);
+const selectedPriceListId = ref('');
+const loading = ref(false);
+const submitting = ref(false);
+const search = ref('');
+
+const cleanedData = (rawData: any): PriceListOption[] => {
+  return rawData?.edges ? rawData.edges.map((edge: any) => edge.node) : [];
+};
+
+const fetchExistingPriceListIds = async () => {
+  try {
+    const { data } = await apolloClient.query({
+      query: salesPriceListItemsQuery,
+      variables: {
+        filter: { product: { id: { exact: props.product.id } } },
+        first: 250,
+      },
+      fetchPolicy: 'network-only',
+    });
+
+    if (data?.salesPriceListItems?.edges) {
+      existingPriceListIds.value = data.salesPriceListItems.edges.map(
+        (edge: any) => edge.node.salespricelist.id,
+      );
+    } else {
+      existingPriceListIds.value = [];
+    }
+  } catch (error) {
+    existingPriceListIds.value = [];
+  }
+};
+
+const fetchPriceLists = async () => {
+  loading.value = true;
+  const filter: Record<string, any> = {
+    NOT: { id: { inList: existingPriceListIds.value } },
+  };
+
+  if (search.value) {
+    filter.search = search.value;
+  }
+
+  try {
+    const { data } = await apolloClient.query({
+      query: salesPriceListsQuerySelector,
+      variables: { filter },
+      fetchPolicy: 'network-only',
+    });
+
+    priceLists.value = cleanedData(data?.salesPriceLists);
+  } finally {
+    loading.value = false;
+  }
+};
+
+const resetForm = () => {
+  selectedPriceListId.value = '';
+  search.value = '';
+  priceLists.value = [];
+  isFormVisible.value = false;
+};
+
+const handleAddClick = async () => {
+  isFormVisible.value = true;
+  await fetchExistingPriceListIds();
+  await fetchPriceLists();
+};
+
+const handleSearch = debounce(async (value: string) => {
+  search.value = value;
+  await fetchPriceLists();
+}, 300);
+
+const handleSubmit = async () => {
+  if (!selectedPriceListId.value) {
+    return;
+  }
+
+  submitting.value = true;
+
+  try {
+    await apolloClient.mutate({
+      mutation: createSalesPriceListItemMutation,
+      variables: {
+        data: {
+          product: { id: props.product.id },
+          salespricelist: { id: selectedPriceListId.value },
+        },
+      },
+    });
+
+    emit('added');
+    resetForm();
+  } catch (error) {
+    const errors = processGraphQLErrors(error, t);
+
+    if (errors['__all__']) {
+      Toast.error(errors['__all__']);
+    }
+  } finally {
+    submitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <Flex class="mb-4" gap="2">
+    <template v-if="isFormVisible">
+      <FlexCell grow>
+        <div v-if="loading" class="flex items-center gap-2">
+          <svg class="h-5 w-5 animate-spin text-black" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <span>{{ t('shared.messages.loading') }}</span>
+        </div>
+        <Selector
+          v-else
+          v-model="selectedPriceListId"
+          :options="priceLists"
+          label-by="name"
+          value-by="id"
+          :placeholder="t('products.products.priceLists.add.placeholder')"
+          :removable="false"
+          filterable
+          class="min-w-96"
+          @searched="handleSearch"
+        />
+      </FlexCell>
+      <FlexCell>
+        <PrimaryButton :disabled="submitting || !selectedPriceListId" type="button" @click="handleSubmit">
+          {{ t('products.products.priceLists.add.select') }}
+        </PrimaryButton>
+      </FlexCell>
+      <FlexCell>
+        <DangerButton type="button" class="ml-2" @click="resetForm">
+          {{ t('shared.button.cancel') }}
+        </DangerButton>
+      </FlexCell>
+    </template>
+    <FlexCell v-else>
+      <PrimaryButton type="button" class="btn btn-primary" @click="handleAddClick">
+        {{ t('shared.button.add') }}
+      </PrimaryButton>
+    </FlexCell>
+  </Flex>
+</template>

--- a/src/core/products/products/product-show/containers/tabs/sales-price-lists/SalesPricelistList.vue
+++ b/src/core/products/products/product-show/containers/tabs/sales-price-lists/SalesPricelistList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 
+import { ref } from "vue";
 import { Product } from "../../../../configs";
 import { listingQuery, listingQueryKey, searchConfigConstructor, listingConfigConstructor } from "./configs";
 import { GeneralListing } from "../../../../../../../shared/components/organisms/general-listing";
@@ -7,6 +8,7 @@ import { Link } from "../../../../../../../shared/components/atoms/link";
 import { Button } from "../../../../../../../shared/components/atoms/button";
 import { useI18n } from "vue-i18n";
 import TabContentTemplate from "../TabContentTemplate.vue";
+import SalesPricelistAdd from "./SalesPricelistAdd.vue";
 
 const { t } = useI18n();
 
@@ -15,12 +17,20 @@ const props = defineProps<{ product: Product }>();
 const searchConfig = searchConfigConstructor(t);
 const listingConfig = listingConfigConstructor(t);
 
+const refreshKey = ref(0);
+
+const handleItemAdded = () => {
+  refreshKey.value += 1;
+};
+
 </script>
 
 <template>
   <TabContentTemplate>
     <template v-slot:content>
+      <SalesPricelistAdd :product="product" @added="handleItemAdded" />
       <GeneralListing
+        :key="refreshKey"
         :search-config="searchConfig"
         :config="listingConfig"
         :query="listingQuery"

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -103,6 +103,12 @@
       "tabs": {
         "amazon": "Amazon"
       },
+      "priceLists": {
+        "add": {
+          "placeholder": "",
+          "select": ""
+        }
+      },
       "variations": {
         "content": {
           "validation": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -996,6 +996,12 @@
         "hsCodes": "HS Codes",
         "eanCodes": "EAN Codes"
       },
+      "priceLists": {
+        "add": {
+          "placeholder": "Select a price list",
+          "select": "Select"
+        }
+      },
       "variations": {
         "tabs": {
           "list": "List",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -98,6 +98,12 @@
       "tabs": {
         "amazon": "Amazon"
       },
+      "priceLists": {
+        "add": {
+          "placeholder": "",
+          "select": ""
+        }
+      },
       "variations": {
         "content": {
           "validation": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -679,6 +679,12 @@
         "websites": "Verkoopskanalen",
         "amazon": "Amazon"
       },
+      "priceLists": {
+        "add": {
+          "placeholder": "",
+          "select": ""
+        }
+      },
       "variations": {
         "tabs": {
           "list": "Lijst",


### PR DESCRIPTION
## Summary
- add a price list selector to the product price list tab so users can attach available lists to the product
- refresh the listing after creating a SalesPriceListItem to include the newly linked list
- add i18n keys for the new controls across supported locales

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2f6ebded8832e959ccf7f2d0d4a33