### PR TITLE
Fix remote select value mapping to keep generated IDs

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/remote-property-select-values/components/RemoteSelectValueEditProperty.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/property-select-values/containers/remote-property-select-values/components/RemoteSelectValueEditProperty.vue
@@ -146,9 +146,11 @@ const applyValueData = (result: MapValueDataResult | null | undefined) => {
     });
   }
   if (result.localInstanceId !== undefined) {
+    const currentLocalInstance = form[props.config.localInstanceFieldKey] || { id: null };
     if (!form[props.config.localInstanceFieldKey]) {
-      form[props.config.localInstanceFieldKey] = { id: result.localInstanceId };
-    } else {
+      form[props.config.localInstanceFieldKey] = currentLocalInstance;
+    }
+    if (result.localInstanceId !== null || currentLocalInstance.id === null || currentLocalInstance.id === undefined) {
       form[props.config.localInstanceFieldKey].id = result.localInstanceId;
     }
   }


### PR DESCRIPTION
## Summary
- preserve remotely mapped select value form state when a newly created local value is returned via query parameters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7b5bf9d0832eac383a4b0a13a414

## Summary by Sourcery

Bug Fixes:
- Retain existing localInstance object in form state and update only its id based on remote query results to prevent losing generated IDs in select value mapping