### PR TITLE
Adjust remote currency queries for eBay

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayCurrenciesStep.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/imports/containers/create-import/containers/ebay/ebay-importer/components/EbayCurrenciesStep.vue
@@ -8,7 +8,7 @@ import {
 } from "../../../../../../../../../../../../shared/components/organisms/general-form/containers/form-fields/field-query";
 import { QueryFormField } from "../../../../../../../../../../../../shared/components/organisms/general-form/formConfig";
 import { FieldType } from "../../../../../../../../../../../../shared/utils/constants";
-import { remoteCurrenciesQuery } from "../../../../../../../../../../../../shared/api/queries/salesChannels.js";
+import { ebayRemoteCurrenciesQuery } from "../../../../../../../../../../../../shared/api/queries/salesChannels.js";
 import { currenciesQuerySelector } from "../../../../../../../../../../../../shared/api/queries/currencies.js";
 import { currencyOnTheFlyConfig } from "../../../../../../../../../../../settings/currencies/configs";
 import type { RemoteCurrency } from "../../../../../../configs";
@@ -89,7 +89,7 @@ const fetchCurrencies = async () => {
   try {
     const [remoteResult, localCurrencyMap] = await Promise.all([
       apolloClient.query({
-        query: remoteCurrenciesQuery,
+        query: ebayRemoteCurrenciesQuery,
         variables: {
           filter: { salesChannel: { id: { exact: props.salesChannelId } } },
         },
@@ -120,7 +120,7 @@ const fetchCurrencies = async () => {
           id: node.id,
           remoteCode: node.remoteCode,
           name: node.name,
-          marketplaceName: node?.marketplace?.name || null,
+          marketplaceName: node?.salesChannelView?.name || null,
           localInstance: autoMappedInstance,
         };
       }) || [];

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -790,7 +790,43 @@ export const remoteCurrenciesQuery = gql`
           id
           remoteCode
           name
-          marketplace {
+          localInstance {
+            id
+            name
+            symbol
+            isoCode
+          }
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const ebayRemoteCurrenciesQuery = gql`
+  query EbayRemoteCurrencies(
+    $first: Int,
+    $last: Int,
+    $after: String,
+    $before: String,
+    $order: RemoteCurrencyOrder,
+    $filter: RemoteCurrencyFilter
+  ) {
+    remoteCurrencies(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          id
+          remoteCode
+          name
+          salesChannelView {
+            id
             name
           }
           localInstance {


### PR DESCRIPTION
## Summary
- remove the unavailable `marketplace` selection from the shared remote currencies query
- add a dedicated eBay remote currencies query that exposes the related sales channel view
- switch the eBay import currency step to the new query and derive the marketplace name from the sales channel view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cdc0e528832eaf39b4caca69b5ab