### PR TITLE
Refactor remote property edit to type-specific components

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
@@ -1,8 +1,49 @@
 import { FieldType, getPropertyTypeOptions } from "../../../../../../../../shared/utils/constants";
-import { ebayPropertiesQuery, ebayChannelViewsQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
+import { ebayPropertiesQuery, ebayChannelViewsQuery, getEbayPropertyQuery } from "../../../../../../../../shared/api/queries/salesChannels.js";
 import { propertiesQuerySelector } from "../../../../../../../../shared/api/queries/properties.js";
 import { ListingConfig } from "../../../../../../../../shared/components/organisms/general-listing/listingConfig";
+import { FormConfig, FormType } from "../../../../../../../../shared/components/organisms/general-form/formConfig";
 import { SearchConfig } from "../../../../../../../../shared/components/organisms/general-search/searchConfig";
+import { updateEbayPropertyMutation } from "../../../../../../../../shared/api/mutations/salesChannels.js";
+
+export const ebayPropertyEditFormConfigConstructor = (
+  t: Function,
+  type: string,
+  propertyId: string,
+  integrationId: string,
+): FormConfig => ({
+  cols: 1,
+  type: FormType.EDIT,
+  mutation: updateEbayPropertyMutation,
+  mutationKey: "updateEbayProperty",
+  query: getEbayPropertyQuery,
+  queryVariables: { id: propertyId },
+  queryDataKey: "ebayProperty",
+  submitUrl: { name: 'integrations.integrations.show', params: { type, id: integrationId }, query: { tab: 'properties' } },
+  fields: [
+    { type: FieldType.Hidden, name: 'id', value: propertyId },
+    { type: FieldType.Text, name: 'localizedName', label: t('shared.labels.name'), help: t('integrations.show.properties.help.name') },
+    {
+      type: FieldType.Choice,
+      name: 'type',
+      label: t('products.products.labels.type.title'),
+      labelBy: 'name',
+      valueBy: 'code',
+      options: getPropertyTypeOptions(t),
+      disabled: true,
+      removable: false,
+      help: t('integrations.show.properties.help.type'),
+    },
+    {
+      type: FieldType.Boolean,
+      name: 'allowsUnmappedValues',
+      label: t('integrations.show.properties.labels.allowsUnmappedValues'),
+      disabled: true,
+      strict: true,
+      help: t('integrations.show.properties.help.allowsUnmappedValues'),
+    },
+  ],
+});
 
 export const ebayPropertiesSearchConfigConstructor = (t: Function, salesChannelId: string): SearchConfig => ({
   search: true,

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
+import RemotePropertyEdit from "../../remote-properties/components/RemotePropertyEdit.vue";
+import { ebayPropertyEditFormConfigConstructor } from "../configs";
+import { FieldType } from "../../../../../../../../../shared/utils/constants";
+import { propertiesQuerySelector } from "../../../../../../../../../shared/api/queries/properties.js";
+import apolloClient from "../../../../../../../../../../apollo-client";
+import { Toast } from "../../../../../../../../../shared/modules/toast";
+import { ebayPropertiesQuery } from "../../../../../../../../../shared/api/queries/salesChannels";
+import type { FormConfig } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
+
+const { t } = useI18n();
+const router = useRouter();
+const route = useRoute();
+
+const ebayPropertyId = ref(String(route.params.id));
+const type = ref(String(route.params.type));
+const integrationId = route.query.integrationId?.toString() || '';
+const salesChannelId = route.query.salesChannelId?.toString() || '';
+const isWizard = route.query.wizard === '1';
+const propertyId = route.query.propertyId?.toString() || null;
+
+const formConfig = ref<FormConfig | null>(null);
+
+const breadcrumbsLinks = computed(() => [
+  { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
+  {
+    path: {
+      name: 'integrations.integrations.show',
+      params: { id: integrationId, type: type.value },
+      query: { tab: 'properties' },
+    },
+    name: t('integrations.show.ebay.title'),
+  },
+  { name: t('integrations.show.mapProperty') },
+]);
+
+const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boolean }> => {
+  const { data } = await apolloClient.query({
+    query: ebayPropertiesQuery,
+    variables: {
+      first: 2,
+      filter: {
+        salesChannel: { id: { exact: salesChannelId } },
+        mappedLocally: false,
+      },
+    },
+    fetchPolicy: 'network-only',
+  });
+
+  const edges = data?.ebayProperties?.edges || [];
+  let nextId: string | null = null;
+  for (const edge of edges) {
+    if (edge.node.id !== ebayPropertyId.value) {
+      nextId = edge.node.id;
+      break;
+    }
+  }
+  const last = edges.length === 1 && edges[0].node.id === ebayPropertyId.value;
+  return { nextId, last };
+};
+
+onMounted(async () => {
+  formConfig.value = ebayPropertyEditFormConfigConstructor(t, type.value, ebayPropertyId.value, integrationId);
+
+  if (!formConfig.value) {
+    return;
+  }
+
+  formConfig.value.cancelUrl = {
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: 'properties' },
+  };
+
+  if (!isWizard) {
+    return;
+  }
+
+  const { nextId, last } = await fetchNextUnmapped();
+
+  formConfig.value.addSubmitAndContinue = false;
+
+  if (nextId) {
+    formConfig.value.submitUrl = {
+      name: 'integrations.remoteProperties.edit',
+      params: { type: type.value, id: nextId },
+      query: { integrationId, salesChannelId, wizard: '1' },
+    };
+    formConfig.value.submitLabel = t('integrations.show.mapping.saveAndMapNext');
+    return;
+  }
+
+  if (last) {
+    formConfig.value.submitUrl = {
+      name: 'integrations.integrations.show',
+      params: { type: type.value, id: integrationId },
+      query: { tab: 'properties' },
+    };
+    return;
+  }
+
+  Toast.success(t('integrations.show.mapping.allMappedSuccess'));
+  router.push({
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: 'properties' },
+  });
+});
+
+const handleSetData = (data: any) => {
+  if (!formConfig.value) {
+    return;
+  }
+
+  const propertyType = data?.ebayProperty?.type;
+  if (!propertyType) {
+    return;
+  }
+
+  const defaultValue = propertyId || data?.ebayProperty?.localInstance?.id || null;
+
+  const field = {
+    type: FieldType.Query,
+    name: 'localInstance',
+    label: t('integrations.show.properties.labels.property'),
+    help: t('integrations.show.properties.help.property'),
+    labelBy: 'name',
+    valueBy: 'id',
+    query: propertiesQuerySelector,
+    queryVariables: { filter: { type: { exact: propertyType } } },
+    dataKey: 'properties',
+    isEdge: true,
+    multiple: false,
+    filterable: true,
+    formMapIdentifier: 'id',
+    ...(defaultValue ? { default: defaultValue } : {}),
+  };
+
+  const index = formConfig.value.fields.findIndex((f) => f.name === 'localInstance');
+  if (index === -1) {
+    formConfig.value.fields.push(field as any);
+  } else {
+    formConfig.value.fields[index] = field as any;
+  }
+};
+</script>
+
+<template>
+  <RemotePropertyEdit
+    :breadcrumbs-links="breadcrumbsLinks"
+    :form-config="formConfig"
+    @set-data="handleSetData"
+  />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/IntegrationsRemotePropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/IntegrationsRemotePropertyEditController.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { IntegrationTypes } from "../../../../../integrations";
+import AmazonEditProperty from "../amazon-properties/containers/AmazonEditProperty.vue";
+import EbayEditProperty from "../ebay-properties/containers/EbayEditProperty.vue";
+
+const route = useRoute();
+
+const type = computed(() => String(route.params.type));
+
+const componentMap: Record<string, any> = {
+  [IntegrationTypes.Amazon]: AmazonEditProperty,
+  [IntegrationTypes.Ebay]: EbayEditProperty,
+};
+
+const currentComponent = computed(() => componentMap[type.value] || null);
+</script>
+
+<template>
+  <component v-if="currentComponent" :is="currentComponent" />
+</template>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/components/RemotePropertyEdit.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/components/RemotePropertyEdit.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import GeneralTemplate from "../../../../../../../../../shared/templates/GeneralTemplate.vue";
+import { Breadcrumbs } from "../../../../../../../../../shared/components/molecules/breadcrumbs";
+import { GeneralForm } from "../../../../../../../../../shared/components/organisms/general-form";
+import type { FormConfig } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
+
+interface BreadcrumbLink {
+  path?: {
+    name: string;
+    params?: Record<string, any>;
+    query?: Record<string, any>;
+  };
+  name: string;
+}
+
+const props = defineProps<{
+  breadcrumbsLinks: BreadcrumbLink[];
+  formConfig: FormConfig | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'set-data', value: any): void;
+  (e: 'form-updated', value: Record<string, any>): void;
+}>();
+
+const handleSetData = (payload: any) => {
+  emit('set-data', payload);
+};
+
+const handleFormUpdated = (form: Record<string, any>) => {
+  emit('form-updated', form);
+};
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template #breadcrumbs>
+      <Breadcrumbs :links="props.breadcrumbsLinks" />
+    </template>
+    <template #content>
+      <GeneralForm
+        v-if="props.formConfig"
+        :config="props.formConfig"
+        @set-data="handleSetData"
+        @form-updated="handleFormUpdated"
+      >
+        <template #additional-button>
+          <slot name="additional-button" />
+        </template>
+        <template #additional-fields>
+          <slot name="additional-fields" />
+        </template>
+      </GeneralForm>
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/integrations/routes.ts
+++ b/src/core/integrations/routes.ts
@@ -52,7 +52,7 @@ export const routes = [
     path: '/integrations/:type/property/:id',
     name: 'integrations.remoteProperties.edit',
     meta: { title: 'integrations.show.properties.title' },
-    component: () => import('./integrations/integrations-show/containers/properties/containers/amazon-properties/containers/IntegrationsAmazonPropertyEditController.vue'),
+    component: () => import('./integrations/integrations-show/containers/properties/containers/remote-properties/IntegrationsRemotePropertyEditController.vue'),
   },
   {
     path: '/integrations/:type/internal-property/:id',

--- a/src/shared/api/mutations/salesChannels.js
+++ b/src/shared/api/mutations/salesChannels.js
@@ -607,6 +607,16 @@ export const updateAmazonPropertyMutation = gql`
   }
 `;
 
+export const updateEbayPropertyMutation = gql`
+  mutation updateEbayProperty($data: EbayPropertyPartialInput!) {
+    updateEbayProperty(data: $data) {
+      id
+      mappedLocally
+      mappedRemotely
+    }
+  }
+`;
+
 // Amazon Property Select Value Mutations
 
 export const updateAmazonPropertySelectValueMutation = gql`

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -1131,6 +1131,27 @@ export const getAmazonPropertyQuery = gql`
   }
 `;
 
+export const getEbayPropertyQuery = gql`
+  query getEbayProperty($id: GlobalID!) {
+    ebayProperty(id: $id) {
+      id
+      mappedLocally
+      mappedRemotely
+      localizedName
+      type
+      allowsUnmappedValues
+      marketplace {
+        id
+        name
+      }
+      localInstance {
+        id
+        name
+      }
+    }
+  }
+`;
+
 // Amazon Property Select Value Queries
 export const amazonPropertySelectValuesQuery = gql`
   query AmazonPropertySelectValues(


### PR DESCRIPTION
## Summary
- add a reusable RemotePropertyEdit wrapper and migrate the Amazon property editor to it
- implement an eBay property editor with dedicated config and GraphQL operations
- update the remote property route to select the integration-specific editor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d42cccf590832e960ac3d81663f259