### PR TITLE
Adjust bullet points and add starting stock for shopify

### DIFF
--- a/src/core/integrations/integrations/integrations-show/containers/general/shopify-general-tab/ShopifyGeneralInfoTab.vue
+++ b/src/core/integrations/integrations/integrations-show/containers/general/shopify-general-tab/ShopifyGeneralInfoTab.vue
@@ -37,6 +37,7 @@ interface EditShopifyForm {
   syncEanCodes: boolean;
   syncPrices: boolean;
   importOrders: boolean;
+  startingStock: number | null;
   apiKey: string;
   apiSecret: string;
   accessToken?: string;
@@ -49,7 +50,10 @@ interface EditShopifyForm {
 const props = defineProps<{ data: EditShopifyForm }>();
 
 const { t } = useI18n();
-const formData = ref<EditShopifyForm>({ ...props.data });
+const formData = ref<EditShopifyForm>({
+  ...props.data,
+  startingStock: props.data.startingStock ?? null,
+});
 const fieldErrors = ref<Record<string, string>>({});
 const router = useRouter();
 const submitButtonRef = ref();
@@ -61,7 +65,10 @@ const accordionItems = [
 ];
 
 watch(() => props.data, (newData) => {
-  formData.value = { ...newData };
+  formData.value = {
+    ...newData,
+    startingStock: newData.startingStock ?? null,
+  };
 }, { deep: true });
 
 const cleanupAndMutate = async (mutate) => {
@@ -269,6 +276,30 @@ useShiftBackspaceKeyboardListener(goBack);
             </div>
             <div class="md:col-span-8 col-span-12 text-sm text-gray-400">
               {{ t(`integrations.salesChannel.helpText.${toggleField}`) }}
+            </div>
+          </div>
+          <div class="pt-4 mt-4 border-t border-gray-200 grid grid-cols-12 gap-4 items-start">
+            <div class="md:col-span-4 col-span-12">
+              <Flex class="items-center" gap="2">
+                <FlexCell>
+                  <Label class="font-semibold text-sm text-gray-900">
+                    {{ t('integrations.labels.startingStock') }}
+                  </Label>
+                </FlexCell>
+                <FlexCell>
+                  <TextInput
+                    :model-value="formData.startingStock ?? ''"
+                    :number="true"
+                    :min-number="0"
+                    class="w-full md:w-24"
+                    @update:modelValue="(value) => { formData.startingStock = Number.isNaN(value) ? null : value; }"
+                  />
+                </FlexCell>
+              </Flex>
+              <p class="text-red-500 text-sm mt-1" v-if="fieldErrors['startingStock']">{{ fieldErrors['startingStock'] }}</p>
+            </div>
+            <div class="md:col-span-8 col-span-12 text-sm text-gray-400">
+              {{ t('integrations.salesChannel.helpText.startingStock') }}
             </div>
           </div>
         </div>

--- a/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductTranslationBulletPoints.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {ref, watch, onMounted, computed} from 'vue';
 import {useI18n} from 'vue-i18n';
-import {TextInput} from '../../../../../../../shared/components/atoms/input-text';
+import { TextEditor } from '../../../../../../../shared/components/atoms/input-text-editor';
 import {Button} from '../../../../../../../shared/components/atoms/button';
 import {Label} from '../../../../../../../shared/components/atoms/label';
 import {Icon} from '../../../../../../../shared/components/atoms/icon';
@@ -203,7 +203,11 @@ defineExpose({save, fetchPoints, hasChanges});
           <Icon class="text-primary" name="fa-up-down-left-right"/>
         </FlexCell>
         <FlexCell grow>
-          <TextInput v-model="point.text" class="w-full"/>
+          <TextEditor
+            v-model="point.text"
+            class="w-full min-h-[96px]"
+            :scroll="true"
+          />
         </FlexCell>
         <FlexCell>
           <Button class="btn btn-sm btn-outline-danger" @click="removeBulletPoint(index)">

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-content-bulk-edit/VariationsContentBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-content-bulk-edit/VariationsContentBulkEdit.vue
@@ -8,6 +8,7 @@ import { Icon } from '../../../../../../../../../shared/components/atoms/icon';
 import { Button } from '../../../../../../../../../shared/components/atoms/button';
 import { Link } from '../../../../../../../../../shared/components/atoms/link';
 import { TextInput } from '../../../../../../../../../shared/components/atoms/input-text';
+import { TextEditor } from '../../../../../../../../../shared/components/atoms/input-text-editor';
 import { TextHtmlEditor } from '../../../../../../../../../shared/components/atoms/input-text-html-editor';
 import { Selector } from '../../../../../../../../../shared/components/atoms/selector';
 import { Modal } from '../../../../../../../../../shared/components/atoms/modal';
@@ -1458,11 +1459,17 @@ defineExpose({ hasUnsavedChanges });
     </Modal>
 
     <Modal v-model="textModal.visible" @closed="closeTextModal">
-      <Card class="modal-content w-2/3 max-w-2xl">
+      <Card class="modal-content w-4/5 max-w-3xl">
         <h3 class="text-xl font-semibold text-center mb-4">
           {{ t('products.products.bulkEditModal.textTitle') }}
         </h3>
-        <TextInput class="w-full" v-model="textModal.value" />
+        <TextEditor
+          v-if="textModal.key.startsWith('bullet-')"
+          v-model="textModal.value"
+          class="w-full min-h-[96px]"
+          :scroll="true"
+        />
+        <TextInput v-else class="w-full" v-model="textModal.value" />
         <div class="flex justify-end gap-4 mt-4">
           <Button class="btn btn-outline-dark" @click="closeTextModal">{{ t('shared.button.cancel') }}</Button>
           <Button class="btn btn-primary" @click="saveTextModal">{{ t('shared.button.edit') }}</Button>

--- a/src/shared/api/queries/salesChannels.js
+++ b/src/shared/api/queries/salesChannels.js
@@ -85,6 +85,7 @@ export const getShopifyChannelQuery = gql`
       syncEanCodes
       syncPrices
       importOrders
+      startingStock
       apiKey
       apiSecret
       accessToken


### PR DESCRIPTION
## Summary by Sourcery

Enable configurable starting stock in Shopify integration while enhancing bullet point editing with a rich text editor and adjusting modal layout

New Features:
- Add startingStock property to Shopify integration form with corresponding UI input and GraphQL support

Enhancements:
- Replace TextInput with TextEditor for bullet point editing in bulk edit modal and translation tabs
- Adjust bulk edit text modal width for better layout