### PR TITLE
Add marketplace display and filter to eBay product types

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/RemoteProductTypes.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/RemoteProductTypes.vue
@@ -30,7 +30,7 @@ const pulling = ref(false);
 const listingQueryKey = computed(() => getListingQueryKey(type.value));
 const listingQuery = computed(() => getListingQuery(type.value));
 const pullMutation = computed(() => getCreateProductTypesFromLocalRulesMutation(type.value));
-const searchConfig = computed(() => productTypesSearchConfigConstructor(t, type.value));
+const searchConfig = computed(() => productTypesSearchConfigConstructor(t, type.value, salesChannelId.value));
 const listingConfig = computed(() => productTypesListingConfigConstructor(t, type.value, integrationId.value, salesChannelId.value));
 
 const fetchFirstUnmapped = async () => {

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/configs.ts
@@ -2,6 +2,7 @@ import { IntegrationTypes } from "../../../../../integrations";
 import { FieldType } from "../../../../../../../../shared/utils/constants";
 import {
   amazonProductTypesQuery,
+  ebayChannelViewsQuery,
   ebayProductTypesQuery,
   getAmazonProductTypeQuery,
   getEbayProductTypeQuery,
@@ -17,7 +18,7 @@ import {
 } from "../../../../../../../../shared/api/mutations/salesChannels.js";
 import { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
 import { FormConfig, FormType } from "../../../../../../../../shared/components/organisms/general-form/formConfig";
-import { SearchConfig } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
+import { SearchConfig, SearchFilter } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
 import type {
   ImportedRemoteProductTypeConfig,
   MappedRemoteProductTypeConfig,
@@ -141,16 +142,38 @@ export const productTypeEditFormConfigConstructor = (
 
 export const productTypesSearchConfigConstructor = (
   t: Function,
-  _integrationType: string
-): SearchConfig => ({
-  search: true,
-  orderKey: 'sort',
-  filters: [
+  integrationType: string,
+  salesChannelId: string,
+): SearchConfig => {
+  const filters: SearchFilter[] = [
     { type: FieldType.Boolean, name: 'mappedLocally', label: t('integrations.show.mapping.mappedLocally'), strict: true },
     { type: FieldType.Boolean, name: 'mappedRemotely', label: t('integrations.show.mapping.mappedRemotely'), strict: true },
-  ],
-  orders: [],
-});
+  ];
+
+  if (integrationType === IntegrationTypes.Ebay) {
+    filters.push({
+      type: FieldType.Query,
+      name: 'marketplace',
+      label: t('integrations.show.propertySelectValues.labels.marketplace'),
+      labelBy: 'name',
+      valueBy: 'id',
+      query: ebayChannelViewsQuery,
+      dataKey: 'ebaySalesChannelViews',
+      filterable: true,
+      isEdge: true,
+      addLookup: true,
+      lookupKeys: ['id'],
+      queryVariables: { filters: { salesChannel: { id: { exact: salesChannelId } } } },
+    });
+  }
+
+  return {
+    search: true,
+    orderKey: 'sort',
+    filters,
+    orders: [],
+  };
+};
 
 const amazonProductTypesListingConfig = (
   t: Function,
@@ -200,6 +223,7 @@ const ebayProductTypesListingConfig = (
     t('integrations.show.mapping.mappedLocally'),
     t('integrations.show.mapping.mappedRemotely'),
     t('properties.rule.title'),
+    t('integrations.show.propertySelectValues.labels.marketplace'),
   ],
   fields: [
     { name: 'name', type: FieldType.Text },
@@ -213,6 +237,12 @@ const ebayProductTypesListingConfig = (
       clickable: true,
       clickIdentifiers: [{ id: ['id'] }],
       clickUrl: { name: 'properties.rule.show' },
+    },
+    {
+      name: 'marketplace',
+      type: FieldType.NestedText,
+      keys: ['name'],
+      showLabel: true,
     },
   ],
   identifierKey: 'id',

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/ImportedRemoteProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/ImportedRemoteProductType.vue
@@ -42,6 +42,7 @@ const localInstancePath = computed(() => {
   return id ? { name: 'properties.rule.show', params: { id } } : null;
 });
 const localInstanceName = computed(() => props.productType?.localInstance?.value || '');
+const marketplaceName = computed(() => props.productType?.marketplace?.name || '');
 
 const marketplaceField = computed<QueryFormField>(() => ({
   type: FieldType.Query,
@@ -58,7 +59,7 @@ const marketplaceField = computed<QueryFormField>(() => ({
 }));
 
 const productName = ref('');
-const marketplace = ref();
+const marketplace = ref<string | null>(null);
 const suggestions = ref<NormalizedSuggestion[]>([]);
 const allProductTypes = ref<NormalizedSuggestion[]>([]);
 const selectedCode = ref<string>('');
@@ -72,6 +73,14 @@ watch(
   () => props.productType?.localInstance?.value,
   (value) => {
     productName.value = value || '';
+  },
+  { immediate: true },
+);
+
+watch(
+  () => props.productType?.marketplace?.id,
+  (value) => {
+    marketplace.value = value || null;
   },
   { immediate: true },
 );
@@ -102,7 +111,7 @@ const runSuggestion = async (name: string | null): Promise<NormalizedSuggestion[
     mutation: props.config.suggestMutation,
     variables: props.config.getSuggestionVariables({
       name,
-      marketplace: String(marketplace.value),
+      marketplace: marketplace.value ? String(marketplace.value) : '',
     }),
   });
 
@@ -247,6 +256,10 @@ const save = async () => {
               <div v-if="selectedName">
                 <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('integrations.show.productRules.labels.selectedProductType') }}</label>
                 <p class="mt-1 text-sm">{{ selectedName }}</p>
+              </div>
+              <div v-if="marketplaceName">
+                <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('integrations.show.propertySelectValues.labels.marketplace') }}</label>
+                <p class="mt-1 text-sm">{{ marketplaceName }}</p>
               </div>
               <div class="grid grid-cols-1 md:grid-cols-2 md:gap-6 md:divide-x">
                 <div class="space-y-4">

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/RemotelyMappedRemoteProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/RemotelyMappedRemoteProductType.vue
@@ -58,6 +58,7 @@ const accordionItems = [
 ];
 
 const integrationTitle = computed(() => props.config.getIntegrationTitle(t, type.value));
+const marketplaceName = computed(() => props.productType?.marketplace?.name || '');
 
 const updateItemsFromData = (data: any) => {
   items.value = props.config.extractItems(data, state);
@@ -250,6 +251,14 @@ const showCodeColumn = computed(() => typeof props.config.getItemCode === 'funct
           </Link>
         </template>
       </GeneralForm>
+
+      <div
+        v-if="marketplaceName"
+        class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl p-6 mt-4"
+      >
+        <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('integrations.show.propertySelectValues.labels.marketplace') }}</label>
+        <p class="mt-1 text-sm">{{ marketplaceName }}</p>
+      </div>
 
       <div class="grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3 mt-4">
         <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -1356,6 +1356,10 @@ export const ebayProductTypesQuery = gql`
           mappedRemotely
           name
           translatedName
+          marketplace {
+            id
+            name
+          }
           localInstance {
             id
             value
@@ -1387,6 +1391,10 @@ export const getEbayProductTypeQuery = gql`
       imported
       name
       translatedName
+      marketplace {
+        id
+        name
+      }
       localInstance {
         id
         value


### PR DESCRIPTION
## Summary
- add a marketplace filter and column to the eBay product type listing
- show the marketplace of the current eBay product type in both imported and mapped edit views
- extend the eBay product type queries to include marketplace details for listings and edits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d302f89088832eaf56c6c7cc96a9cc