### PR TITLE
Add image title metadata management

### DIFF
--- a/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
+++ b/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
@@ -275,6 +275,7 @@ const addImageUrl = () => {
                 <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('media.images.labels.title') }}</label>
                 <TextInput
                   v-model="image.title"
+                  class="w-full"
                   :placeholder="t('media.images.placeholders.title')"
                 />
               </FlexCell>

--- a/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
+++ b/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
@@ -33,6 +33,7 @@ type ShowImage = {
     file: any;
     url?: any;
     type: string;
+    title: string;
 };
 
 type Image = {
@@ -46,6 +47,41 @@ const urlInput = ref('')
 const activeTab = ref<'upload' | 'urls'>('upload')
 const isSubmitting = ref(false)
 const singleUpload = computed(() => props.singleUpload ?? false)
+
+const stripExtension = (value: string) => value.replace(/\.[^/.]+$/, '');
+
+const getDefaultTitleFromFile = (file?: File) => {
+  if (!file?.name) {
+    return '';
+  }
+  const stripped = stripExtension(file.name);
+  return stripped || file.name;
+};
+
+const getDefaultTitleFromUrl = (value: string) => {
+  if (!value) {
+    return '';
+  }
+  try {
+    const parsed = new URL(value);
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    const lastSegment = segments.pop();
+    if (!lastSegment) {
+      return stripExtension(parsed.hostname);
+    }
+    const decoded = decodeURIComponent(lastSegment);
+    const stripped = stripExtension(decoded);
+    return stripped || decoded;
+  } catch (error) {
+    const fallbackSegments = value.split('/').filter(Boolean);
+    const lastSegment = fallbackSegments.pop();
+    if (!lastSegment) {
+      return value;
+    }
+    const stripped = stripExtension(lastSegment);
+    return stripped || lastSegment;
+  }
+};
 
 const imageTypeOptions = [
   { label: t('media.images.labels.packShot'), value: IMAGE_TYPE_PACK },
@@ -71,16 +107,18 @@ const onUploaded = (files: UploadedImage[]) => {
   if (props.singleUpload) {
     images.value = [];
     const file = files[0];
+    const title = getDefaultTitleFromFile(file);
     const reader = new FileReader();
     reader.onload = (e) => {
-      images.value = [{ url: e?.target?.result, type: IMAGE_TYPE_PACK, file }];
+      images.value = [{ url: e?.target?.result, type: IMAGE_TYPE_PACK, file, title }];
     };
     reader.readAsDataURL(file);
   } else {
     files.forEach(file => {
+      const title = getDefaultTitleFromFile(file);
       const reader = new FileReader();
       reader.onload = (e) => {
-        images.value.push({ url: e?.target?.result, type: IMAGE_TYPE_PACK, file });
+        images.value.push({ url: e?.target?.result, type: IMAGE_TYPE_PACK, file, title });
       };
       reader.readAsDataURL(file);
     });
@@ -107,11 +145,11 @@ const submitImages = async () => {
     let dataKey = 'createImages'
 
     if (activeTab.value === 'upload') {
-      variables.data = images.value.map(image => ({ image: image.file, imageType: image.type }))
+      variables.data = images.value.map(image => ({ image: image.file, imageType: image.type, title: image.title?.trim() || null }))
     } else {
       mutation = uploadImagesFromUrlsMutation
       dataKey = 'uploadImagesFromUrls'
-      variables.urls = images.value.map(image => ({ url: image.url, type: image.type }))
+      variables.urls = images.value.map(image => ({ url: image.url, type: image.type, title: image.title?.trim() || null }))
     }
 
     const { data } = await apolloClient.mutate({
@@ -168,10 +206,11 @@ const addImageUrl = () => {
       Toast.error(t('media.images.alert.toast.invalidUrl'))
       return
     }
+    const title = getDefaultTitleFromUrl(urlInput.value);
     if (props.singleUpload) {
-      images.value = [{ file: null, url: urlInput.value, type: IMAGE_TYPE_PACK }]
+      images.value = [{ file: null, url: urlInput.value, type: IMAGE_TYPE_PACK, title }]
     } else {
-      images.value.push({ file: null, url: urlInput.value, type: IMAGE_TYPE_PACK })
+      images.value.push({ file: null, url: urlInput.value, type: IMAGE_TYPE_PACK, title })
     }
     urlInput.value = ''
   }
@@ -231,6 +270,13 @@ const addImageUrl = () => {
                 <div class="w-full h-48 overflow-hidden flex justify-center items-center">
                   <Image :source="image.url" alt="File thumbnail" class="h-full object-contain rounded-md" />
                 </div>
+              </FlexCell>
+              <FlexCell class="mt-2">
+                <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('media.images.labels.title') }}</label>
+                <TextInput
+                  v-model="image.title"
+                  :placeholder="t('media.images.placeholders.title')"
+                />
               </FlexCell>
               <FlexCell>
                 <Flex between class="mt-2">

--- a/src/core/media/images/image-show/ImageShowController.vue
+++ b/src/core/media/images/image-show/ImageShowController.vue
@@ -46,6 +46,8 @@ type Image = {
     imageType: string;
     imageWebUrl: string;
     imageUrl: string;
+    title?: string | null;
+    description?: string | null;
 };
 
 type ImageSubscriptionResult = {

--- a/src/core/media/images/image-show/containers/image-edit-view/ImageEditView.vue
+++ b/src/core/media/images/image-show/containers/image-edit-view/ImageEditView.vue
@@ -1,19 +1,24 @@
 <script lang="ts" setup>
 
-import { ref, defineProps } from "vue";
+import { ref, defineProps, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { Selector } from "../../../../../../shared/components/atoms/selector";
 import { Image } from "../../../../../../shared/components/atoms/image";
 import { PrimaryButton } from "../../../../../../shared/components/atoms/button-primary";
+import { TextInput } from "../../../../../../shared/components/atoms/input-text";
+import { TextEditor } from "../../../../../../shared/components/atoms/input-text-editor";
 import apolloClient from "../../../../../../../apollo-client";
 import { updateImageMutation } from "../../../../../../shared/api/mutations/media.js";
 import { Toast } from "../../../../../../shared/modules/toast";
 import {IMAGE_TYPE_MOOD, IMAGE_TYPE_PACK} from "../../../../files/media";
 
 const { t } = useI18n();
-const props = defineProps<{ image: { imageWebUrl: string, imageType: string, id: string } }>();
+const props = defineProps<{ image: { imageWebUrl: string, imageType: string, id: string, title?: string | null, description?: string | null } }>();
 const emit = defineEmits(['show-view']);
 const localType = ref(props.image.imageType);
+const localTitle = ref(props.image.title ?? '');
+const localDescription = ref(props.image.description ?? '');
+const isSaving = ref(false);
 
 const imageTypeOptions = [
   { label: t('media.images.labels.packShot'), value: IMAGE_TYPE_PACK },
@@ -21,7 +26,11 @@ const imageTypeOptions = [
 ];
 
 const saveChanges = async () => {
-  const variables = { data: { id: props.image.id, imageType: localType.value } };
+  if (isSaving.value) {
+    return;
+  }
+  isSaving.value = true;
+  const variables = { data: { id: props.image.id, imageType: localType.value, title: localTitle.value.trim() || null, description: localDescription.value.trim() || null } };
   try {
     const { data } = await apolloClient.mutate({
       mutation: updateImageMutation,
@@ -34,12 +43,20 @@ const saveChanges = async () => {
   } catch (err) {
     console.error('Error updating video:', err);
     Toast.error(t('media.images.show.updateFailed'));
+  } finally {
+    isSaving.value = false;
   }
 };
 
 const handleUpdate = (newVal) => {
   localType.value = newVal;
-}
+};
+
+watch(() => props.image, (newImage) => {
+  localType.value = newImage.imageType;
+  localTitle.value = newImage.title ?? '';
+  localDescription.value = newImage.description ?? '';
+});
 
 </script>
 
@@ -51,6 +68,21 @@ const handleUpdate = (newVal) => {
     <div class="mt-1">
       <Flex vertical>
         <FlexCell>
+          <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('media.images.labels.title') }}</label>
+          <TextInput
+            v-model="localTitle"
+            :placeholder="t('media.images.placeholders.title')"
+          />
+        </FlexCell>
+        <FlexCell class="mt-4">
+          <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('media.images.labels.description') }}</label>
+          <TextEditor
+            class="h-32"
+            v-model="localDescription"
+            :placeholder="t('media.images.placeholders.description')"
+          />
+        </FlexCell>
+        <FlexCell class="mt-4">
           <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('media.images.labels.imageType') }}</label>
         </FlexCell>
         <FlexCell>
@@ -69,7 +101,7 @@ const handleUpdate = (newVal) => {
               />
             </FlexCell>
             <FlexCell center>
-              <PrimaryButton @click="saveChanges">{{ t('shared.button.save') }}</PrimaryButton>
+              <PrimaryButton :disabled="isSaving" @click="saveChanges">{{ t('shared.button.save') }}</PrimaryButton>
             </FlexCell>
           </Flex>
         </FlexCell>

--- a/src/core/media/images/image-show/containers/image-edit-view/ImageEditView.vue
+++ b/src/core/media/images/image-show/containers/image-edit-view/ImageEditView.vue
@@ -71,6 +71,7 @@ watch(() => props.image, (newImage) => {
           <label class="font-semibold block text-sm leading-6 text-gray-900">{{ t('media.images.labels.title') }}</label>
           <TextInput
             v-model="localTitle"
+            class="w-full"
             :placeholder="t('media.images.placeholders.title')"
           />
         </FlexCell>

--- a/src/core/media/images/image-show/containers/image-show-view/ImageShowView.vue
+++ b/src/core/media/images/image-show/containers/image-show-view/ImageShowView.vue
@@ -9,7 +9,7 @@ import { Toast } from "../../../../../../shared/modules/toast";
 import {getFileName, getFileSize, truncateText} from "../../../../files/media";
 
 const { t } = useI18n();
-const props = defineProps<{ image: { imageWebUrl: string, imageType: string, id: string, image: {size: string, name: string}; imageUrl: string } }>();
+const props = defineProps<{ image: { imageWebUrl: string, imageType: string, id: string, image: {size: string, name: string}; imageUrl: string, title?: string | null, description?: string | null } }>();
 
 const imageTypeOptions = {
       PACK: t('media.images.labels.packShot'),
@@ -50,6 +50,14 @@ const copyUrlToClipboard = async () => {
       <FlexCell>
         <label class="mt-2 font-semibold block text-sm leading-6 text-gray-900">{{ t('media.media.labels.fileSize') }}</label>
         <span class="flex-grow text-gray-900">{{ getFileSize(image) }}</span>
+      </FlexCell>
+      <FlexCell>
+        <label class="mt-2 font-semibold block text-sm leading-6 text-gray-900">{{ t('media.images.labels.title') }}</label>
+        <span class="flex-grow text-gray-900">{{ image.title || '—' }}</span>
+      </FlexCell>
+      <FlexCell>
+        <label class="mt-2 font-semibold block text-sm leading-6 text-gray-900">{{ t('media.images.labels.description') }}</label>
+        <p class="flex-grow text-gray-900 whitespace-pre-line">{{ image.description || '—' }}</p>
       </FlexCell>
       <FlexCell>
           <div class="mt-2">

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -551,6 +551,14 @@
         "upload": "Hochladen",
         "urls": "URLs"
       },
+      "labels": {
+        "title": "",
+        "description": ""
+      },
+      "placeholders": {
+        "title": "",
+        "description": ""
+      },
       "alert": {
         "toast": {
           "invalidUrl": "Bitte geben Sie eine gültige Bild-URL ein (jpg, jpeg, png, webp)."

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1988,10 +1988,14 @@
         "imageType": "Image Type",
         "packShot": "Pack Shot",
         "moodShot": "Mood Shot",
-        "addImages": "Add new images"
+        "addImages": "Add new images",
+        "title": "Title",
+        "description": "Description"
       },
       "placeholders": {
-        "imageType": "Image Type"
+        "imageType": "Image Type",
+        "title": "Enter a title",
+        "description": "Add a description"
       },
       "alert": {
         "toast": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -546,6 +546,14 @@
         "upload": "Téléverser",
         "urls": "URLs"
       },
+      "labels": {
+        "title": "",
+        "description": ""
+      },
+      "placeholders": {
+        "title": "",
+        "description": ""
+      },
       "alert": {
         "toast": {
           "invalidUrl": "Veuillez saisir une URL d'image valide (jpg, jpeg, png, webp)."

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -1602,10 +1602,14 @@
         "imageType": "Afbeeldingstype",
         "packShot": "Packshot",
         "moodShot": "Mood Shot",
-        "addImages": "Afbeeldingen toevoegen"
+        "addImages": "Afbeeldingen toevoegen",
+        "title": "",
+        "description": ""
       },
       "placeholders": {
-        "imageType": "Afbeeldingstype"
+        "imageType": "Afbeeldingstype",
+        "title": "",
+        "description": ""
       },
       "alert": {
         "toast": {

--- a/src/shared/api/queries/media.js
+++ b/src/shared/api/queries/media.js
@@ -103,6 +103,8 @@ export const getImageQuery = gql`
           id
           proxyId
           type
+          title
+          description
           image {
             size
             name

--- a/src/shared/api/subscriptions/media.js
+++ b/src/shared/api/subscriptions/media.js
@@ -17,6 +17,8 @@ export const imageSubscription = gql`
       imageType
       imageWebUrl
       imageUrl
+      title
+      description
       type
       image {
         size


### PR DESCRIPTION
## Summary
- allow specifying image titles during upload with defaults derived from filenames or URLs
- enable editing image title and description on the image edit view and show them in the read view
- request the new metadata fields via GraphQL and provide translation placeholders for all locales

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd9d3f5f00832ea6a768c7f1709ec2

## Summary by Sourcery

Add full metadata management for images by introducing title and description fields across upload, edit, and display workflows, with defaults derived from filenames or URLs and updated GraphQL support.

New Features:
- Allow specifying and storing image title and description metadata

Enhancements:
- Automatically derive default titles from uploaded filenames or image URLs
- Add title input to the image upload modal and title/description fields to the image edit view
- Display image title and description in the image show view
- Update GraphQL queries, mutations, and subscriptions to include title and description fields

Documentation:
- Provide translation placeholders for image title and description labels in all locales