### PR TITLE
Improve eBay property edit flow and remote rule handling

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/AmazonEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/amazon-properties/containers/AmazonEditProperty.vue
@@ -27,6 +27,11 @@ const salesChannelId = route.query.salesChannelId?.toString() || '';
 const isWizard = route.query.wizard === '1';
 const propertyId = route.query.propertyId?.toString() || null;
 const amazonCreateValue = route.query.amazonCreateValue?.toString() || null;
+const remoteRuleId = computed(() =>
+  [amazonPropertyId.value, integrationId, salesChannelId, type.value]
+    .map((part) => part ?? '')
+    .join('__'),
+);
 const formConfig = ref<FormConfig | null>(null);
 const formData = ref<Record<string, any>>({});
 
@@ -209,10 +214,10 @@ const selectRecommendation = (id: string) => {
     <template #additional-button>
       <Link
         :path="{ name: 'properties.properties.create', query: {
-          amazonRuleId: `${amazonPropertyId}__${integrationId}__${salesChannelId}`,
+          remoteRuleId,
           name: formData.name,
           type: formData.type,
-          amazonWizard: isWizard ? '1' : '0',
+          remoteWizard: isWizard ? '1' : '0',
           ...(amazonCreateValue ? { amazonCreateValue } : {}),
         } }"
       >

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/configs.ts
@@ -22,7 +22,18 @@ export const ebayPropertyEditFormConfigConstructor = (
   submitUrl: { name: 'integrations.integrations.show', params: { type, id: integrationId }, query: { tab: 'properties' } },
   fields: [
     { type: FieldType.Hidden, name: 'id', value: propertyId },
-    { type: FieldType.Text, name: 'localizedName', label: t('shared.labels.name'), help: t('integrations.show.properties.help.name') },
+    {
+      type: FieldType.Text,
+      name: 'localizedName',
+      label: t('integrations.show.properties.labels.localizedName'),
+      help: t('integrations.show.properties.help.localizedName'),
+    },
+    {
+      type: FieldType.Text,
+      name: 'translatedName',
+      label: t('integrations.show.properties.labels.translatedName'),
+      help: t('integrations.show.properties.help.translatedName'),
+    },
     {
       type: FieldType.Choice,
       name: 'type',

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import RemotePropertyEdit from "../../remote-properties/components/RemotePropertyEdit.vue";
@@ -10,6 +10,11 @@ import apolloClient from "../../../../../../../../../../apollo-client";
 import { Toast } from "../../../../../../../../../shared/modules/toast";
 import { ebayPropertiesQuery } from "../../../../../../../../../shared/api/queries/salesChannels";
 import type { FormConfig } from "../../../../../../../../../shared/components/organisms/general-form/formConfig";
+import { Link } from "../../../../../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Label } from "../../../../../../../../../shared/components/atoms/label";
+import { checkPropertyForDuplicatesMutation } from "../../../../../../../../../shared/api/mutations/properties.js";
+import debounce from 'lodash.debounce';
 
 const { t } = useI18n();
 const router = useRouter();
@@ -23,6 +28,10 @@ const isWizard = route.query.wizard === '1';
 const propertyId = route.query.propertyId?.toString() || null;
 
 const formConfig = ref<FormConfig | null>(null);
+const formData = ref<Record<string, any>>({});
+const recommendations = ref<{ id: string; name: string }[]>([]);
+const loadingRecommendations = ref(false);
+const marketplaceInfo = ref<{ id: string | null; name: string }>({ id: null, name: '' });
 
 const breadcrumbsLinks = computed(() => [
   { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
@@ -36,6 +45,29 @@ const breadcrumbsLinks = computed(() => [
   },
   { name: t('integrations.show.mapProperty') },
 ]);
+
+const marketplaceLink = computed(() => {
+  if (!marketplaceInfo.value.id) {
+    return null;
+  }
+
+  const query: Record<string, string> = {};
+  if (integrationId) {
+    query.integrationId = integrationId;
+  }
+
+  return {
+    name: 'integrations.stores.edit',
+    params: { type: type.value, id: marketplaceInfo.value.id },
+    ...(Object.keys(query).length ? { query } : {}),
+  };
+});
+
+const remoteRuleId = computed(() =>
+  [ebayPropertyId.value, integrationId, salesChannelId, type.value]
+    .map((part) => part ?? '')
+    .join('__'),
+);
 
 const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boolean }> => {
   const { data } = await apolloClient.query({
@@ -120,6 +152,11 @@ const handleSetData = (data: any) => {
     return;
   }
 
+  marketplaceInfo.value = {
+    id: data?.ebayProperty?.marketplace?.id ?? null,
+    name: data?.ebayProperty?.marketplace?.name ?? '',
+  };
+
   const defaultValue = propertyId || data?.ebayProperty?.localInstance?.id || null;
 
   const field = {
@@ -146,6 +183,67 @@ const handleSetData = (data: any) => {
     formConfig.value.fields[index] = field as any;
   }
 };
+
+const handleFormUpdate = (form: Record<string, any>) => {
+  formData.value = form;
+};
+
+const fetchRecommendations = async () => {
+  const searchValue = formData.value.translatedName || formData.value.localizedName;
+  if (!searchValue) {
+    recommendations.value = [];
+    return;
+  }
+
+  loadingRecommendations.value = true;
+
+  try {
+    const { data } = await apolloClient.mutate({
+      mutation: checkPropertyForDuplicatesMutation,
+      variables: { name: searchValue },
+    });
+
+    if (data && data.checkPropertyForDuplicates && data.checkPropertyForDuplicates.duplicateFound) {
+      recommendations.value = data.checkPropertyForDuplicates.duplicates
+        .filter((p: any) => p.id !== formData.value.localInstance?.id)
+        .map((p: any) => ({ id: p.id, name: p.name }));
+    } else {
+      recommendations.value = [];
+    }
+  } finally {
+    loadingRecommendations.value = false;
+  }
+};
+
+const debouncedFetchRecommendations = debounce(fetchRecommendations, 500);
+
+watch(
+  () => formData.value.translatedName,
+  () => {
+    debouncedFetchRecommendations();
+  },
+);
+
+watch(
+  () => formData.value.localizedName,
+  (newValue, oldValue) => {
+    if (newValue !== oldValue && !formData.value.translatedName) {
+      debouncedFetchRecommendations();
+    }
+  },
+);
+
+watch(
+  () => formData.value.localInstance,
+  () => {
+    recommendations.value = recommendations.value.filter((r) => r.id !== formData.value.localInstance);
+  },
+);
+
+const selectRecommendation = (id: string) => {
+  formData.value.localInstance = id;
+  recommendations.value = recommendations.value.filter((r) => r.id !== id);
+};
 </script>
 
 <template>
@@ -153,5 +251,101 @@ const handleSetData = (data: any) => {
     :breadcrumbs-links="breadcrumbsLinks"
     :form-config="formConfig"
     @set-data="handleSetData"
-  />
+    @form-updated="handleFormUpdate"
+  >
+    <template #before-form>
+      <div v-if="marketplaceInfo.name" class="px-4 pt-6 sm:px-8 sm:pt-8">
+        <Label class="font-semibold block text-sm leading-6 text-gray-900">
+          {{ t('integrations.show.propertySelectValues.labels.marketplace') }}
+        </Label>
+        <Link v-if="marketplaceLink" class="text-sm text-purple-700 hover:underline" :path="marketplaceLink">
+          {{ marketplaceInfo.name }}
+        </Link>
+        <span v-else class="text-sm text-gray-500">{{ marketplaceInfo.name }}</span>
+      </div>
+    </template>
+    <template #additional-button>
+      <Link
+        v-if="remoteRuleId"
+        :path="{
+          name: 'properties.properties.create',
+          query: {
+            remoteRuleId,
+            ...(formData.localizedName ? { name: formData.localizedName } : {}),
+            ...(formData.translatedName ? { translatedName: formData.translatedName } : {}),
+            ...(formData.type ? { type: formData.type } : {}),
+            remoteWizard: isWizard ? '1' : '0',
+          },
+        }"
+      >
+        <Button type="button" class="btn btn-info">
+          {{ t('integrations.show.generateProperty') }}
+        </Button>
+      </Link>
+    </template>
+    <template #additional-fields>
+      <div class="mt-4 border border-gray-300 bg-gray-50 rounded p-4">
+        <Label class="font-semibold block text-sm leading-6 text-gray-900 mb-2">
+          {{ t('integrations.show.propertySelectValues.recommendation.title') }}
+        </Label>
+        <div v-if="loadingRecommendations" class="flex items-center gap-2">
+          <div class="loader-mini"></div>
+          <span class="text-sm text-gray-500">
+            {{ t('integrations.show.propertySelectValues.recommendation.searching') }}
+          </span>
+        </div>
+        <div v-else>
+          <div v-if="recommendations.length" class="flex flex-wrap gap-2">
+            <button
+              v-for="item in recommendations"
+              :key="item.id"
+              type="button"
+              class="bg-purple-100 text-purple-800 px-2 py-1 rounded text-sm hover:bg-purple-200"
+              @click="selectRecommendation(item.id)"
+            >
+              {{ item.name }}
+            </button>
+          </div>
+          <p v-else class="text-sm text-gray-500">
+            {{ t('integrations.show.propertySelectValues.recommendation.none') }}
+          </p>
+        </div>
+      </div>
+    </template>
+  </RemotePropertyEdit>
 </template>
+
+<style scoped>
+.loader-mini {
+  width: 24px;
+  aspect-ratio: 1;
+  display: grid;
+}
+
+.loader-mini::before,
+.loader-mini::after {
+  content: "";
+  grid-area: 1/1;
+  --c: no-repeat radial-gradient(farthest-side, currentColor 92%, #0000);
+  background:
+    var(--c) 50% 0,
+    var(--c) 50% 100%,
+    var(--c) 100% 50%,
+    var(--c) 0 50%;
+  background-size: 5px 5px;
+  animation: l2 1s infinite;
+}
+
+.loader-mini::after {
+  margin: 2px;
+  filter: hue-rotate(45deg);
+  background-size: 3px 3px;
+  animation-direction: reverse;
+}
+
+@keyframes l2 {
+  100% {
+    transform: rotate(0.5turn);
+  }
+}
+</style>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/components/RemotePropertyEdit.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/components/RemotePropertyEdit.vue
@@ -38,6 +38,7 @@ const handleFormUpdated = (form: Record<string, any>) => {
       <Breadcrumbs :links="props.breadcrumbsLinks" />
     </template>
     <template #content>
+      <slot name="before-form" />
       <GeneralForm
         v-if="props.formConfig"
         :config="props.formConfig"

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/configs.ts
@@ -428,7 +428,7 @@ export const amazonMappedRemoteProductTypeConfig: MappedRemoteProductTypeConfig<
         query: {
           propertyId: state.propertyProductTypeId,
           isRule: '1',
-          amazonRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${isWizard ? '1' : '0'}`,
+          remoteRuleId: `${productTypeId}__${integrationId}__${salesChannelId}__${IntegrationTypes.Amazon}__${isWizard ? '1' : '0'}`,
           value: formData?.name,
         },
       },

--- a/src/core/properties/properties/properties-create/PropertiesCreateController.vue
+++ b/src/core/properties/properties/properties-create/PropertiesCreateController.vue
@@ -26,13 +26,18 @@ import {processGraphQLErrors} from "../../../../shared/utils";
 const router = useRouter();
 const { t } = useI18n();
 const route = useRoute();
-const amazonRuleId = route.query.amazonRuleId ? route.query.amazonRuleId.toString() : null;
-const nameFromUrl = route.query.name ? route.query.name.toString() : '';
+const remoteRuleId = route.query.remoteRuleId
+  ? route.query.remoteRuleId.toString()
+  : route.query.amazonRuleId
+  ? route.query.amazonRuleId.toString()
+  : null;
+const translatedNameFromUrl = route.query.translatedName ? route.query.translatedName.toString() : null;
+const nameFromUrl = translatedNameFromUrl || (route.query.name ? route.query.name.toString() : '');
 const typeFromUrl = route.query.type ? route.query.type.toString() : '';
 const wizardRef = ref();
 const step = ref(0);
 const loading = ref(false);
-const isAmazonWizard = route.query.amazonWizard === '1';
+const isRemoteWizard = route.query.remoteWizard === '1' || route.query.amazonWizard === '1';
 const amazonCreateValue = route.query.amazonCreateValue ? route.query.amazonCreateValue.toString() : null;
 const showDuplicateModal = ref(false);
 const duplicateItems = ref<{ label: string; urlParam: any }[]>([]);
@@ -150,19 +155,37 @@ const createProperty = async () => {
 
   if (data && data.createProperty) {
     Toast.success(t('shared.alert.toast.submitSuccessUpdate'));
-    if (amazonRuleId) {
-      const [ruleId, integrationId, salesChannelId] = amazonRuleId.split('__');
-      const url: any = { name: 'integrations.remoteProperties.edit', params: { type: 'amazon', id: ruleId, integrationId: integrationId } };
-      if (integrationId) {
-        url.query = {
-          integrationId,
-          salesChannelId,
-          propertyId: data.createProperty.id,
-          wizard: isAmazonWizard ? '1' : '0',
-          ...(amazonCreateValue ? { amazonCreateValue } : {}),
-        };
+    if (remoteRuleId) {
+      const parts = remoteRuleId.split('__');
+      const ruleId = parts[0] || '';
+      const integrationIdFromRule = parts[1] || '';
+      const salesChannelIdFromRule = parts[2] || '';
+      const potentialType = parts[3] || '';
+      const remoteIntegrationType =
+        potentialType && potentialType !== '0' && potentialType !== '1' ? potentialType : 'amazon';
+
+      const query: Record<string, string> = {
+        propertyId: String(data.createProperty.id),
+        wizard: isRemoteWizard ? '1' : '0',
+      };
+
+      if (integrationIdFromRule) {
+        query.integrationId = integrationIdFromRule;
       }
-      router.push(url);
+
+      if (salesChannelIdFromRule) {
+        query.salesChannelId = salesChannelIdFromRule;
+      }
+
+      if (amazonCreateValue) {
+        query.amazonCreateValue = amazonCreateValue;
+      }
+
+      router.push({
+        name: 'integrations.remoteProperties.edit',
+        params: { type: remoteIntegrationType, id: ruleId },
+        query,
+      });
     } else {
       router.push({ name: 'properties.properties.edit', params: { id: data.createProperty.id }, query: { tab: 'translations' } });
     }

--- a/src/core/properties/property-select-values/configs.ts
+++ b/src/core/properties/property-select-values/configs.ts
@@ -28,7 +28,7 @@ export const baseFormConfigConstructor = (
     propertyId: string | null = null,
     addImage: boolean = true,
     redirectToRules: boolean = false,
-    amazonRuleId: string | null = null,
+    remoteRuleId: string | null = null,
     remoteSelectValueId: string | null = null,
     remoteSelectValueType: string | null = null,
 ): FormConfig => ({
@@ -36,11 +36,11 @@ export const baseFormConfigConstructor = (
     type: type,
     mutation: mutation,
     mutationKey: mutationKey,
-    submitUrl: getSubmitUrl(redirectToRules, propertyId, amazonRuleId, remoteSelectValueId, remoteSelectValueType),
-    addSubmitAndContinue: !amazonRuleId && !remoteSelectValueId,
+    submitUrl: getSubmitUrl(redirectToRules, propertyId, remoteRuleId, remoteSelectValueId, remoteSelectValueType),
+    addSubmitAndContinue: !remoteRuleId && !remoteSelectValueId,
     submitAndContinueUrl: {name: 'properties.values.edit'},
     deleteMutation: deletePropertySelectValueMutation,
-    ...((redirectToRules && amazonRuleId) || remoteSelectValueId ? { addIdAsQueryParamInSubmitUrl: true } : {}),
+    ...((redirectToRules && remoteRuleId) || remoteSelectValueId ? { addIdAsQueryParamInSubmitUrl: true } : {}),
     fields: [
         getPropertyField(t, propertyId, type),
         {
@@ -61,15 +61,35 @@ export const baseFormConfigConstructor = (
 const getSubmitUrl = (
     redirectToRules: boolean,
     propertyId: string | null,
-    amazonRuleId: string | null,
+    remoteRuleId: string | null,
     remoteSelectValueId: string | null,
     remoteSelectValueType: string | null,
 ) => {
+    const parseRemoteIdentifier = (value: string) => {
+        const parts = value.split('__');
+        const [id = '', integrationId = '', salesChannelId = '', fourth = '', fifth = ''] = parts;
+        let type = '';
+        let wizard = '';
+
+        if (parts.length >= 5) {
+            type = fourth;
+            wizard = fifth;
+        } else if (parts.length === 4) {
+            if (fourth === '0' || fourth === '1') {
+                wizard = fourth;
+            } else {
+                type = fourth;
+            }
+        }
+
+        return { id, integrationId, salesChannelId, type, wizard };
+    };
+
     if (remoteSelectValueId) {
-        const [selectValueId, integrationId, salesChannelId, wizard] = remoteSelectValueId.split('__');
+        const { id: selectValueId, integrationId, salesChannelId, type, wizard } = parseRemoteIdentifier(remoteSelectValueId);
         const url: any = {
             name: 'integrations.remotePropertySelectValues.edit',
-            params: { type: remoteSelectValueType ?? 'amazon', id: selectValueId }
+            params: { type: remoteSelectValueType ?? (type || 'amazon'), id: selectValueId }
         };
         if (integrationId) {
             url.query = { integrationId } as any;
@@ -82,9 +102,9 @@ const getSubmitUrl = (
         }
         return url;
     }
-    if (redirectToRules && amazonRuleId) {
-        const [ruleId, integrationId, salesChannelId, wizard] = amazonRuleId.split('__');
-        const url: any = { name: 'integrations.remoteProductTypes.edit', params: { type: 'amazon', id: ruleId } };
+    if (redirectToRules && remoteRuleId) {
+        const { id: ruleId, integrationId, salesChannelId, type, wizard } = parseRemoteIdentifier(remoteRuleId);
+        const url: any = { name: 'integrations.remoteProductTypes.edit', params: { type: type || 'amazon', id: ruleId } };
         if (integrationId) {
             url.query = { integrationId } as any;
             if (salesChannelId) {

--- a/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
+++ b/src/core/properties/property-select-values/property-select-values-create/PropertySelectValuesCreateController.vue
@@ -43,7 +43,11 @@ onMounted(async () => {
   let addImage = false;
   const propertyId = route.query.propertyId ? route.query.propertyId.toString() : null;
   const isRule = route.query.isRule ? route.query.isRule.toString() : null;
-  const amazonRuleId = route.query.amazonRuleId ? route.query.amazonRuleId.toString() : null;
+  const remoteRuleId = route.query.remoteRuleId
+    ? route.query.remoteRuleId.toString()
+    : route.query.amazonRuleId
+    ? route.query.amazonRuleId.toString()
+    : null;
   const remoteSelectValueId = route.query.remoteSelectValueId
     ? route.query.remoteSelectValueId.toString()
     : route.query.amazonSelectValueId
@@ -73,7 +77,7 @@ onMounted(async () => {
     propertyId,
     addImage,
     isRule !== null,
-    amazonRuleId,
+    remoteRuleId,
     remoteSelectValueId,
     remoteSelectValueType
   );

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -248,6 +248,26 @@
       "isDefaultMarketplace": "Standardmarktplatz"
     },
     "show": {
+      "properties": {
+        "title": "",
+        "labels": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        },
+        "help": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "name": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        }
+      },
       "propertySelectValues": {
         "labels": {
           "remoteName": "",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -2583,14 +2583,18 @@
           "code": "Code",
           "type": "Type",
           "allowsUnmappedValues": "Allow Unmapped Values",
-          "property": "Property"
+          "property": "Property",
+          "localizedName": "Marketplace Name",
+          "translatedName": "Translated Name"
         },
         "help": {
-          "code": "Amazon's code for this property.",
-          "type": "Type mapped from Amazon. Cannot be changed.",
+          "code": "Marketplace code for this property.",
+          "type": "Type mapped from the marketplace. Cannot be changed.",
           "allowsUnmappedValues": "Allow values that have not been mapped locally.",
-          "name": "Name from Amazon. You can modify it.",
-          "property": "Select the local property this Amazon property maps to."
+          "name": "Name provided by the marketplace. You can modify it.",
+          "property": "Select the local property this marketplace property maps to.",
+          "localizedName": "Name provided by the marketplace. Usually localized to the marketplace language.",
+          "translatedName": "Name translated into your company language. You can adjust it."
         }
       },
       "propertySelectValues": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -243,6 +243,26 @@
       "isDefaultMarketplace": "Marketplace par défaut"
     },
     "show": {
+      "properties": {
+        "title": "",
+        "labels": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        },
+        "help": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "name": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        }
+      },
       "propertySelectValues": {
         "labels": {
           "remoteName": "",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -2058,6 +2058,26 @@
           }
         }
       },
+      "properties": {
+        "title": "",
+        "labels": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        },
+        "help": {
+          "code": "",
+          "type": "",
+          "allowsUnmappedValues": "",
+          "name": "",
+          "property": "",
+          "localizedName": "",
+          "translatedName": ""
+        }
+      },
       "products": {
         "labels": {
           "store": "Winkel",

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -1138,6 +1138,7 @@ export const getEbayPropertyQuery = gql`
       mappedLocally
       mappedRemotely
       localizedName
+      translatedName
       type
       allowsUnmappedValues
       marketplace {


### PR DESCRIPTION
## Summary
- add marketplace info, translated name, duplicate recommendations, and remote rule generation to the eBay property edit view
- expose translated name in the eBay property form config/query and update translations to use marketplace terminology
- generalize property creation helpers to accept remoteRuleId across controllers and configs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d444498bfc832e9db58f612f3a3da7