### PR TITLE
Fix eBay property listing data and tab ordering

### DIFF
--- a/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
+++ b/src/core/integrations/integrations/integrations-show/IntegrationsShowController.vue
@@ -77,9 +77,9 @@ if (type.value !== IntegrationTypes.Webhook) {
     );
   } else if (type.value === IntegrationTypes.Ebay) {
     tabItems.value.push(
+      { name: 'inventoryFields', label: t('integrations.show.ebay.internalProperties.title'), icon: 'boxes-stacked' },
       { name: 'productRules', label: t('properties.rule.title'), icon: 'cog' },
       { name: 'properties', label: t('properties.title'), icon: 'screwdriver-wrench' },
-      { name: 'inventoryFields', label: t('integrations.show.ebay.internalProperties.title'), icon: 'boxes-stacked' },
       { name: 'propertySelectValues', label: t('properties.values.title'), icon: 'sitemap' }
     );
   }

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
@@ -101,6 +101,7 @@ export const ebayPropertiesListingConfigConstructor = (t: Function, specificInte
   ],
   fields: [
     { name: 'localizedName', type: FieldType.Text },
+    { name: 'code', type: FieldType.Text },
     { name: 'mappedLocally', type: FieldType.Boolean },
     {
       name: 'localInstance',

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -1024,6 +1024,7 @@ export const ebayPropertiesQuery = gql`
       edges {
         node {
           id
+          code
           mappedLocally
           mappedRemotely
           localizedName


### PR DESCRIPTION
## Summary
- request the ebay property `code` field in the listing query and display it in the table
- keep the local property column aligned with its header by adding the missing code field configuration
- show the ebay inventory fields tab before the product rules tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d440c1da94832e82fd14b62089b206

## Summary by Sourcery

Include the eBay property code field in listings and adjust the eBay integration tab order

Enhancements:
- Add the code field to the eBay properties GraphQL query and listing configuration
- Reorder eBay integration tabs to show the inventory fields tab before the product rules tab