### PR TITLE
Adjust eBay categories query to use connection structure

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/rules/containers/ebay-product-types/ImportedEbayProductType.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/rules/containers/ebay-product-types/ImportedEbayProductType.vue
@@ -109,12 +109,15 @@ const categoryField = computed<QueryFormField>(() => {
     valueBy: 'remoteId',
     query: ebayCategoriesQuery,
     dataKey: 'ebayCategories',
-    isEdge: false,
+    isEdge: true,
     multiple: false,
     filterable: true,
     minSearchLength: 1,
     disabled: !marketplaceDefaultTreeId.value,
-    queryVariables: { filter },
+    queryVariables: {
+      first: 20,
+      filter,
+    },
   };
 });
 

--- a/src/shared/api/queries/ebayCategories.js
+++ b/src/shared/api/queries/ebayCategories.js
@@ -1,11 +1,37 @@
 import { gql } from 'graphql-tag';
 
 export const ebayCategoriesQuery = gql`
-  query EbayCategories($filter: EbayCategoryFilter) {
-    ebayCategories(filters: $filter) {
-      remoteId
-      name
-      marketplaceDefaultTreeId
+  query EbayCategories(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: EbayCategoryOrder
+    $filter: EbayCategoryFilter
+  ) {
+    ebayCategories(
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+      order: $order
+      filters: $filter
+    ) {
+      edges {
+        node {
+          remoteId
+          name
+          marketplaceDefaultTreeId
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- request ebay categories through the standard connection shape with edges, cursors, and page info
- update the imported eBay product type form field to consume the connection and request a sensible page size

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d523625854832e9e6b5c9d94233226

## Summary by Sourcery

Switch eBay categories query to use the GraphQL connection pattern and update the UI form to handle paginated results

Enhancements:
- Refactor ebayCategoriesQuery to accept pagination and ordering args and return edges, cursors, totalCount, and pageInfo
- Configure ImportedEbayProductType form field to use the connection shape (isEdge: true) and request a default page size