### PR TITLE
Add eBay dashboard cards and fix Amazon toggle state

### DIFF
--- a/src/core/dashboard/dashboard/containers/dashboard-cards/DashboardCards.vue
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/DashboardCards.vue
@@ -1,18 +1,23 @@
 <script lang="ts" setup>
-
+import { computed } from 'vue';
 import { DashboardSectionProducts } from "./containers/dashboard-section-products";
 import { DashboardSectionGeneral } from "./containers/dashboard-section-general";
 import { DashboardSectionAmazon } from "./containers/dashboard-section-amazon";
+import { DashboardSectionEbay } from "./containers/dashboard-section-ebay";
 import { injectAuth } from "../../../../../shared/modules/auth";
+
 const auth = injectAuth();
 
+const hasAmazonIntegration = computed(() => Boolean(auth.user.company?.hasAmazonIntegration));
+const hasEbayIntegration = computed(() => Boolean((auth.user.company as any)?.hasEbayIntegration));
 </script>
 
 <template>
   <div>
     <DashboardSectionProducts />
     <DashboardSectionGeneral />
-    <DashboardSectionAmazon v-if="auth.user.company?.hasAmazonIntegration" />
+    <DashboardSectionAmazon v-if="hasAmazonIntegration" />
+    <DashboardSectionEbay v-if="hasEbayIntegration" />
   </div>
 </template>
 

--- a/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-ebay/index.ts
+++ b/src/core/dashboard/dashboard/containers/dashboard-cards/containers/dashboard-section-ebay/index.ts
@@ -1,0 +1,1 @@
+export { default as DashboardSectionEbay } from './DashboardSectionEbay.vue';

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -82,8 +82,35 @@
         "email": "E-Mail eingeben"
       }
     }
-  }
-  ,
+  },
+  "dashboard": {
+    "cards": {
+      "ebay": {
+        "title": "",
+        "description": "",
+        "unmappedProperties": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedProductTypes": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedLocalProductTypes": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedSelectValues": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedInventoryFields": {
+          "title": "",
+          "description": ""
+        }
+      }
+    }
+  },
   "products": {
     "translation": {
       "messages": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -213,6 +213,30 @@
           "title": "Products With Issues",
           "description": "Amazon products that failed to sync correctly."
         }
+      },
+      "ebay": {
+        "title": "eBay integration",
+        "description": "Resolve unmapped eBay data to keep your marketplace in sync.",
+        "unmappedProperties": {
+          "title": "Unmapped Properties",
+          "description": "eBay properties that need mapping."
+        },
+        "unmappedProductTypes": {
+          "title": "Unmapped Product Types",
+          "description": "eBay product types that need mapping."
+        },
+        "unmappedLocalProductTypes": {
+          "title": "Unmapped OneSila Product Types",
+          "description": "OneSila product types that need mapping to eBay."
+        },
+        "unmappedSelectValues": {
+          "title": "Unmapped Select Values",
+          "description": "eBay property values that need mapping in order to be imported into OneSila."
+        },
+        "unmappedInventoryFields": {
+          "title": "Inventory Fields",
+          "description": "eBay inventory fields missing a mapped OneSila property."
+        }
       }
     },
     "onboarding": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -82,8 +82,35 @@
         "email": "Entrez l'e-mail"
       }
     }
-  }
-  ,
+  },
+  "dashboard": {
+    "cards": {
+      "ebay": {
+        "title": "",
+        "description": "",
+        "unmappedProperties": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedProductTypes": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedLocalProductTypes": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedSelectValues": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedInventoryFields": {
+          "title": "",
+          "description": ""
+        }
+      }
+    }
+  },
   "products": {
     "products": {
       "create": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -10,6 +10,32 @@
       "addProduct": "Product Toevoegen",
       "addInventory": "Voorraad Toevoegen"
     },
+    "cards": {
+      "ebay": {
+        "title": "",
+        "description": "",
+        "unmappedProperties": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedProductTypes": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedLocalProductTypes": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedSelectValues": {
+          "title": "",
+          "description": ""
+        },
+        "unmappedInventoryFields": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
     "onboarding": {
       "completedHeader": "Alle stappen zijn afgewerkt!",
       "completedMessage": "Proficiat!  Alle stappen om van start te kunnen gaan zijn nu klaar en uw bedrijf te beheren via OneSila.  We wensen u veel success, en weet dat we voor uw klaar staan om u te helpen.",


### PR DESCRIPTION
## Summary
- add an eBay dashboard section with cards for unmapped product data and inventory fields
- ensure Amazon dashboard cards have independent hide-completed toggles per integration
- extend locale files with translation keys for the new eBay dashboard strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43ee2af68832eb18371888e08c93a