### PR TITLE
Align starting stock label and input in integration tabs

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/amazon-general-tab/AmazonGeneralInfoTab.vue
@@ -275,16 +275,22 @@ useShiftBackspaceKeyboardListener(goBack);
           </div>
           <div class="pt-4 mt-4 border-t border-gray-200 grid grid-cols-12 gap-4 items-start">
             <div class="md:col-span-4 col-span-12">
-              <Label class="font-semibold text-sm text-gray-900 mb-1">
-                {{ t('integrations.labels.startingStock') }}
-              </Label>
-              <TextInput
-                  :model-value="formData.startingStock ?? ''"
-                  :number="true"
-                  :min-number="0"
-                  class="w-full md:w-24"
-                  @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
-              />
+              <Flex class="items-center" gap="2">
+                <FlexCell>
+                  <Label class="font-semibold text-sm text-gray-900">
+                    {{ t('integrations.labels.startingStock') }}
+                  </Label>
+                </FlexCell>
+                <FlexCell>
+                  <TextInput
+                      :model-value="formData.startingStock ?? ''"
+                      :number="true"
+                      :min-number="0"
+                      class="w-full md:w-24"
+                      @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
+                  />
+                </FlexCell>
+              </Flex>
               <p class="text-red-500 text-sm mt-1" v-if="fieldErrors['startingStock']">{{ fieldErrors['startingStock'] }}</p>
             </div>
             <div class="md:col-span-8 col-span-12 text-sm text-gray-400">

--- a/src/core/integrations/integrations/integrations-show/containers/general/ebay-general-tab/EbayGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/ebay-general-tab/EbayGeneralInfoTab.vue
@@ -193,16 +193,22 @@ useShiftBackspaceKeyboardListener(goBack);
           </div>
           <div class="pt-4 mt-4 border-t border-gray-200 grid grid-cols-12 gap-4 items-start">
             <div class="md:col-span-4 col-span-12">
-              <Label class="font-semibold text-sm text-gray-900 mb-1">
-                {{ t('integrations.labels.startingStock') }}
-              </Label>
-              <TextInput
-                  :model-value="formData.startingStock ?? ''"
-                  :number="true"
-                  :min-number="0"
-                  class="w-full md:w-24"
-                  @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
-              />
+              <Flex class="items-center" gap="2">
+                <FlexCell>
+                  <Label class="font-semibold text-sm text-gray-900">
+                    {{ t('integrations.labels.startingStock') }}
+                  </Label>
+                </FlexCell>
+                <FlexCell>
+                  <TextInput
+                      :model-value="formData.startingStock ?? ''"
+                      :number="true"
+                      :min-number="0"
+                      class="w-full md:w-24"
+                      @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
+                  />
+                </FlexCell>
+              </Flex>
               <p class="text-red-500 text-sm mt-1" v-if="fieldErrors['startingStock']">{{ fieldErrors['startingStock'] }}</p>
             </div>
             <div class="md:col-span-8 col-span-12 text-sm text-gray-400">

--- a/src/core/integrations/integrations/integrations-show/containers/general/magento-general-tab/MagentoGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/magento-general-tab/MagentoGeneralInfoTab.vue
@@ -284,16 +284,22 @@ useShiftBackspaceKeyboardListener(goBack);
 
           <div class="pt-4 mt-4 border-t border-gray-200 grid grid-cols-12 gap-4 items-start">
             <div class="md:col-span-4 col-span-12">
-              <Label class="font-semibold text-sm text-gray-900 mb-1">
-                {{ t('integrations.labels.startingStock') }}
-              </Label>
-              <TextInput
-                  :model-value="formData.startingStock ?? ''"
-                  :number="true"
-                  :min-number="0"
-                  class="w-full md:w-24"
-                  @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
-              />
+              <Flex class="items-center" gap="2">
+                <FlexCell>
+                  <Label class="font-semibold text-sm text-gray-900">
+                    {{ t('integrations.labels.startingStock') }}
+                  </Label>
+                </FlexCell>
+                <FlexCell>
+                  <TextInput
+                      :model-value="formData.startingStock ?? ''"
+                      :number="true"
+                      :min-number="0"
+                      class="w-full md:w-24"
+                      @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
+                  />
+                </FlexCell>
+              </Flex>
               <p class="text-red-500 text-sm mt-1" v-if="fieldErrors['startingStock']">{{ fieldErrors['startingStock'] }}</p>
             </div>
             <div class="md:col-span-8 col-span-12 text-sm text-gray-400">

--- a/src/core/integrations/integrations/integrations-show/containers/general/woocommerce-general-tab/WoocommerceGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/woocommerce-general-tab/WoocommerceGeneralInfoTab.vue
@@ -160,16 +160,22 @@ const handleSubmitAndContinueDone = () => Toast.success(t('shared.alert.toast.su
           </div>
           <div class="pt-4 mt-4 border-t border-gray-200 grid grid-cols-12 gap-4 items-start">
             <div class="md:col-span-4 col-span-12">
-              <Label class="font-semibold text-sm text-gray-900 mb-1">
-                {{ t('integrations.labels.startingStock') }}
-              </Label>
-              <TextInput
-                  :model-value="formData.startingStock ?? ''"
-                  :number="true"
-                  :min-number="0"
-                  class="w-full md:w-24"
-                  @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
-              />
+              <Flex class="items-center" gap="2">
+                <FlexCell>
+                  <Label class="font-semibold text-sm text-gray-900">
+                    {{ t('integrations.labels.startingStock') }}
+                  </Label>
+                </FlexCell>
+                <FlexCell>
+                  <TextInput
+                      :model-value="formData.startingStock ?? ''"
+                      :number="true"
+                      :min-number="0"
+                      class="w-full md:w-24"
+                      @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
+                  />
+                </FlexCell>
+              </Flex>
               <p class="text-red-500 text-sm mt-1" v-if="fieldErrors['startingStock']">{{ fieldErrors['startingStock'] }}</p>
             </div>
             <div class="md:col-span-8 col-span-12 text-sm text-gray-400">


### PR DESCRIPTION
## Summary
- align the starting stock label and input on integration general tabs using Flex and FlexCell for a horizontal layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de679039c4832eb267b53f9bc61127