### PR TITLE
Add general bulk edit for product variations

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/VariationsView.vue
@@ -12,6 +12,7 @@ import VariationsBulkEdit from "./containers/variations-bulk-edit/VariationsBulk
 import VariationsContentBulkEdit from "./containers/variations-content-bulk-edit/VariationsContentBulkEdit.vue";
 import VariationsPricesBulkEdit from "./containers/variations-prices-bulk-edit/VariationsPricesBulkEdit.vue";
 import VariationsImagesBulkEdit from "./containers/variations-images-bulk-edit/VariationsImagesBulkEdit.vue";
+import VariationsGeneralBulkEdit from "./containers/variations-general-bulk-edit/VariationsGeneralBulkEdit.vue";
 import { useI18n } from 'vue-i18n';
 import Swal from 'sweetalert2';
 
@@ -20,12 +21,13 @@ const props = defineProps<{ product: Product }>();
 const { t } = useI18n();
 const ids = ref([]);
 const refetchNeeded = ref(false);
-type Mode = 'list' | 'editContent' | 'editProperties' | 'editPrices' | 'editImages';
+type Mode = 'list' | 'editContent' | 'editProperties' | 'editPrices' | 'editImages' | 'editGeneral';
 const mode = ref<Mode>('list');
 const bulkEditRef = ref<InstanceType<typeof VariationsBulkEdit> | null>(null);
 const contentEditRef = ref<InstanceType<typeof VariationsContentBulkEdit> | null>(null);
 const priceEditRef = ref<InstanceType<typeof VariationsPricesBulkEdit> | null>(null);
 const imageEditRef = ref<InstanceType<typeof VariationsImagesBulkEdit> | null>(null);
