### PR TITLE
Ensure variation properties tab refetches fresh data

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-bulk-edit/VariationsBulkEdit.vue
@@ -188,7 +188,7 @@ const fetchProperties = async () => {
   const { data: typeData } = await apolloClient.query({
     query: propertiesQuerySelector,
     variables: { filter: { isProductType: { exact: true } } },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   })
   if (!typeData?.properties?.edges?.length) return
   const typePropertyId = typeData.properties.edges[0].node.id
@@ -201,7 +201,7 @@ const fetchProperties = async () => {
         product: { id: { exact: parentId.value } },
       },
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   })
   if (!valueData?.productProperties?.edges?.length) return
   const productTypeValueId = valueData.productProperties.edges[0].node.valueSelect?.id
@@ -210,7 +210,7 @@ const fetchProperties = async () => {
   const { data: ruleData } = await apolloClient.query({
     query: productPropertiesRulesQuery,
     variables: { filter: { productType: { id: { exact: productTypeValueId } } } },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   })
   if (!ruleData?.productPropertiesRules?.edges?.length) return
   const items = ruleData.productPropertiesRules.edges[0].node.items
@@ -249,7 +249,7 @@ const fetchVariationProperties = async (variationId: string) => {
   const { data } = await apolloClient.query({
     query: productPropertiesQuery,
     variables: { filter: { product: { id: { exact: variationId } } }, first: 100 },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   })
   const edges = data?.productProperties?.edges ?? []
   const propertyValues: Record<string, any> = {}
@@ -283,7 +283,7 @@ const fetchVariations = async () => {
       filter: { parent: { id: { exact: parentId.value } } },
       ...fetchPaginationData.value,
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'network-only',
   })
   const edges = data?.[queryKey.value]?.edges ?? []
   pageInfo.value = data?.[queryKey.value]?.pageInfo ?? null


### PR DESCRIPTION
## Summary
- switch the product variations bulk edit queries to network-only so returning to the properties tab reloads updated data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de7cee5ef8832ebf466fa16350791e

## Summary by Sourcery

Ensure the product variations bulk edit tab always reloads the latest data by switching all Apollo queries to use a network-only fetch policy

Enhancements:
- Use network-only fetch policy for property definitions, product property values, and property rules queries
- Use network-only fetch policy for variation-specific property queries
- Use network-only fetch policy for the variations listing query