### PR TITLE
Allow partial eBay import mappings

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/EbayImporter.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/EbayImporter.vue
@@ -54,17 +54,11 @@ const allowNextStep = computed(() => {
   }
 
   if (step.value === 1) {
-    return (
-      mappedLanguages.value.length > 0 &&
-      mappedLanguages.value.every((language) => Boolean(language.localInstance))
-    );
+    return mappedLanguages.value.some((language) => Boolean(language.localInstance));
   }
 
   if (step.value === 2) {
-    return (
-      mappedCurrencies.value.length > 0 &&
-      mappedCurrencies.value.every((currency) => Boolean(currency.localInstance))
-    );
+    return mappedCurrencies.value.some((currency) => Boolean(currency.localInstance));
   }
 
   return true;

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayCurrenciesStep.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayCurrenciesStep.vue
@@ -78,7 +78,7 @@ const fetchCurrencies = async () => {
 onMounted(fetchCurrencies);
 
 const isValid = computed(() =>
-  currencies.value.length > 0 && currencies.value.every((currency) => Boolean(currency.localInstance))
+  currencies.value.some((currency) => Boolean(currency.localInstance))
 );
 
 defineExpose({

--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayLanguagesStep.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayLanguagesStep.vue
@@ -73,7 +73,7 @@ const fetchLanguages = async () => {
 onMounted(fetchLanguages);
 
 const isValid = computed(() =>
-  languages.value.length > 0 && languages.value.every((language) => Boolean(language.localInstance))
+  languages.value.some((language) => Boolean(language.localInstance))
 );
 
 defineExpose({

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -3075,13 +3075,13 @@
           },
           "languages": {
             "title": "Map your remote languages",
-            "description": "Match every remote language with a local language to continue.",
+            "description": "Match at least one remote language with a local language to continue.",
             "noData": "No languages available. Please try again later.",
             "fetchError": "An error occurred while fetching remote languages."
           },
           "currencies": {
             "title": "Map your remote currencies",
-            "description": "Match every remote currency with a local currency to continue.",
+            "description": "Match at least one remote currency with a local currency to continue.",
             "noData": "No currencies available. Please try again later.",
             "fetchError": "An error occurred while fetching remote currencies."
           }


### PR DESCRIPTION
## Summary
- allow the eBay import wizard to advance when at least one language or currency has been mapped
- update the eBay import copy to clarify that only one mapping is required

## Testing
- npm run build *(fails: TS2345 in IntegrationsRemoteProductTypeEditController.vue, pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68d303ef295c832ebdcff74429ae9a49