### PR TITLE
Fix inventory field navigation and link styling

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayInventoryProperties.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/EbayInventoryProperties.vue
@@ -14,12 +14,12 @@ const emit = defineEmits(['pull-data']);
 const { t } = useI18n();
 
 const internalSearchConfig = computed(() => ebayInternalPropertiesSearchConfigConstructor(t));
-const internalListingConfig = ebayInternalPropertiesListingConfigConstructor(t, props.id);
+const internalListingConfig = ebayInternalPropertiesListingConfigConstructor(t, props.id, 'inventoryFields');
 
 const buildInternalStartMappingRoute = ({ id, integrationId, salesChannelId }: { id: string; integrationId: string; salesChannelId: string }) => ({
   name: 'integrations.remoteInternalProperties.edit',
   params: { type: 'ebay', id },
-  query: { integrationId, salesChannelId, wizard: '1' },
+  query: { integrationId, salesChannelId, wizard: '1', fromTab: 'inventoryFields' },
 });
 </script>
 

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/EbayEditProperty.vue
@@ -26,6 +26,7 @@ const integrationId = route.query.integrationId?.toString() || '';
 const salesChannelId = route.query.salesChannelId?.toString() || '';
 const isWizard = route.query.wizard === '1';
 const propertyId = route.query.propertyId?.toString() || null;
+const returnTab = route.query.fromTab?.toString() || 'properties';
 
 const formConfig = ref<FormConfig | null>(null);
 const formData = ref<Record<string, any>>({});
