### PR TITLE
Improve marketplace property editing

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/AmazonEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/AmazonEditProperty.vue
@@ -26,7 +26,7 @@ const integrationId = route.query.integrationId?.toString() || '';
 const salesChannelId = route.query.salesChannelId?.toString() || '';
 const isWizard = route.query.wizard === '1';
 const propertyId = route.query.propertyId?.toString() || null;
-const amazonCreateValue = route.query.amazonCreateValue?.toString() || null;
+const remoteCreateValue = route.query.remoteCreateValue?.toString() || null;
 const formConfig = ref<FormConfig | null>(null);
 const formData = ref<Record<string, any>>({});
 
@@ -78,10 +78,10 @@ onMounted(async () => {
     return;
   }
 
-  if (amazonCreateValue) {
+  if (remoteCreateValue) {
     formConfig.value.submitUrl = {
       name: 'integrations.remotePropertySelectValues.edit',
-      params: { type: type.value, id: amazonCreateValue },
+      params: { type: type.value, id: remoteCreateValue },
       query: { integrationId, salesChannelId, ...(isWizard ? { wizard: '1' } : {}) },
     };
     return;
@@ -209,11 +209,12 @@ const selectRecommendation = (id: string) => {
     <template #additional-button>
       <Link
         :path="{ name: 'properties.properties.create', query: {
-          amazonRuleId: `${amazonPropertyId}__${integrationId}__${salesChannelId}`,
+          remoteRuleId: `${amazonPropertyId}__${integrationId}__${salesChannelId}`,
+          remoteIntegrationType: type,
           name: formData.name,
           type: formData.type,
-          amazonWizard: isWizard ? '1' : '0',
-          ...(amazonCreateValue ? { amazonCreateValue } : {}),
+          remoteWizard: isWizard ? '1' : '0',
+          ...(remoteCreateValue ? { remoteCreateValue } : {}),
         } }"
       >
         <Button type="button" class="btn btn-info">

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
@@ -22,7 +22,19 @@ export const ebayPropertyEditFormConfigConstructor = (
   submitUrl: { name: 'integrations.integrations.show', params: { type, id: integrationId }, query: { tab: 'properties' } },
   fields: [
     { type: FieldType.Hidden, name: 'id', value: propertyId },
-    { type: FieldType.Text, name: 'localizedName', label: t('shared.labels.name'), help: t('integrations.show.properties.help.name') },
+    {
+      type: FieldType.Text,
+      name: 'localizedName',
+      label: t('integrations.show.properties.labels.localizedName'),
+      help: t('integrations.show.properties.help.localizedName'),
+      disabled: true,
+    },
+    {
+      type: FieldType.Text,
+      name: 'translatedName',
+      label: t('integrations.show.properties.labels.translatedName'),
+      help: t('integrations.show.properties.help.translatedName'),
+    },
     {
       type: FieldType.Choice,
       name: 'type',

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import RemotePropertyEdit from "../../remote-properties/components/RemotePropertyEdit.vue";
@@ -9,6 +9,11 @@ import { propertiesQuerySelector } from "../../../../../../../../../shared/api/q
 import apolloClient from "../../../../../../../../../../apollo-client";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import { ebayPropertiesQuery } from "../../../../../../../../../shared/api/queries/salesChannels";
+import { Link } from "../../../../../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Label } from "../../../../../../../../../shared/components/atoms/label";
+import { checkPropertyForDuplicatesMutation } from "../../../../../../../../../shared/api/mutations/properties.js";
+import debounce from 'lodash.debounce';
 import type { FormConfig } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
 
 const { t } = useI18n();
@@ -21,8 +26,13 @@ const integrationId = route.query.integrationId?.toString() || '';
 const salesChannelId = route.query.salesChannelId?.toString() || '';
 const isWizard = route.query.wizard === '1';
 const propertyId = route.query.propertyId?.toString() || null;
+const remoteCreateValue = route.query.remoteCreateValue?.toString() || null;
 
 const formConfig = ref<FormConfig | null>(null);
+const formData = ref<Record<string, any>>({});
+const recommendations = ref<{ id: string; name: string }[]>([]);
+const loadingRecommendations = ref(false);
+const currentMarketplace = ref<{ id: string; name: string } | null>(null);
 
 const breadcrumbsLinks = computed(() => [
   { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
@@ -36,6 +46,47 @@ const breadcrumbsLinks = computed(() => [
   },
   { name: t('integrations.show.mapProperty') },
 ]);
+
+const marketplaceLink = computed(() => {
+  if (!currentMarketplace.value) {
+    return null;
+  }
+
+  const query: Record<string, string> = {};
+  if (integrationId) {
+    query.integrationId = integrationId;
+  }
+
+  return {
+    name: 'integrations.stores.edit',
+    params: { type: type.value, id: currentMarketplace.value.id },
+    ...(Object.keys(query).length ? { query } : {}),
+  };
+});
+
+const generatePropertyLink = computed(() => {
+  if (!formData.value || !formConfig.value || !formData.value.type) {
+    return null;
+  }
+
+  const query: Record<string, string> = {
+    remoteRuleId: `${ebayPropertyId.value}__${integrationId}__${salesChannelId}`,
+    remoteIntegrationType: type.value,
+    type: formData.value.type || '',
+    remoteWizard: isWizard ? '1' : '0',
+  };
+
+  const propertyName = formData.value.translatedName || formData.value.localizedName;
+  if (propertyName) {
+    query.name = propertyName;
+  }
+
+  if (remoteCreateValue) {
+    query.remoteCreateValue = remoteCreateValue;
+  }
+
+  return { name: 'properties.properties.create', query };
+});
 
 const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boolean }> => {
   const { data } = await apolloClient.query({
@@ -69,11 +120,14 @@ onMounted(async () => {
     return;
   }
 
-  formConfig.value.cancelUrl = {
-    name: 'integrations.integrations.show',
-    params: { type: type.value, id: integrationId },
-    query: { tab: 'properties' },
-  };
+  if (remoteCreateValue) {
+    formConfig.value.submitUrl = {
+      name: 'integrations.remotePropertySelectValues.edit',
+      params: { type: type.value, id: remoteCreateValue },
+      query: { integrationId, salesChannelId, ...(isWizard ? { wizard: '1' } : {}) },
+    };
+    return;
+  }
 
   if (!isWizard) {
     return;
@@ -82,6 +136,11 @@ onMounted(async () => {
   const { nextId, last } = await fetchNextUnmapped();
 
   formConfig.value.addSubmitAndContinue = false;
+  formConfig.value.cancelUrl = {
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: 'properties' },
+  };
 
   if (nextId) {
     formConfig.value.submitUrl = {
@@ -90,30 +149,29 @@ onMounted(async () => {
       query: { integrationId, salesChannelId, wizard: '1' },
     };
     formConfig.value.submitLabel = t('integrations.show.mapping.saveAndMapNext');
-    return;
-  }
-
-  if (last) {
+  } else if (last) {
     formConfig.value.submitUrl = {
       name: 'integrations.integrations.show',
       params: { type: type.value, id: integrationId },
       query: { tab: 'properties' },
     };
-    return;
+  } else {
+    Toast.success(t('integrations.show.mapping.allMappedSuccess'));
+    router.push({
+      name: 'integrations.integrations.show',
+      params: { type: type.value, id: integrationId },
+      query: { tab: 'properties' },
+    });
   }
-
-  Toast.success(t('integrations.show.mapping.allMappedSuccess'));
-  router.push({
-    name: 'integrations.integrations.show',
-    params: { type: type.value, id: integrationId },
-    query: { tab: 'properties' },
-  });
 });
 
 const handleSetData = (data: any) => {
   if (!formConfig.value) {
     return;
   }
+
+  const marketplace = data?.ebayProperty?.marketplace;
+  currentMarketplace.value = marketplace ? { id: marketplace.id, name: marketplace.name } : null;
 
   const propertyType = data?.ebayProperty?.type;
   if (!propertyType) {
@@ -146,6 +204,72 @@ const handleSetData = (data: any) => {
     formConfig.value.fields[index] = field as any;
   }
 };
+
+const handleFormUpdate = (form: Record<string, any>) => {
+  formData.value = form;
+};
+
+const fetchRecommendations = async () => {
+  const searchValue = formData.value.translatedName || formData.value.localizedName;
+  if (!searchValue) {
+    recommendations.value = [];
+    return;
+  }
+
+  loadingRecommendations.value = true;
+  try {
+    const { data } = await apolloClient.mutate({
+      mutation: checkPropertyForDuplicatesMutation,
+      variables: { name: searchValue },
+    });
+
+    if (data?.checkPropertyForDuplicates?.duplicateFound) {
+      const currentId =
+        typeof formData.value.localInstance === 'string'
+          ? formData.value.localInstance
+          : formData.value.localInstance?.id || null;
+
+      recommendations.value = data.checkPropertyForDuplicates.duplicates
+        .filter((p: any) => p.id !== currentId)
+        .map((p: any) => ({ id: p.id, name: p.name }));
+    } else {
+      recommendations.value = [];
+    }
+  } finally {
+    loadingRecommendations.value = false;
+  }
+};
+
+const debouncedFetchRecommendations = debounce(fetchRecommendations, 500);
+
+watch(
+  () => [formData.value.translatedName, formData.value.localizedName],
+  () => {
+    debouncedFetchRecommendations();
+  },
+);
+
+watch(
+  () => formData.value.localInstance,
+  () => {
+    const currentId =
+      typeof formData.value.localInstance === 'string'
+        ? formData.value.localInstance
+        : formData.value.localInstance?.id || null;
+
+    if (!currentId) {
+      return;
+    }
+
+    recommendations.value = recommendations.value.filter((recommendation) => recommendation.id !== currentId);
+  },
+  { deep: true },
+);
+
+const selectRecommendation = (id: string) => {
+  formData.value.localInstance = id;
+  recommendations.value = recommendations.value.filter((recommendation) => recommendation.id !== id);
+};
 </script>
 
 <template>
@@ -153,5 +277,78 @@ const handleSetData = (data: any) => {
     :breadcrumbs-links="breadcrumbsLinks"
     :form-config="formConfig"
     @set-data="handleSetData"
-  />
+    @form-updated="handleFormUpdate"
+  >
+    <template #before-form>
+      <div v-if="currentMarketplace" class="mb-6">
+        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-2">
+          {{ t('integrations.show.propertySelectValues.labels.marketplace') }}
+        </Label>
+        <Link
+          v-if="marketplaceLink"
+          :path="marketplaceLink"
+          class="text-purple-600 hover:text-purple-500 text-sm"
+        >
+          {{ currentMarketplace.name }}
+        </Link>
+        <span v-else class="text-sm text-gray-500">{{ currentMarketplace.name }}</span>
+      </div>
+    </template>
+    <template #additional-button>
+      <Link v-if="generatePropertyLink" :path="generatePropertyLink">
+        <Button type="button" class="btn btn-info">
+          {{ t('integrations.show.generateProperty') }}
+        </Button>
+      </Link>
+    </template>
+    <template #additional-fields>
+      <div class="mt-4 border border-gray-300 bg-gray-50 rounded p-4">
+        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-2">
+          {{ t('integrations.show.propertySelectValues.recommendation.title') }}
+        </Label>
+        <div v-if="loadingRecommendations" class="flex items-center gap-2">
+          <div class="loader-mini"></div>
+          <span class="text-sm text-gray-500">
+            {{ t('integrations.show.propertySelectValues.recommendation.searching') }}
+          </span>
+        </div>
+        <div v-else>
+          <div v-if="recommendations.length" class="flex flex-wrap gap-2">
+            <button
+              v-for="item in recommendations"
+              :key="item.id"
+              type="button"
+              class="bg-purple-100 text-purple-800 px-2 py-1 rounded text-sm hover:bg-purple-200"
+              @click="selectRecommendation(item.id)"
+            >
+              {{ item.name }}
+            </button>
+          </div>
+          <p v-else class="text-sm text-gray-500">
+            {{ t('integrations.show.propertySelectValues.recommendation.none') }}
+          </p>
+        </div>
+      </div>
+    </template>
+  </RemotePropertyEdit>
 </template>
+
+<style scoped>
+.loader-mini {
+  width: 24px;
+  aspect-ratio: 1;
+  display: grid;
+  border-radius: 50%;
+  background:
+    radial-gradient(farthest-side, #7c3aed 94%, #0000) top/4px 4px no-repeat,
+    conic-gradient(#0000 10%, #7c3aed);
+  -webkit-mask: radial-gradient(farthest-side, #0000 calc(100% - 4px), #000 0);
+  animation: spinner-rotate 1s infinite linear;
+}
+
+@keyframes spinner-rotate {
+  100% {
+    transform: rotate(1turn);
+  }
+}
+</style>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/components/RemotePropertyEdit.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/components/RemotePropertyEdit.vue
@@ -38,6 +38,7 @@ const handleFormUpdated = (form: Record<string, any>) => {
       <Breadcrumbs :links="props.breadcrumbsLinks" />
     </template>
     <template #content>
+      <slot name="before-form" />
       <GeneralForm
         v-if="props.formConfig"
         :config="props.formConfig"

--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonSelectValueEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/amazon-property-select-values/AmazonSelectValueEditProperty.vue
@@ -108,7 +108,7 @@ const config: RemoteSelectValueEditPropertyConfig = {
       query: {
         integrationId: ctx.integrationId,
         salesChannelId: ctx.salesChannelId,
-        amazonCreateValue: ctx.valueId,
+        remoteCreateValue: ctx.valueId,
       },
     }),
   },
@@ -133,7 +133,8 @@ const config: RemoteSelectValueEditPropertyConfig = {
           name: 'properties.values.create',
           query: {
             propertyId: ctx.localPropertyId,
-            amazonSelectValueId: `${ctx.valueId}__${ctx.integrationId}__${ctx.salesChannelId}__${ctx.isWizard ? '1' : '0'}`,
+            remoteSelectValueId: `${ctx.valueId}__${ctx.integrationId}__${ctx.salesChannelId}__${ctx.isWizard ? '1' : '0'}`,
+            remoteIntegrationType: ctx.type,
             value: ctx.form.translatedRemoteName || ctx.form.remoteName,
           },
         }

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/configs.ts
@@ -428,7 +428,8 @@ export const amazonMappedRemoteProductTypeConfig: MappedRemoteProductTypeConfig<
         query: {
           propertyId: state.propertyProductTypeId,
           isRule: '1',
-          amazonRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`,
+          remoteRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`,
+          remoteIntegrationType: IntegrationTypes.Amazon,
           value: formData?.name,
         },
       },

--- a/src/core/properties/properties/properties-create/PropertiesCreateController.vue
+++ b/src/core/properties/properties/properties-create/PropertiesCreateController.vue
@@ -26,14 +26,15 @@ import {processGraphQLErrors} from "../../../../shared/utils";
 const router = useRouter();
 const { t } = useI18n();
 const route = useRoute();
-const amazonRuleId = route.query.amazonRuleId ? route.query.amazonRuleId.toString() : null;
+const remoteRuleId = route.query.remoteRuleId ? route.query.remoteRuleId.toString() : null;
+const remoteIntegrationType = route.query.remoteIntegrationType ? route.query.remoteIntegrationType.toString() : null;
 const nameFromUrl = route.query.name ? route.query.name.toString() : '';
 const typeFromUrl = route.query.type ? route.query.type.toString() : '';
 const wizardRef = ref();
 const step = ref(0);
 const loading = ref(false);
-const isAmazonWizard = route.query.amazonWizard === '1';
-const amazonCreateValue = route.query.amazonCreateValue ? route.query.amazonCreateValue.toString() : null;
+const isRemoteWizard = route.query.remoteWizard === '1';
+const remoteCreateValue = route.query.remoteCreateValue ? route.query.remoteCreateValue.toString() : null;
 const showDuplicateModal = ref(false);
 const duplicateItems = ref<{ label: string; urlParam: any }[]>([]);
 const checkingDuplicates = ref(false);
@@ -150,16 +151,20 @@ const createProperty = async () => {
 
   if (data && data.createProperty) {
     Toast.success(t('shared.alert.toast.submitSuccessUpdate'));
-    if (amazonRuleId) {
-      const [ruleId, integrationId, salesChannelId] = amazonRuleId.split('__');
-      const url: any = { name: 'integrations.remoteProperties.edit', params: { type: 'amazon', id: ruleId, integrationId: integrationId } };
+    if (remoteRuleId) {
+      const [ruleId, integrationId = '', salesChannelId = ''] = remoteRuleId.split('__');
+      const integrationType = remoteIntegrationType || 'amazon';
+      const url: any = {
+        name: 'integrations.remoteProperties.edit',
+        params: { type: integrationType, id: ruleId, integrationId },
+      };
       if (integrationId) {
         url.query = {
           integrationId,
-          salesChannelId,
+          ...(salesChannelId ? { salesChannelId } : {}),
           propertyId: data.createProperty.id,
-          wizard: isAmazonWizard ? '1' : '0',
-          ...(amazonCreateValue ? { amazonCreateValue } : {}),
+          wizard: isRemoteWizard ? '1' : '0',
+          ...(remoteCreateValue ? { remoteCreateValue } : {}),
         };
       }
       router.push(url);

--- a/src/core/properties/property-select-values/configs.ts
+++ b/src/core/properties/property-select-values/configs.ts
@@ -28,18 +28,19 @@ export const baseFormConfigConstructor = (
     propertyId: string | null = null,
     addImage: boolean = true,
     redirectToRules: boolean = false,
-    amazonRuleId: string | null = null,
-    amazonSelectValueId: string | null = null,
+    remoteRuleId: string | null = null,
+    remoteSelectValueId: string | null = null,
+    remoteIntegrationType: string | null = null,
 ): FormConfig => ({
     cols: 1,
     type: type,
     mutation: mutation,
     mutationKey: mutationKey,
-    submitUrl: getSubmitUrl(redirectToRules, propertyId, amazonRuleId, amazonSelectValueId),
-    addSubmitAndContinue: !amazonRuleId && !amazonSelectValueId,
+    submitUrl: getSubmitUrl(redirectToRules, propertyId, remoteRuleId, remoteSelectValueId, remoteIntegrationType),
+    addSubmitAndContinue: !remoteRuleId && !remoteSelectValueId,
     submitAndContinueUrl: {name: 'properties.values.edit'},
     deleteMutation: deletePropertySelectValueMutation,
-    ...((redirectToRules && amazonRuleId) || amazonSelectValueId ? { addIdAsQueryParamInSubmitUrl: true } : {}),
+    ...((redirectToRules && remoteRuleId) || remoteSelectValueId ? { addIdAsQueryParamInSubmitUrl: true } : {}),
     fields: [
         getPropertyField(t, propertyId, type),
         {
@@ -60,12 +61,15 @@ export const baseFormConfigConstructor = (
 const getSubmitUrl = (
     redirectToRules: boolean,
     propertyId: string | null,
-    amazonRuleId: string | null,
-    amazonSelectValueId: string | null,
+    remoteRuleId: string | null,
+    remoteSelectValueId: string | null,
+    remoteIntegrationType: string | null,
 ) => {
-    if (amazonSelectValueId) {
-        const [selectValueId, integrationId, salesChannelId, wizard] = amazonSelectValueId.split('__');
-        const url: any = { name: 'integrations.remotePropertySelectValues.edit', params: { type: 'amazon', id: selectValueId } };
+    const integrationType = remoteIntegrationType || 'amazon';
+
+    if (remoteSelectValueId) {
+        const [selectValueId, integrationId, salesChannelId, wizard] = remoteSelectValueId.split('__');
+        const url: any = { name: 'integrations.remotePropertySelectValues.edit', params: { type: integrationType, id: selectValueId } };
         if (integrationId) {
             url.query = { integrationId } as any;
             if (salesChannelId) {
@@ -77,9 +81,9 @@ const getSubmitUrl = (
         }
         return url;
     }
-    if (redirectToRules && amazonRuleId) {
-        const [ruleId, integrationId, salesChannelId, wizard] = amazonRuleId.split('__');
-        const url: any = { name: 'integrations.remoteProductTypes.edit', params: { type: 'amazon', id: ruleId } };
+    if (redirectToRules && remoteRuleId) {
+        const [ruleId, integrationId, salesChannelId, wizard] = remoteRuleId.split('__');
+        const url: any = { name: 'integrations.remoteProductTypes.edit', params: { type: integrationType, id: ruleId } };
         if (integrationId) {
             url.query = { integrationId } as any;
             if (salesChannelId) {

--- a/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
+++ b/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
@@ -43,8 +43,9 @@ onMounted(async () => {
   let addImage = false;
   const propertyId = route.query.propertyId ? route.query.propertyId.toString() : null;
   const isRule = route.query.isRule ? route.query.isRule.toString() : null;
-  const amazonRuleId = route.query.amazonRuleId ? route.query.amazonRuleId.toString() : null;
-  const amazonSelectValueId = route.query.amazonSelectValueId ? route.query.amazonSelectValueId.toString() : null;
+  const remoteRuleId = route.query.remoteRuleId ? route.query.remoteRuleId.toString() : null;
+  const remoteIntegrationType = route.query.remoteIntegrationType ? route.query.remoteIntegrationType.toString() : null;
+  const remoteSelectValueId = route.query.remoteSelectValueId ? route.query.remoteSelectValueId.toString() : null;
 
   if (propertyId) {
     const { data } = await apolloClient.query({
@@ -64,8 +65,9 @@ onMounted(async () => {
     propertyId,
     addImage,
     isRule !== null,
-    amazonRuleId,
-    amazonSelectValueId
+    remoteRuleId,
+    remoteSelectValueId,
+    remoteIntegrationType
   );
 
   if (formConfig.value) {

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -221,6 +221,26 @@
       "isDefaultMarketplace": "Standardmarktplatz"
     },
     "show": {
+      "properties": {
+        "title": "",
+        "labels": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        },
+        "help": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "name": "",
+          "localizedName": "",
+          "translatedName": "",
+          "property": ""
+        }
+      },
       "propertySelectValues": {
         "labels": {
           "remoteName": "",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2559,14 +2559,18 @@
           "code": "Code",
           "type": "Type",
           "allowsUnmappedValues": "Allow Unmapped Values",
-          "property": "Property"
+          "property": "Property",
+          "localizedName": "Marketplace Name",
+          "translatedName": "OneSila Name"
         },
         "help": {
-          "code": "Amazon's code for this property.",
-          "type": "Type mapped from Amazon. Cannot be changed.",
+          "code": "Marketplace code for this property.",
+          "type": "Type mapped from the marketplace. Cannot be changed.",
           "allowsUnmappedValues": "Allow values that have not been mapped locally.",
-          "name": "Name from Amazon. You can modify it.",
-          "property": "Select the local property this Amazon property maps to."
+          "name": "Marketplace name. You can modify it.",
+          "localizedName": "Original name provided by the marketplace.",
+          "translatedName": "Name that will appear inside OneSila. You can modify it.",
+          "property": "Select the local property this marketplace property maps to."
         }
       },
       "propertySelectValues": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -216,6 +216,26 @@
       "isDefaultMarketplace": "Marketplace par défaut"
     },
     "show": {
+      "properties": {
+        "title": "",
+        "labels": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        },
+        "help": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "name": "",
+          "localizedName": "",
+          "translatedName": "",
+          "property": ""
+        }
+      },
       "propertySelectValues": {
         "labels": {
           "remoteName": "",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -2010,6 +2010,26 @@
   },
   "integrations": {
     "show": {
+      "properties": {
+        "title": "",
+        "labels": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        },
+        "help": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "name": "",
+          "localizedName": "",
+          "translatedName": "",
+          "property": ""
+        }
+      },
       "ebay": {
         "title": "",
         "productRules": {

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -1138,6 +1138,7 @@ export const getEbayPropertyQuery = gql`
       mappedLocally
       mappedRemotely
       localizedName
+      translatedName
       type
       allowsUnmappedValues
       marketplace {


### PR DESCRIPTION
## Summary
- add marketplace-aware helpers and duplicate recommendations to the eBay property edit experience
- generalize remote property generation parameters and property select value flows for reuse across marketplaces
- update marketplace property translations to remove Amazon-specific messaging and support localized/translated names

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43c1976ac832ea298f8c87a948b1c