### PR TITLE
Move eBay marketplace info into form body

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
@@ -254,7 +254,7 @@ const selectRecommendation = (id: string) => {
     @form-updated="handleFormUpdate"
   >
     <template #before-form>
-      <div v-if="marketplaceInfo.name" class="px-4 pt-6 sm:px-8 sm:pt-8">
+      <div v-if="marketplaceInfo.name" class="mb-6">
         <Label class="font-semibold block text-sm leading-6 text-gray-900">
           {{ t('integrations.show.propertySelectValues.labels.marketplace') }}
         </Label>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/components/RemotePropertyEdit.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/remote-properties/components/RemotePropertyEdit.vue
@@ -38,13 +38,15 @@ const handleFormUpdated = (form: Record<string, any>) => {
       <Breadcrumbs :links="props.breadcrumbsLinks" />
     </template>
     <template #content>
-      <slot name="before-form" />
       <GeneralForm
         v-if="props.formConfig"
         :config="props.formConfig"
         @set-data="handleSetData"
         @form-updated="handleFormUpdated"
       >
+        <template #before-fields>
+          <slot name="before-form" />
+        </template>
         <template #additional-button>
           <slot name="additional-button" />
         </template>

--- a/src/shared/components/organisms/general-form/GeneralForm.vue
+++ b/src/shared/components/organisms/general-form/GeneralForm.vue
@@ -48,6 +48,9 @@ watch(() => props.config, (newConfig) => {
       <HelpSection :config="enhancedConfig" />
       <div class="bg-white shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl md:col-span-2">
         <FormCreate v-if="enhancedConfig.type === FormType.CREATE" :config="enhancedConfig" :fields-to-clear="fieldsToClear"  @submit="emit('submit')" @form-updated="handleFormUpdate" >
+          <template #before-fields>
+            <slot name="before-fields" />
+          </template>
           <template #additional-button>
             <slot name="additional-button" />
           </template>
@@ -57,12 +60,15 @@ watch(() => props.config, (newConfig) => {
         </FormCreate>
 
         <FormEdit v-else-if="enhancedConfig.type === FormType.EDIT" :config="enhancedConfig" :fields-to-clear="fieldsToClear" @submit="emit('submit')"  @set-data="handleSetData" @form-updated="handleFormUpdate" >
-            <template #additional-button>
-              <slot name="additional-button" />
-            </template>
-            <template #additional-fields>
-              <slot name="additional-fields" />
-            </template>
+          <template #before-fields>
+            <slot name="before-fields" />
+          </template>
+          <template #additional-button>
+            <slot name="additional-button" />
+          </template>
+          <template #additional-fields>
+            <slot name="additional-fields" />
+          </template>
         </FormEdit>
       </div>
     </div>

--- a/src/shared/components/organisms/general-form/containers/form-create/FormCreate.vue
+++ b/src/shared/components/organisms/general-form/containers/form-create/FormCreate.vue
@@ -77,6 +77,7 @@ watch(() => props.fieldsToClear, (fields) => {
 
 <template>
   <div class="px-4 py-6 sm:p-8">
+    <slot name="before-fields" />
     <div class="grid max-w grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-6">
       <FormLayout :config="config" :form="form" :errors="outsideErrors !== null && outsideErrors !== undefined ? outsideErrors : errors" />
     </div>

--- a/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
+++ b/src/shared/components/organisms/general-form/containers/form-edit/FormEdit.vue
@@ -97,7 +97,8 @@ watch(() => props.fieldsToClear, (fields) => {
 
 <template>
   <div class="px-4 py-6 sm:p-8">
-      <template v-if="config.queryData">
+    <slot name="before-fields" />
+    <template v-if="config.queryData">
         <div class="grid max-w grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-6">
           <FormLayout v-if="initialFormUpdate(config.queryData)" :config="config" :form="form" :errors="errors" />
         </div>


### PR DESCRIPTION
## Summary
- add a before-fields slot to GeneralForm so feature forms can inject content ahead of the fields
- render RemotePropertyEdit's marketplace section via the new slot so it appears within the form body
- adjust the eBay edit property view to use the new placement styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44b660004832eb3814a30665ee8e8