@@ -39,7 +40,7 @@ const breadcrumbsLinks = computed(() => [
     path: {
       name: 'integrations.integrations.show',
       params: { id: integrationId, type: type.value },
-      query: { tab: 'properties' },
+      query: { tab: returnTab },
     },
     name: t('integrations.show.ebay.title'),
   },
@@ -104,7 +105,13 @@ onMounted(async () => {
   formConfig.value.cancelUrl = {
     name: 'integrations.integrations.show',
     params: { type: type.value, id: integrationId },
-    query: { tab: 'properties' },
+    query: { tab: returnTab },
+  };
+
+  formConfig.value.submitUrl = {
+    name: 'integrations.integrations.show',
+    params: { type: type.value, id: integrationId },
+    query: { tab: returnTab },
   };
 
   if (!isWizard) {
@@ -119,7 +126,7 @@ onMounted(async () => {
     formConfig.value.submitUrl = {
       name: 'integrations.remoteProperties.edit',
       params: { type: type.value, id: nextId },
-      query: { integrationId, salesChannelId, wizard: '1' },
+      query: { integrationId, salesChannelId, wizard: '1', fromTab: returnTab },
     };
     formConfig.value.submitLabel = t('integrations.show.mapping.saveAndMapNext');
     return;
@@ -129,7 +136,7 @@ onMounted(async () => {
     formConfig.value.submitUrl = {
       name: 'integrations.integrations.show',
       params: { type: type.value, id: integrationId },
-      query: { tab: 'properties' },
+      query: { tab: returnTab },
     };
     return;
   }
@@ -138,7 +145,7 @@ onMounted(async () => {
   router.push({
     name: 'integrations.integrations.show',
     params: { type: type.value, id: integrationId },
-    query: { tab: 'properties' },
+    query: { tab: returnTab },
   });
 });
 
@@ -258,7 +265,7 @@ const selectRecommendation = (id: string) => {
         <Label class="font-semibold block text-sm leading-6 text-gray-900">
           {{ t('integrations.show.propertySelectValues.labels.marketplace') }}
         </Label>
-        <Link v-if="marketplaceLink" class="text-sm text-purple-700 hover:underline" :path="marketplaceLink">
+        <Link v-if="marketplaceLink" :path="marketplaceLink">
           {{ marketplaceInfo.name }}
         </Link>
         <span v-else class="text-sm text-gray-500">{{ marketplaceInfo.name }}</span>

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/IntegrationsEbayInternalPropertyEditController.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/containers/IntegrationsEbayInternalPropertyEditController.vue
@@ -22,6 +22,7 @@ const integrationId = route.query.integrationId?.toString() || '';
 const salesChannelId = route.query.salesChannelId?.toString() || '';
 const isWizard = route.query.wizard === '1';
 const propertyId = route.query.propertyId?.toString() || null;
+const returnTab = route.query.fromTab?.toString() || 'properties';
 
 const formConfig = ref<FormConfig | null>(null);
 
@@ -51,7 +52,13 @@ const fetchNextUnmapped = async (): Promise<{ nextId: string | null; last: boole
 };
 
 onMounted(async () => {
-  formConfig.value = ebayInternalPropertyEditFormConfigConstructor(t, type.value, ebayInternalPropertyId.value, integrationId);
+  formConfig.value = ebayInternalPropertyEditFormConfigConstructor(
+    t,
+    type.value,
+    ebayInternalPropertyId.value,
+    integrationId,
+    returnTab,
+  );
 
   if (!formConfig.value) {
     return;
@@ -60,7 +67,7 @@ onMounted(async () => {
   formConfig.value.cancelUrl = {
     name: 'integrations.integrations.show',
     params: { type: type.value, id: integrationId },
-    query: { tab: 'properties' },
+    query: { tab: returnTab },
   };
 
   if (!isWizard) {
@@ -75,7 +82,7 @@ onMounted(async () => {
     formConfig.value.submitUrl = {
       name: 'integrations.remoteInternalProperties.edit',
       params: { type: type.value, id: nextId },
-      query: { integrationId, salesChannelId, wizard: '1' },
+      query: { integrationId, salesChannelId, wizard: '1', fromTab: returnTab },
     };
     formConfig.value.submitLabel = t('integrations.show.mapping.saveAndMapNext');
     return;
@@ -85,7 +92,7 @@ onMounted(async () => {
     formConfig.value.submitUrl = {
       name: 'integrations.integrations.show',
       params: { type: type.value, id: integrationId },
-      query: { tab: 'properties' },
+      query: { tab: returnTab },
     };
     return;
   }
@@ -94,7 +101,7 @@ onMounted(async () => {
   router.push({
     name: 'integrations.integrations.show',
     params: { type: type.value, id: integrationId },
-    query: { tab: 'properties' },
+    query: { tab: returnTab },
   });
 });
 
@@ -144,7 +151,7 @@ const handleSetData = (data: any) => {
       <Breadcrumbs
         :links="[
           { path: { name: 'integrations.integrations.list' }, name: t('integrations.title') },
-          { path: { name: 'integrations.integrations.show', params: { id: integrationId, type: type }, query: { tab: 'properties' } }, name: t('integrations.show.ebay.title') },
+          { path: { name: 'integrations.integrations.show', params: { id: integrationId, type: type }, query: { tab: returnTab } }, name: t('integrations.show.ebay.title') },
           { name: t('integrations.show.mapProperty') },
         ]"
       />

--- a/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/ebayInternalConfigs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/properties/containers/ebay-properties/ebayInternalConfigs.ts
@@ -39,7 +39,11 @@ export const ebayInternalPropertiesSearchConfigConstructor = (t: Function): Sear
   orders: [],
 });
 
-export const ebayInternalPropertiesListingConfigConstructor = (t: Function, specificIntegrationId): ListingConfig => ({
+export const ebayInternalPropertiesListingConfigConstructor = (
+  t: Function,
+  specificIntegrationId,
+  returnTab = 'properties'
+): ListingConfig => ({
   headers: [
     t('shared.labels.name'),
     t('integrations.show.properties.labels.code'),
@@ -63,7 +67,7 @@ export const ebayInternalPropertiesListingConfigConstructor = (t: Function, spec
     { name: 'isRoot', type: FieldType.Boolean },
   ],
   identifierKey: 'id',
-  urlQueryParams: { integrationId: specificIntegrationId },
+  urlQueryParams: { integrationId: specificIntegrationId, fromTab: returnTab },
   addActions: true,
   addEdit: true,
   addShow: true,
@@ -77,7 +81,8 @@ export const ebayInternalPropertyEditFormConfigConstructor = (
   t: Function,
   type: string,
   propertyId: string,
-  integrationId: string
+  integrationId: string,
+  returnTab = 'properties'
 ): FormConfig => ({
   cols: 1,
   type: FormType.EDIT,
@@ -86,7 +91,11 @@ export const ebayInternalPropertyEditFormConfigConstructor = (
   query: getEbayInternalPropertyQuery,
   queryVariables: { id: propertyId },
   queryDataKey: "ebayInternalProperty",
-  submitUrl: { name: 'integrations.integrations.show', params: { type, id: integrationId }, query: { tab: 'properties' } },
+  submitUrl: {
+    name: 'integrations.integrations.show',
+    params: { type, id: integrationId },
+    query: { tab: returnTab },
+  },
   fields: [
     { type: FieldType.Hidden, name: 'id', value: propertyId },
     { type: FieldType.Text, name: 'code', label: t('integrations.show.properties.labels.code'), disabled: true },

--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/RemotelyMappedRemoteProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/remote-product-types/containers/RemotelyMappedRemoteProductType.vue
@@ -269,7 +269,6 @@ const showCodeColumn = computed(() => typeof props.config.getItemCode === 'funct
             </Label>
             <Link
               v-if="marketplaceLink"
-              class="text-sm text-purple-700 hover:underline"
               :path="marketplaceLink"
             >
               {{ marketplaceName }}


### PR DESCRIPTION
## Summary
- keep the Inventory Fields tab when starting, editing, or finishing eBay inventory property mappings
- ensure marketplace form breadcrumbs route back to the originating tab for both remote and internal eBay properties
- align marketplace link styling in eBay property and product rule editors with the Select Value view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4fdec658c832eb95b59f57a4ba6a8