+const generalEditRef = ref<InstanceType<typeof VariationsGeneralBulkEdit> | null>(null);
 
 const getUnsavedChangesForMode = (currentMode: Mode) => {
   if (currentMode === 'editContent') {
@@ -40,6 +42,9 @@ const getUnsavedChangesForMode = (currentMode: Mode) => {
   if (currentMode === 'editImages') {
     return imageEditRef.value?.hasUnsavedChanges ?? false;
   }
+  if (currentMode === 'editGeneral') {
+    return generalEditRef.value?.hasUnsavedChanges ?? false;
+  }
   return false;
 };
 
@@ -48,7 +53,8 @@ const hasUnsavedChanges = computed(
     (bulkEditRef.value?.hasUnsavedChanges ?? false) ||
     (contentEditRef.value?.hasUnsavedChanges ?? false) ||
     (priceEditRef.value?.hasUnsavedChanges ?? false) ||
-    (imageEditRef.value?.hasUnsavedChanges ?? false)
+    (imageEditRef.value?.hasUnsavedChanges ?? false) ||
+    (generalEditRef.value?.hasUnsavedChanges ?? false)
 );
 
 const tabs = computed<{ key: Mode; label: string; icon: string }[]>(() => [
@@ -57,6 +63,7 @@ const tabs = computed<{ key: Mode; label: string; icon: string }[]>(() => [
   { key: 'editProperties', label: t('products.products.tabs.properties'), icon: 'screwdriver-wrench' },
   { key: 'editPrices', label: t('products.products.tabs.prices'), icon: 'coins' },
   { key: 'editImages', label: t('products.products.variations.tabs.images'), icon: 'images' },
+  { key: 'editGeneral', label: t('products.products.variations.tabs.general'), icon: 'sliders' },
 ]);
 
 const searchConfig: SearchConfig = {
@@ -173,8 +180,11 @@ defineExpose({ hasUnsavedChanges });
           <template v-else-if="mode === 'editPrices'">
             <VariationsPricesBulkEdit ref="priceEditRef" :product="product" />
           </template>
-          <template v-else>
+          <template v-else-if="mode === 'editImages'">
             <VariationsImagesBulkEdit ref="imageEditRef" :product="product" />
+          </template>
+          <template v-else>
+            <VariationsGeneralBulkEdit ref="generalEditRef" :product="product" />
           </template>
         </div>
       </div>

--- a/src/core/products/products/product-show/containers/tabs/variations/containers/variations-general-bulk-edit/VariationsGeneralBulkEdit.vue
+++ b/src/core/products/products/product-show/containers/tabs/variations/containers/variations-general-bulk-edit/VariationsGeneralBulkEdit.vue
@@ -1,0 +1,405 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import type { FetchPolicy } from '@apollo/client';
+import { useI18n } from 'vue-i18n';
+import MatrixEditor from "../../../../../../../../../shared/components/organisms/matrix-editor/MatrixEditor.vue";
+import type { MatrixColumn, MatrixEditorExpose } from "../../../../../../../../../shared/components/organisms/matrix-editor/types";
+import { Product } from "../../../../../../configs";
+import { ProductType } from "../../../../../../../../../shared/utils/constants";
+import apolloClient from "../../../../../../../../../../apollo-client";
+import {
+  bundleVariationsWithGeneralQuery,
+  configurableVariationsWithGeneralQuery,
+} from "../../../../../../../../../shared/api/queries/products.js";
+import { vatRatesQuery } from "../../../../../../../../../shared/api/queries/vatRates.js";
+import { updateProductMutation } from "../../../../../../../../../shared/api/mutations/products.js";
+import { Toast } from "../../../../../../../../../shared/modules/toast";
+import { processGraphQLErrors, shortenText } from "../../../../../../../../../shared/utils";
+import { Link } from "../../../../../../../../../shared/components/atoms/link";
+import { Button } from "../../../../../../../../../shared/components/atoms/button";
+import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
+import { Toggle } from "../../../../../../../../../shared/components/atoms/toggle";
+import { Selector } from "../../../../../../../../../shared/components/atoms/selector";
+
+interface VatRateOption {
+  id: string;
+  name: string;
+  rate: number | string | null;
+}
+
+interface VariationRow {
+  id: string;
+  variation: {
+    id: string;
+    sku: string;
+    name: string;
+  };
+  active: boolean;
+  allowBackorder: boolean;
+  vatRate: VatRateOption | null;
+}
+
+const props = defineProps<{ product: Product }>();
+const { t } = useI18n();
+
+const matrixRef = ref<MatrixEditorExpose | null>(null);
+const variations = ref<VariationRow[]>([]);
+const originalVariations = ref<VariationRow[]>([]);
+const vatRates = ref<VatRateOption[]>([]);
+const loading = ref(false);
+const saving = ref(false);
+
+const isAlias = computed(() => props.product.type === ProductType.Alias);
+const parentProduct = computed(() => (isAlias.value ? props.product.aliasParentProduct : props.product));
+const parentProductType = computed(() => parentProduct.value.type);
+
+const columns = computed<MatrixColumn[]>(() => [
+  { key: 'sku', label: t('shared.labels.sku'), sticky: true, editable: false },
+  { key: 'name', label: t('shared.labels.name'), editable: false },
+  { key: 'active', label: t('shared.labels.active'), editable: true, initialWidth: 80, valueType: 'boolean' },
+  {
+    key: 'allowBackorder',
+    label: t('products.products.labels.allowBackorder'),
+    editable: true,
+    initialWidth: 160,
+    valueType: 'boolean',
+  },
+  {
+    key: 'vatRate',
+    label: t('products.products.labels.vatRate'),
+    editable: true,
+    initialWidth: 200,
+    valueType: 'select',
+  },
+]);
+
+const vatRateOptions = computed(() =>
+  vatRates.value.map((rate) => ({
+    id: rate.id,
+    label:
+      rate.rate !== null && rate.rate !== undefined && rate.rate !== ''
+        ? t('products.products.variations.general.optionLabel', {
+            name: rate.name,
+            rate: rate.rate,
+          })
+        : rate.name,
+  }))
+);
+
+const hasChanges = computed(
+  () => JSON.stringify(variations.value) !== JSON.stringify(originalVariations.value)
+);
+
+const hasUnsavedChanges = hasChanges;
+
+const copySkuToClipboard = async (sku: string) => {
+  try {
+    await navigator.clipboard.writeText(sku);
+    Toast.success(t('shared.alert.toast.clipboardSuccess'));
+  } catch (_error) {
+    Toast.error(t('shared.alert.toast.clipboardFail'));
+  }
+};
+
+const normalizeVatRate = (value: any): VatRateOption | null => {
+  if (!value) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    const option = vatRates.value.find((rate) => rate.id === value);
+    return option ? { ...option } : null;
+  }
+  if (typeof value === 'object' && value.id) {
+    const option = vatRates.value.find((rate) => rate.id === value.id);
+    if (option) {
+      return { ...option };
+    }
+    return {
+      id: value.id,
+      name: value.name ?? '',
+      rate: 'rate' in value ? (value as VatRateOption).rate ?? null : null,
+    };
+  }
+  return null;
+};
+
+const getMatrixCellValue = (rowIndex: number, columnKey: string) => {
+  const row = variations.value[rowIndex];
+  if (!row) return null;
+  if (columnKey === 'active') return row.active;
+  if (columnKey === 'allowBackorder') return row.allowBackorder;
+  if (columnKey === 'vatRate') return row.vatRate ? { ...row.vatRate } : null;
+  if (columnKey === 'sku') return row.variation.sku;
+  if (columnKey === 'name') return row.variation.name;
+  return null;
+};
+
+const setMatrixCellValue = (rowIndex: number, columnKey: string, value: any) => {
+  const row = variations.value[rowIndex];
+  if (!row) return;
+  if (columnKey === 'active' || columnKey === 'allowBackorder') {
+    row[columnKey] = Boolean(value);
+    return;
+  }
+  if (columnKey === 'vatRate') {
+    row.vatRate = normalizeVatRate(value);
+  }
+};
+
+const cloneMatrixCellValue = (fromRow: number, toRow: number, columnKey: string) => {
+  const value = getMatrixCellValue(fromRow, columnKey);
+  if (columnKey === 'vatRate') {
+    const clonedValue =
+      value && typeof value === 'object'
+        ? { ...(value as Record<string, any>) }
+        : value;
+    setMatrixCellValue(toRow, columnKey, clonedValue ?? null);
+    return;
+  }
+  setMatrixCellValue(toRow, columnKey, value);
+};
+
+const clearMatrixCellValue = (rowIndex: number, columnKey: string) => {
+  if (columnKey === 'active' || columnKey === 'allowBackorder') {
+    setMatrixCellValue(rowIndex, columnKey, false);
+    return;
+  }
+  if (columnKey === 'vatRate') {
+    setMatrixCellValue(rowIndex, columnKey, null);
+  }
+};
+
+const updateBooleanValue = (
+  rowIndex: number,
+  key: 'active' | 'allowBackorder',
+  value: boolean | null
+) => {
+  const row = variations.value[rowIndex];
+  if (!row) return;
+  row[key] = Boolean(value);
+};
+
+const updateVatRate = (rowIndex: number, value: string | null) => {
+  const row = variations.value[rowIndex];
+  if (!row) return;
+  row.vatRate = value ? normalizeVatRate(value) : null;
+};
+
+const loadVatRates = async (policy: FetchPolicy = 'cache-first') => {
+  const { data } = await apolloClient.query({
+    query: vatRatesQuery,
+    variables: { first: 100 },
+    fetchPolicy: policy,
+  });
+  const edges = data?.vatRates?.edges ?? [];
+  vatRates.value = edges.map((edge: any) => ({
+    id: edge.node?.id,
+    name: edge.node?.name ?? '',
+    rate: edge.node?.rate ?? null,
+  }));
+};
+
+const fetchVariations = async (policy: FetchPolicy = 'cache-first') => {
+  const isBundle = parentProductType.value === ProductType.Bundle;
+  const query = isBundle ? bundleVariationsWithGeneralQuery : configurableVariationsWithGeneralQuery;
+  const key = isBundle ? 'bundleVariations' : 'configurableVariations';
+  const pageSize = 100;
+  let after: string | null = null;
+  const nodes: any[] = [];
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const { data } = await apolloClient.query({
+      query,
+      variables: {
+        first: pageSize,
+        after,
+        filter: { parent: { id: { exact: parentProduct.value.id } } },
+      },
+      fetchPolicy: policy,
+    });
+    const connection = data?.[key];
+    if (!connection) break;
+    const edges = connection.edges ?? [];
+    edges.forEach((edge: any) => nodes.push(edge.node));
+    hasNextPage = connection.pageInfo?.hasNextPage ?? false;
+    after = connection.pageInfo?.endCursor ?? null;
+    if (!after) break;
+  }
+
+  return nodes.map((node: any) => {
+    const variationProduct = node.variation;
+    return {
+      id: variationProduct.id,
+      variation: {
+        id: variationProduct.id,
+        sku: variationProduct.sku,
+        name: variationProduct.name,
+      },
+      active: Boolean(variationProduct.active),
+      allowBackorder: Boolean(variationProduct.allowBackorder),
+      vatRate: variationProduct.vatRate
+        ? {
+            id: variationProduct.vatRate.id,
+            name: variationProduct.vatRate.name ?? '',
+            rate: variationProduct.vatRate.rate ?? null,
+          }
+        : null,
+    } as VariationRow;
+  });
+};
+
+const loadData = async (policy: FetchPolicy = 'cache-first') => {
+  loading.value = true;
+  try {
+    await loadVatRates(policy);
+    const variationRows = await fetchVariations(policy);
+    variations.value = variationRows;
+    originalVariations.value = JSON.parse(JSON.stringify(variationRows));
+    matrixRef.value?.resetHistory(variationRows);
+  } finally {
+    loading.value = false;
+  }
+};
+
+const save = async () => {
+  if (!hasChanges.value) return;
+  saving.value = true;
+  try {
+    const originalMap = new Map<string, VariationRow>();
+    originalVariations.value.forEach((row) => {
+      originalMap.set(row.id, row);
+    });
+
+    const updates: any[] = [];
+
+    variations.value.forEach((row) => {
+      const original = originalMap.get(row.id);
+      if (!original) return;
+      const input: Record<string, any> = { id: row.id };
+      let changed = false;
+
+      if (row.active !== original.active) {
+        input.active = row.active;
+        changed = true;
+      }
+      if (row.allowBackorder !== original.allowBackorder) {
+        input.allowBackorder = row.allowBackorder;
+        changed = true;
+      }
+      const currentVatRateId = row.vatRate?.id ?? null;
+      const originalVatRateId = original.vatRate?.id ?? null;
+      if (currentVatRateId !== originalVatRateId) {
+        input.vatRate = currentVatRateId ? { id: currentVatRateId } : null;
+        changed = true;
+      }
+
+      if (changed) {
+        updates.push(input);
+      }
+    });
+
+    if (!updates.length) {
+      return;
+    }
+
+    for (const data of updates) {
+      await apolloClient.mutate({
+        mutation: updateProductMutation,
+        variables: { data },
+      });
+    }
+
+    originalVariations.value = JSON.parse(JSON.stringify(variations.value));
+    matrixRef.value?.resetHistory(variations.value);
+    Toast.success(
+      t('products.products.variations.general.toast.updated', {
+        count: updates.length,
+      })
+    );
+  } catch (error) {
+    const validationErrors = processGraphQLErrors(error, t);
+    const messages = Object.values(validationErrors).filter(Boolean);
+    if (messages.length) {
+      Toast.error(messages.join('<br>'));
+    } else {
+      Toast.error(t('shared.messages.somethingWentWrong'));
+    }
+  } finally {
+    saving.value = false;
+  }
+};
+
+onMounted(() => {
+  loadData();
+});
+
+defineExpose({ save, hasUnsavedChanges });
+</script>
+
+<template>
+  <div class="relative w-full min-w-0">
+    <MatrixEditor
+      ref="matrixRef"
+      v-model:rows="variations"
+      :columns="columns"
+      :loading="loading || saving"
+      :has-changes="hasChanges"
+      row-key="id"
+      :get-cell-value="getMatrixCellValue"
+      :set-cell-value="setMatrixCellValue"
+      :clone-cell-value="cloneMatrixCellValue"
+      :clear-cell-value="clearMatrixCellValue"
+      @save="save"
+    >
+      <template #cell="{ row, column, rowIndex }">
+        <template v-if="column.key === 'name'">
+          <Link
+            :path="{ name: 'products.products.show', params: { id: row.variation.id }, query: { tab: 'general' } }"
+            target="_blank"
+          >
+            <span class="block truncate" :title="row.variation.name">
+              {{ shortenText(row.variation.name, 32) }}
+            </span>
+          </Link>
+        </template>
+        <template v-else-if="column.key === 'sku'">
+          <div class="flex items-center gap-1">
+            <span class="block truncate" :title="row.variation.sku">
+              {{ row.variation.sku }}
+            </span>
+            <Button class="p-0" @click="copySkuToClipboard(row.variation.sku)">
+              <Icon name="clipboard" class="h-4 w-4 text-gray-500" aria-hidden="true" />
+            </Button>
+          </div>
+        </template>
+        <template v-else-if="column.key === 'active'">
+          <Toggle :model-value="variations[rowIndex].active" @update:modelValue="(value) => updateBooleanValue(rowIndex, 'active', value)" />
+        </template>
+        <template v-else-if="column.key === 'allowBackorder'">
+          <Toggle
+            :model-value="variations[rowIndex].allowBackorder"
+            @update:modelValue="(value) => updateBooleanValue(rowIndex, 'allowBackorder', value)"
+          />
+        </template>
+        <template v-else-if="column.key === 'vatRate'">
+          <Selector
+            class="w-full"
+            :options="vatRateOptions"
+            :model-value="variations[rowIndex].vatRate?.id ?? null"
+            label-by="label"
+            value-by="id"
+            dropdown-position="bottom"
+            :placeholder="t('products.products.variations.general.placeholders.vatRate')"
+            @update:modelValue="(value) => updateVatRate(rowIndex, value)"
+          />
+        </template>
+        <template v-else>
+          <span class="block truncate">
+            {{ getMatrixCellValue(rowIndex, column.key) ?? '' }}
+          </span>
+        </template>
+      </template>
+    </MatrixEditor>
+  </div>
+</template>

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -153,7 +153,8 @@
         },
         "tabs": {
           "list": "Liste",
-          "images": "Bilder"
+          "images": "Bilder",
+          "general": ""
         },
         "images": {
           "columns": {
@@ -162,6 +163,15 @@
           "labels": {
             "noImage": "Kein Bild"
           }
+        },
+        "general": {
+          "placeholders": {
+            "vatRate": ""
+          },
+          "toast": {
+            "updated": ""
+          },
+          "optionLabel": ""
         },
         "prices": {
           "columns": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1032,7 +1032,8 @@
         "tabs": {
           "list": "List",
           "content": "Content",
-          "images": "Images"
+          "images": "Images",
+          "general": "General"
         },
         "images": {
           "columns": {
@@ -1080,6 +1081,15 @@
           "validation": {
             "fieldError": "{field}: {message}"
           }
+        },
+        "general": {
+          "placeholders": {
+            "vatRate": "Select VAT rate"
+          },
+          "toast": {
+            "updated": "Updated {count} variation(s)."
+          },
+          "optionLabel": "{name} ({rate}%)"
         },
         "prices": {
           "columns": {

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -150,7 +150,8 @@
         },
         "tabs": {
           "list": "Liste",
-          "images": "Images"
+          "images": "Images",
+          "general": ""
         },
         "images": {
           "columns": {
@@ -159,6 +160,15 @@
           "labels": {
             "noImage": "Aucune image"
           }
+        },
+        "general": {
+          "placeholders": {
+            "vatRate": ""
+          },
+          "toast": {
+            "updated": ""
+          },
+          "optionLabel": ""
         },
         "prices": {
           "columns": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -718,7 +718,8 @@
           "list": "Lijst",
           "editProperties": "Eigenschappen bewerken",
           "editPrices": "Prijzen",
-          "images": "Afbeeldingen"
+          "images": "Afbeeldingen",
+          "general": ""
         },
         "content": {
           "ai": {
@@ -730,6 +731,15 @@
           "columns": {
             "subtitle": ""
           }
+        },
+        "general": {
+          "placeholders": {
+            "vatRate": ""
+          },
+          "toast": {
+            "updated": ""
+          },
+          "optionLabel": ""
         },
         "images": {
           "columns": {

--- a/src/shared/api/queries/products.js
+++ b/src/shared/api/queries/products.js
@@ -349,6 +349,34 @@ export const configurableVariationsWithPricesQuery = gql`
   }
 `;
 
+export const configurableVariationsWithGeneralQuery = gql`
+  query ConfigurableVariationsWithGeneral($first: Int, $after: String, $filter: ConfigurableVariationFilter) {
+    configurableVariations(first: $first, after: $after, filters: $filter) {
+      edges {
+        node {
+          id
+          variation {
+            id
+            sku
+            name
+            active
+            allowBackorder
+            vatRate {
+              id
+              name
+              rate
+            }
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
 export const bundleVariationsWithPricesQuery = gql`
   query BundleVariationsWithPrices($first: Int, $after: String, $filter: BundleVariationFilter) {
     bundleVariations(first: $first, after: $after, filters: $filter) {
@@ -368,6 +396,34 @@ export const bundleVariationsWithPricesQuery = gql`
                 id
                 isoCode
               }
+            }
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+export const bundleVariationsWithGeneralQuery = gql`
+  query BundleVariationsWithGeneral($first: Int, $after: String, $filter: BundleVariationFilter) {
+    bundleVariations(first: $first, after: $after, filters: $filter) {
+      edges {
+        node {
+          id
+          variation {
+            id
+            sku
+            name
+            active
+            allowBackorder
+            vatRate {
+              id
+              name
+              rate
             }
           }
         }


### PR DESCRIPTION
## Summary
- add a General tab to the product variations bulk editor for active, backorder, and VAT rate updates
- introduce queries and UI to edit these variation fields via the matrix editor
- localize new labels and messages for the General bulk edit workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0083a9168832e998d98ecb2da2673

## Summary by Sourcery

Add general bulk edit workflow for product variations

New Features:
- Introduce a "General" bulk edit tab for variations to update active status, allowBackorder, and VAT rate.
- Add GraphQL queries for configurable and bundle variations to fetch general fields (active, allowBackorder, vatRate).
- Implement VariationsGeneralBulkEdit component using a matrix editor for bulk editing general variation attributes.
- Add localization entries for new general bulk edit labels, messages, and placeholders.