### PR TITLE
feat: improve product media channel management

### DIFF
--- a/src/core/media/files/containers/create-modals/documents-modal/CreateDocumentsModal.vue
+++ b/src/core/media/files/containers/create-modals/documents-modal/CreateDocumentsModal.vue
@@ -11,7 +11,7 @@ import { createFilesMutation, createMediaProductThroughMutation } from "../../..
 import { Toast } from "../../../../../../shared/modules/toast";
 import { processGraphQLErrors } from "../../../../../../shared/utils";
 
-const props = defineProps<{ modelValue: boolean; productId?: string }>();
+const props = defineProps<{ modelValue: boolean; productId?: string; salesChannelId?: string }>();
 const emit = defineEmits(['update:modelValue', 'entries-created']);
 const localShowModal = ref(props.modelValue);
 
@@ -71,10 +71,13 @@ const submitImages = async () => {
 
     if (props.productId) {
       for (const file of data.createFiles) {
-        const variables = {
+        const variables: any = {
           product: {id: props.productId},
           media: {id: file.id},
         };
+        if (props.salesChannelId) {
+          variables.salesChannel = { id: props.salesChannelId };
+        }
         try {
           const {data} = await apolloClient.mutate({
             mutation: createMediaProductThroughMutation,

--- a/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
+++ b/src/core/media/files/containers/create-modals/images-modal/CreateImagesModal.vue
@@ -17,7 +17,7 @@ import { IMAGE_TYPE_MOOD, IMAGE_TYPE_PACK } from "../../../media";
 import { processGraphQLErrors } from "../../../../../../shared/utils";
 
 const props = withDefaults(
-  defineProps<{ modelValue: boolean; productId?: string; singleUpload?: boolean }>(),
+  defineProps<{ modelValue: boolean; productId?: string; singleUpload?: boolean; salesChannelId?: string }>(),
   {
     singleUpload: false,
   }
@@ -162,9 +162,12 @@ const submitImages = async () => {
     if (createdImages) {
       if (props.productId) {
         for (const image of createdImages) {
-          const variables = {
+          const variables: any = {
             product: { id: props.productId },
             media: { id: image.id },
+          }
+          if (props.salesChannelId) {
+            variables.salesChannel = { id: props.salesChannelId };
           }
           try {
             await apolloClient.mutate({

--- a/src/core/media/files/containers/create-modals/videos-modals/CreateVideosModal.vue
+++ b/src/core/media/files/containers/create-modals/videos-modals/CreateVideosModal.vue
@@ -12,7 +12,7 @@ import {Toast} from "../../../../../../shared/modules/toast";
 import {VideoPreview} from "../../../../videos/video-show/containers/video-preview";
 import apolloClient from "../../../../../../../apollo-client";
 
-const props = defineProps<{ modelValue: boolean; productId?: string }>();
+const props = defineProps<{ modelValue: boolean; productId?: string; salesChannelId?: string }>();
 const emit = defineEmits(['update:modelValue', 'entries-created']);
 const websites = ref(['']);
 
@@ -57,10 +57,13 @@ const onVideosCreated = async (d) => {
 
   if (props.productId) {
     for (const video of d.data.createVideos) {
-      const variables = {
+      const variables: any = {
         product: {id: props.productId},
         media: {id: video.id},
       };
+      if (props.salesChannelId) {
+        variables.salesChannel = { id: props.salesChannelId };
+      }
       try {
         const {data} = await apolloClient.mutate({
           mutation: createMediaProductThroughMutation,

--- a/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
+++ b/src/core/products/products/product-show/containers/tabs/content/ProductContentView.vue
@@ -14,7 +14,7 @@ import { Toast } from "../../../../../../../shared/modules/toast";
 import { processGraphQLErrors } from "../../../../../../../shared/utils";
 import { IntegrationTypes } from "../../../../../../integrations/integrations/integrations";
 import { getContentFieldRules } from './contentFieldRules';
-import SalesChannelTabs from "./SalesChannelTabs.vue";
+import { SalesChannelTabs } from "../../../../../../../shared/components/molecules/sales-channel-tabs";
 import ProductContentPreview from "./ProductContentPreview.vue";
 import ProductContentForm from "./ProductContentForm.vue";
 import ProductTranslationBulletPoints from "./ProductTranslationBulletPoints.vue";

--- a/src/core/products/products/product-show/containers/tabs/media/MediaView.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/MediaView.vue
@@ -1,42 +1,140 @@
 <script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
 
-import { ref } from 'vue';
-import { Product } from "../../../../configs";
-import { useI18n } from "vue-i18n";
-import TabContentTemplate from "../TabContentTemplate.vue";
-import { MediaCreate } from "./containers/media-create";
-import { MediaList } from "./containers/media-list";
+import apolloClient from '../../../../../../../../apollo-client';
+import { integrationsQuery } from '../../../../../../../shared/api/queries/integrations.js';
+import { SalesChannelTabs } from '../../../../../../../shared/components/molecules/sales-channel-tabs';
+import { IntegrationTypes } from '../../../../../../integrations/integrations/integrations';
+import { Product } from '../../../../configs';
+import TabContentTemplate from '../TabContentTemplate.vue';
+import { MediaCreate } from './containers/media-create';
+import { MediaList } from './containers/media-list';
+import ProductMediaPreview from './ProductMediaPreview.vue';
 
-const { t } = useI18n();
+type MediaListExpose = {
+  ensureChannelSpecificSet: () => Promise<boolean>;
+};
 
 const props = defineProps<{ product: Product }>();
-const ids = ref([]);
-const refetchNeeded = ref(false);
 
-const handleVariationAdded = (response) => {
+const ids = ref<string[]>([]);
+const refetchNeeded = ref(false);
+const salesChannels = ref<any[]>([]);
+const currentSalesChannel = ref<'default' | string>('default');
+const previewItems = ref<any[]>([]);
+const inheritedFromDefault = ref(false);
+const mediaListRef = ref<MediaListExpose | null>(null);
+
+const defaultChannelLabel = window.location.hostname;
+const productName = computed(() => (props.product as any)?.name ?? '');
+
+const cleanHostname = (hostname: string, type: string) => {
+  if (!hostname) return '';
+  if (type === IntegrationTypes.Amazon || type === IntegrationTypes.Ebay) {
+    return hostname;
+  }
+  try {
+    const url = new URL(hostname.startsWith('http') ? hostname : `https://${hostname}`);
+    const clean = url.hostname.replace(/^www\./i, '');
+    return clean.split('.')[0];
+  } catch {
+    return hostname;
+  }
+};
+
+const channelLabel = computed(() => {
+  if (currentSalesChannel.value === 'default') {
+    return defaultChannelLabel;
+  }
+  const channel = salesChannels.value.find((entry: any) => entry.id === currentSalesChannel.value);
+  if (!channel) {
+    return '';
+  }
+  const label = channel.hostname || channel.name || '';
+  return cleanHostname(label, channel.type);
+});
+
+const loadSalesChannels = async () => {
+  try {
+    const { data } = await apolloClient.query({ query: integrationsQuery, fetchPolicy: 'cache-first' });
+    salesChannels.value =
+      data?.integrations.edges
+        ?.map((edge: any) => edge.node)
+        ?.filter((channel: any) => channel.type !== IntegrationTypes.Webhook) || [];
+  } catch (error) {
+    console.error('Failed to load sales channels', error);
+  }
+};
+
+onMounted(async () => {
+  await loadSalesChannels();
+});
+
+const handleMediaAdded = () => {
   refetchNeeded.value = true;
 };
 
-const handleRefeched = () => {
+const handleRefetched = () => {
   refetchNeeded.value = false;
 };
 
-const getIds = (newIds) => {
+const updateIds = (newIds: string[]) => {
   ids.value = newIds;
+};
+
+const handleItemsLoaded = ({ items, inherited }: { items: any[]; inherited: boolean }) => {
+  previewItems.value = items;
+  inheritedFromDefault.value = inherited;
+};
+
+const ensureChannelSet = async () => {
+  if (currentSalesChannel.value === 'default') {
+    return;
+  }
+  await mediaListRef.value?.ensureChannelSpecificSet();
 };
 
 </script>
 
 <template>
   <TabContentTemplate>
-    <template v-slot:content>
-      <Flex class="mb-2">
-        <FlexCell grow></FlexCell>
-        <FlexCell>
-          <MediaCreate :product="product" :media-ids="ids" @media-added="handleVariationAdded" />
-        </FlexCell>
-      </Flex>
-      <MediaList :product="product" :refetch-needed="refetchNeeded" @refetched="handleRefeched" @update-ids="getIds" />
+    <template #content>
+      <div class="grid gap-6 lg:grid-cols-[220px_1fr_380px]">
+        <SalesChannelTabs
+          v-model="currentSalesChannel"
+          :channels="salesChannels"
+        />
+        <div class="space-y-4">
+          <Flex class="items-center justify-end">
+            <FlexCell grow></FlexCell>
+            <FlexCell>
+              <MediaCreate
+                :product="product"
+                :media-ids="ids"
+                :sales-channel-id="currentSalesChannel"
+                :ensure-sales-channel-set="ensureChannelSet"
+                @media-added="handleMediaAdded"
+              />
+            </FlexCell>
+          </Flex>
+          <MediaList
+            ref="mediaListRef"
+            :product="product"
+            :refetch-needed="refetchNeeded"
+            :sales-channel-id="currentSalesChannel"
+            @refetched="handleRefetched"
+            @update-ids="updateIds"
+            @items-loaded="handleItemsLoaded"
+          />
+        </div>
+        <ProductMediaPreview
+          :product-name="productName"
+          :channel-label="channelLabel"
+          :default-label="defaultChannelLabel"
+          :items="previewItems"
+          :is-inherited="inheritedFromDefault"
+        />
+      </div>
     </template>
   </TabContentTemplate>
 </template>

--- a/src/core/products/products/product-show/containers/tabs/media/ProductMediaPreview.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/ProductMediaPreview.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Icon } from '../../../../../../../shared/components/atoms/icon';
+
+type MediaItem = {
+  id: string;
+  isMainImage: boolean;
+  sortOrder: number | null;
+  media: {
+    id: string;
+    type: string;
+    imageWebUrl?: string;
+    onesilaThumbnailUrl?: string;
+    videoUrl?: string;
+  };
+};
+
+const props = defineProps<{
+  productName: string;
+  channelLabel: string;
+  defaultLabel: string;
+  items: MediaItem[];
+  isInherited: boolean;
+}>();
+
+const { t } = useI18n();
+
+const orderedItems = computed(() => {
+  const list = (props.items || []).slice().sort((a, b) => {
+    const first = a.sortOrder ?? 0;
+    const second = b.sortOrder ?? 0;
+    return first - second;
+  });
+  const mainIndex = list.findIndex((entry) => entry.isMainImage);
+  if (mainIndex > 0) {
+    const [main] = list.splice(mainIndex, 1);
+    list.unshift(main);
+  }
+  return list;
+});
+
+const activeIndex = ref(0);
+
+watch(
+  () => props.items,
+  () => {
+    activeIndex.value = 0;
+  },
+  { deep: true }
+);
+
+const activeItem = computed(() => orderedItems.value[activeIndex.value] || null);
+
+const previewTitle = computed(() => props.productName || t('products.media.preview.untitledProduct'));
+const channelDisplay = computed(() => props.channelLabel || props.defaultLabel);
+
+const hasItems = computed(() => orderedItems.value.length > 0);
+
+const mediaType = computed(() => activeItem.value?.media?.type || '');
+const imageSource = computed(() => activeItem.value?.media?.imageWebUrl || activeItem.value?.media?.onesilaThumbnailUrl || '');
+const videoSource = computed(() => activeItem.value?.media?.videoUrl || '');
+
+const setActiveIndex = (index: number) => {
+  activeIndex.value = index;
+};
+
+</script>
+
+<template>
+  <div class="sticky top-20 h-fit max-h-[580px] overflow-hidden rounded border bg-white shadow">
+    <div class="border-b bg-gray-100 px-5 py-3 text-sm text-gray-500">
+      {{ t('products.media.preview.channelHeading', { channel: channelDisplay || t('products.media.preview.channelFallback') }) }}
+    </div>
+    <div class="space-y-4 px-5 py-4">
+      <div>
+        <h3 class="text-lg font-semibold text-gray-900">{{ previewTitle }}</h3>
+        <p class="text-sm text-gray-600">{{ t('products.media.preview.description') }}</p>
+      </div>
+      <div v-if="hasItems" class="space-y-4" :class="{ 'opacity-60': isInherited }">
+        <div class="relative flex aspect-square w-full items-center justify-center overflow-hidden rounded-lg border bg-gray-50">
+          <img
+            v-if="mediaType === 'IMAGE' && imageSource"
+            :src="imageSource"
+            :alt="t('products.media.preview.mainImageAlt')"
+            class="h-full w-full object-cover"
+          />
+          <video
+            v-else-if="mediaType === 'VIDEO' && videoSource"
+            controls
+            class="h-full w-full object-cover"
+          >
+            <source :src="videoSource" />
+          </video>
+          <div v-else class="flex h-full w-full flex-col items-center justify-center text-gray-400">
+            <Icon name="image" class="mb-2 h-8 w-8" />
+            <span class="text-sm">{{ t('products.media.preview.unsupported') }}</span>
+          </div>
+        </div>
+        <div class="flex gap-3 overflow-x-auto pb-1">
+          <button
+            v-for="(item, index) in orderedItems"
+            :key="item.id"
+            type="button"
+            class="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded border"
+            :class="[
+              index === activeIndex
+                ? 'border-primary ring-2 ring-primary'
+                : 'border-gray-200 hover:border-primary'
+            ]"
+            @click="setActiveIndex(index)"
+          >
+            <img
+              v-if="item.media?.imageWebUrl || item.media?.onesilaThumbnailUrl"
+              :src="item.media.imageWebUrl || item.media.onesilaThumbnailUrl"
+              :alt="t('products.media.preview.thumbnailAlt')"
+              class="h-full w-full object-cover"
+            />
+            <Icon v-else-if="item.media?.type === 'VIDEO'" name="video" class="h-5 w-5 text-gray-500" />
+            <Icon v-else name="file" class="h-5 w-5 text-gray-500" />
+          </button>
+        </div>
+      </div>
+      <div v-else class="flex h-64 flex-col items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 text-center">
+        <Icon name="image" class="mb-3 h-8 w-8 text-gray-400" />
+        <p class="text-sm text-gray-500">{{ t('products.media.preview.noImages') }}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-create/MediaCreate.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-create/MediaCreate.vue
@@ -2,22 +2,31 @@
 
 import { Product } from "../../../../../../configs";
 import { useI18n } from "vue-i18n";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { Button } from "../../../../../../../../../shared/components/atoms/button";
 import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
 import { CreateImagesModal } from "../../../../../../../../media/files/containers/create-modals/images-modal";
 import { CreateVideosModal } from "../../../../../../../../media/files/containers/create-modals/videos-modals";
 import { CreateDocumentsModal } from "../../../../../../../../media/files/containers/create-modals/documents-modal";
 import { TYPE_DOCUMENT, TYPE_IMAGE, TYPE_VIDEO } from "../../../../../../../../media/files/media";
-import {UploadMediaModal} from "../upload-media-modal";
+import { UploadMediaModal } from "../upload-media-modal";
 
 const { t } = useI18n();
 
-const props = defineProps<{ product: Product; mediaIds: string[] }>();
+const props = defineProps<{
+  product: Product;
+  mediaIds: string[];
+  salesChannelId?: string | 'default';
+  ensureSalesChannelSet?: () => Promise<void>;
+}>();
 const imagesModalVisible = ref(false);
 const videosModalVisible = ref(false);
 const documentsModalVisible = ref(false);
 const uploadModalVisible = ref(false);
+
+const resolvedSalesChannelId = computed(() =>
+  props.salesChannelId && props.salesChannelId !== 'default' ? props.salesChannelId : undefined
+);
 
 const emit = defineEmits(['media-added']);
 
@@ -25,8 +34,14 @@ const handleEntryAdded = () => {
   emit('media-added')
 };
 
-const openModal = (modalType: string, close: any) => {
+const ensureBeforeAction = async () => {
+  if (resolvedSalesChannelId.value) {
+    await props.ensureSalesChannelSet?.();
+  }
+};
 
+const openModal = async (modalType: string, close: any) => {
+  await ensureBeforeAction();
   if (modalType === TYPE_IMAGE) {
     imagesModalVisible.value = true;
   } else if (modalType === TYPE_VIDEO) {
@@ -79,9 +94,30 @@ const openModal = (modalType: string, close: any) => {
         </template>
       </Popper>
 
-      <UploadMediaModal v-model="uploadModalVisible" :product-id="product.id" :ids="mediaIds" @entries-created="handleEntryAdded" />
-      <CreateImagesModal v-model="imagesModalVisible" :product-id="product.id" @entries-created="handleEntryAdded" />
-      <CreateVideosModal v-model="videosModalVisible" :product-id="product.id" @entries-created="handleEntryAdded"/>
-      <CreateDocumentsModal v-model="documentsModalVisible" :product-id="product.id" @entries-created="handleEntryAdded" />
+      <UploadMediaModal
+        v-model="uploadModalVisible"
+        :product-id="product.id"
+        :ids="mediaIds"
+        :sales-channel-id="resolvedSalesChannelId"
+        @entries-created="handleEntryAdded"
+      />
+      <CreateImagesModal
+        v-model="imagesModalVisible"
+        :product-id="product.id"
+        :sales-channel-id="resolvedSalesChannelId"
+        @entries-created="handleEntryAdded"
+      />
+      <CreateVideosModal
+        v-model="videosModalVisible"
+        :product-id="product.id"
+        :sales-channel-id="resolvedSalesChannelId"
+        @entries-created="handleEntryAdded"
+      />
+      <CreateDocumentsModal
+        v-model="documentsModalVisible"
+        :product-id="product.id"
+        :sales-channel-id="resolvedSalesChannelId"
+        @entries-created="handleEntryAdded"
+      />
   </div>
 </template>

--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
@@ -1,95 +1,214 @@
 <script setup lang="ts">
-
-import {Product} from "../../../../../../configs";
-import { Link } from "../../../../../../../../../shared/components/atoms/link";
-import { useI18n } from "vue-i18n";
-import {ref, onMounted, watch, Ref} from "vue";
-import { Icon } from "../../../../../../../../../shared/components/atoms/icon";
-import { Image } from "../../../../../../../../../shared/components/atoms/image";
-import { formatDate, getFileName, getFileSize, getId, getPath, TYPE_DOCUMENT, TYPE_IMAGE, TYPE_VIDEO } from "../../../../../../../../media/files/media";
-import { mediaProductThroughQuery } from "../../../../../../../../../shared/api/queries/media.js";
-import { Button } from "../../../../../../../../../shared/components/atoms/button";
-import { ApolloAlertMutation } from "../../../../../../../../../shared/components/molecules/apollo-alert-mutation";
-import {deleteMediaProductThroughMutation, updateMediaProductThroughMutation} from "../../../../../../../../../shared/api/mutations/media.js";
+import { computed, nextTick, onMounted, reactive, ref, watch, type Ref } from 'vue';
+import type { FetchPolicy } from '@apollo/client';
+import { useI18n } from 'vue-i18n';
 import { VueDraggableNext } from 'vue-draggable-next';
-import apolloClient from "../../../../../../../../../../apollo-client";
-import {Toggle} from "../../../../../../../../../shared/components/atoms/toggle";
-import {VideoListingPreview} from "../../../../../../../../media/videos/videos-list/containers/video-listing-preview";
-import type { FetchPolicy } from "@apollo/client";
 
-type Media = {
+import { Product } from '../../../../../../configs';
+import { Link } from '../../../../../../../../../shared/components/atoms/link';
+import { Button } from '../../../../../../../../../shared/components/atoms/button';
+import { Icon } from '../../../../../../../../../shared/components/atoms/icon';
+import { Image } from '../../../../../../../../../shared/components/atoms/image';
+import { Toggle } from '../../../../../../../../../shared/components/atoms/toggle';
+import { ApolloAlertMutation } from '../../../../../../../../../shared/components/molecules/apollo-alert-mutation';
+import { VideoListingPreview } from '../../../../../../../../media/videos/videos-list/containers/video-listing-preview';
+import {
+  formatDate,
+  getFileName,
+  getFileSize,
+  getPath,
+  TYPE_DOCUMENT,
+  TYPE_IMAGE,
+  TYPE_VIDEO
+} from '../../../../../../../../media/files/media';
+import { mediaProductThroughQuery } from '../../../../../../../../../shared/api/queries/media.js';
+import {
+  createMediaProductThroughsMutation,
+  deleteMediaProductThroughMutation,
+  updateMediaProductThroughMutation
+} from '../../../../../../../../../shared/api/mutations/media.js';
+import apolloClient from '../../../../../../../../../../apollo-client';
+
+interface MediaOwner {
+  firstName?: string | null;
+  lastName?: string | null;
+}
+
+interface Media {
   id: string;
   type: string;
   imageWebUrl: string;
   videoUrl: string;
   updatedAt: Date;
-  owner: {
-    firstName: string;
-    lastName: string;
-  }
-};
+  owner: MediaOwner | null;
+}
+
+interface SalesChannelInfo {
+  id: string;
+  type: string;
+  hostname?: string | null;
+  name?: string | null;
+}
 
 type Item = {
   id: string;
   isMainImage: boolean;
-  media: Media
-}
+  active: boolean;
+  productType: string | null;
+  sortOrder: number | null;
+  media: Media;
+  salesChannel: SalesChannelInfo | null;
+};
+
+const props = defineProps<{
+  product: Product;
+  refetchNeeded: boolean;
+  salesChannelId: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'refetched'): void;
+  (e: 'update-ids', ids: string[]): void;
+  (e: 'items-loaded', payload: { items: Item[]; inherited: boolean }): void;
+}>();
 
 const { t } = useI18n();
-const props = defineProps<{ product: Product, refetchNeeded: boolean}>();
-const emit = defineEmits(['refetched', 'update-ids']);
-const viewType = ref('gallery');
+
+const viewType = ref<'gallery' | 'table'>('gallery');
 const items: Ref<Item[]> = ref([]);
-const isMainImageMap = ref({});
+const defaultItems: Ref<Item[]> = ref([]);
+const inheritedFromDefault = ref(false);
+const isMainImageMap = ref<Record<string, boolean>>({});
+const deleteVariables = reactive<Record<string, { id: string }>>({});
 
+const isDefaultChannel = computed(() => props.salesChannelId === 'default');
+const isChannelInherited = computed(() => !isDefaultChannel.value && inheritedFromDefault.value);
 
-onMounted(() => {
-  fetchData();
-})
-
-const extractVariationIds = (data) => {
-
-  if (!data || !data.edges) {
+const extractNodes = (connection: any): Item[] => {
+  if (!connection?.edges?.length) {
     return [];
   }
-
-  return data.edges.map(edge => edge.node.media.id);
+  return connection.edges.map((edge: any) => edge.node as Item);
 };
 
-const extractNodes = (data) => {
+const buildFilter = (channelId: string) => {
+  const filter: Record<string, any> = {
+    product: { id: { exact: props.product.id } }
+  };
 
-  if (!data || !data.edges) {
-    return [];
+  if (channelId === 'default') {
+    filter.salesChannel = { id: { isNull: true } };
+  } else {
+    filter.salesChannel = { id: { exact: channelId } };
   }
 
-  return data.edges.map(edge => edge.node);
+  return filter;
 };
 
+const syncMainImageMap = (entries: Item[]) => {
+  const map: Record<string, boolean> = {};
+  entries.forEach((entry) => {
+    map[entry.media.id] = entry.isMainImage;
+  });
+  isMainImageMap.value = map;
+};
 
-const fetchData = async (policy: FetchPolicy = 'cache-first') => {
-
+const loadDefaultItems = async (policy: FetchPolicy = 'cache-first') => {
   const { data } = await apolloClient.query({
     query: mediaProductThroughQuery,
-    variables: { filter: { product: {id: {exact: props.product.id }} }},
+    variables: { filter: buildFilter('default') },
     fetchPolicy: policy
   });
 
-  if (data) {
-    items.value = extractNodes(data.mediaProductThroughs);
-
-    // Reset isMainImageMap
-    isMainImageMap.value = {};
-
-    items.value.forEach(item => {
-      isMainImageMap.value[item.id] = item.isMainImage;
-    });
-
-    emit('update-ids', extractVariationIds(data.mediaProductThroughs))
-  }
-
+  return extractNodes(data?.mediaProductThroughs);
 };
 
-watch(() => props.refetchNeeded, (newValue, oldValue) => {
+const emitState = () => {
+  emit('update-ids', items.value.map((entry) => entry.media.id));
+  emit('items-loaded', { items: items.value, inherited: inheritedFromDefault.value });
+};
+
+const fetchData = async (policy: FetchPolicy = 'cache-first') => {
+  const { data } = await apolloClient.query({
+    query: mediaProductThroughQuery,
+    variables: { filter: buildFilter(props.salesChannelId) },
+    fetchPolicy: policy
+  });
+
+  const nodes = extractNodes(data?.mediaProductThroughs);
+
+  if (isDefaultChannel.value) {
+    items.value = nodes;
+    defaultItems.value = nodes;
+    inheritedFromDefault.value = false;
+  } else if (nodes.length === 0) {
+    const defaults = await loadDefaultItems(policy);
+    defaultItems.value = defaults;
+    items.value = defaults;
+    inheritedFromDefault.value = true;
+  } else {
+    items.value = nodes;
+    inheritedFromDefault.value = false;
+    if (!defaultItems.value.length) {
+      defaultItems.value = await loadDefaultItems(policy);
+    }
+  }
+
+  syncMainImageMap(items.value);
+  Object.keys(deleteVariables).forEach((key) => {
+    delete deleteVariables[key];
+  });
+  emitState();
+};
+
+const ensureChannelSpecificSet = async (): Promise<boolean> => {
+  if (isDefaultChannel.value || !inheritedFromDefault.value) {
+    return false;
+  }
+
+  const defaults = defaultItems.value.length
+    ? defaultItems.value
+    : await loadDefaultItems('network-only');
+
+  if (!defaults.length) {
+    inheritedFromDefault.value = false;
+    items.value = [];
+    syncMainImageMap(items.value);
+    emitState();
+    return false;
+  }
+
+  await apolloClient.mutate({
+    mutation: createMediaProductThroughsMutation,
+    variables: {
+      data: defaults.map((item, index) => ({
+        product: { id: props.product.id },
+        media: { id: item.media.id },
+        salesChannel: { id: props.salesChannelId },
+        sortOrder: index,
+        isMainImage: item.isMainImage,
+        active: item.active,
+        productType: item.productType
+      }))
+    }
+  });
+
+  inheritedFromDefault.value = false;
+  await fetchData('network-only');
+  return true;
+};
+
+defineExpose({ ensureChannelSpecificSet });
+
+onMounted(() => {
+  fetchData();
+});
+
+watch(() => props.salesChannelId, () => {
+  fetchData('network-only');
+});
+
+watch(() => props.refetchNeeded, (newValue) => {
   if (newValue) {
     fetchData('network-only');
     emit('refetched');
@@ -98,180 +217,278 @@ watch(() => props.refetchNeeded, (newValue, oldValue) => {
 
 const handleDeleteSuccess = () => {
   fetchData('network-only');
-}
-const handleEnd = async (event) => {
-    const maxIndexToUpdate = Math.max(event.oldIndex, event.newIndex);
-
-    const updatePromises = items.value.slice(0, maxIndexToUpdate + 1).map((item, index) => {
-        return apolloClient.mutate({
-            mutation: updateMediaProductThroughMutation,
-            variables: {
-                data: {
-                    id: item.id,
-                    sortOrder: index
-                }
-            }
-        });
-    });
-
-    const results = await Promise.allSettled(updatePromises);
-    fetchData('network-only');
 };
 
-const handleMainImageChange = async (changedItem: Item) => {
+const persistSortOrder = async (orderedMediaIds: string[]) => {
+  const orderedEntries = orderedMediaIds
+    .map((mediaId) => items.value.find((entry) => entry.media.id === mediaId))
+    .filter((entry): entry is Item => Boolean(entry));
 
-  const { data } = await apolloClient.mutate({
+  const updatePromises = orderedEntries.map((entry, index) => {
+    if ((entry.sortOrder ?? index) === index) {
+      return null;
+    }
+    return apolloClient.mutate({
+      mutation: updateMediaProductThroughMutation,
+      variables: {
+        data: {
+          id: entry.id,
+          sortOrder: index
+        }
+      }
+    });
+  }).filter(Boolean) as Promise<any>[];
+
+  if (updatePromises.length) {
+    await Promise.allSettled(updatePromises);
+  }
+
+  await fetchData('network-only');
+};
+
+const handleEnd = async () => {
+  const orderedMediaIds = items.value.map((entry) => entry.media.id);
+
+  if (!isDefaultChannel.value && inheritedFromDefault.value) {
+    const duplicated = await ensureChannelSpecificSet();
+    if (duplicated) {
+      await nextTick();
+    }
+  }
+
+  await persistSortOrder(orderedMediaIds);
+};
+
+const updateMainImage = async (target: Item) => {
+  await apolloClient.mutate({
     mutation: updateMediaProductThroughMutation,
     variables: {
       data: {
-        id: changedItem.id,
-        isMainImage: isMainImageMap.value[changedItem.id]
+        id: target.id,
+        isMainImage: !!isMainImageMap.value[target.media.id]
       }
     }
   });
 
-  fetchData('network-only');
+  await fetchData('network-only');
 };
 
+const handleMainImageChange = async (item: Item) => {
+  let target = item;
 
+  if (!isDefaultChannel.value && inheritedFromDefault.value) {
+    const duplicated = await ensureChannelSpecificSet();
+    if (duplicated) {
+      await nextTick();
+    }
+    target = items.value.find((entry) => entry.media.id === item.media.id) || item;
+  }
+
+  await updateMainImage(target);
+};
+
+const prepareDelete = async (item: Item, confirm: () => Promise<void>) => {
+  let target = item;
+
+  if (!isDefaultChannel.value && inheritedFromDefault.value) {
+    const duplicated = await ensureChannelSpecificSet();
+    if (duplicated) {
+      await nextTick();
+    }
+    target = items.value.find((entry) => entry.media.id === item.media.id) || item;
+  }
+
+  deleteVariables[item.media.id] = { id: target.id };
+  await confirm();
+};
 
 </script>
 
 <template>
   <div>
     <Flex between class="py-2">
-          <FlexCell grow></FlexCell>
-          <FlexCell>
-            <div class="bg-gray-100 px-2 py-1 rounded-lg">
-              <Button class="mr-2" @click="viewType = 'table'" :class="{'text-blue-500': viewType === 'table'}">
-                  <Icon name="table" />
-              </Button>
-              <Button @click="viewType = 'gallery'" :class="{'text-blue-500': viewType === 'gallery'}">
-                  <Icon name="images" />
-              </Button>
-            </div>
-          </FlexCell>
-      </Flex>
-      <div>
-        <div v-if="viewType === 'table'" class="overflow-x-auto">
-            <div class="inline-block min-w-full align-middle">
-                <div class="overflow-hidden">
-                    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-600">
-                        <thead class="bg-gray-50 dark:bg-gray-700">
-                            <tr class="text-gray-800 dark:text-gray-300">
-                              <th scope="col" class="p-3.5 text-sm text-start font-semibold">{{ t('media.media.labels.fileName') }}</th>
-                              <th scope="col" class="p-3.5 text-sm text-start font-semibold">{{ t('media.media.labels.lastModified') }}</th>
-                              <th scope="col" class="p-3.5 text-sm text-start font-semibold">{{ t('media.media.labels.fileSize') }}</th>
-                              <th scope="col" class="p-3.5 text-sm text-start font-semibold">{{ t('media.media.labels.owner') }}</th>
-                              <th scope="col" class="p-3.5 text-sm text-start font-semibold">{{ t('media.media.labels.isMainImage') }}</th>
-                              <th scope="col" class="p-3.5 text-sm text-start font-semibold">{{ t('shared.labels.actions') }}</th>
-                            </tr>
-                        </thead>
-                          <VueDraggableNext tag="tbody" :list="items"  @end="handleEnd" class="dragArea divide-y divide-gray-200 dark:divide-gray-600">
-                            <tr v-for="item in items" :key="item.id">
-                              <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
-                                <span v-if="item.media.type === TYPE_DOCUMENT">
-                                  {{ getFileName(item.media) }}
-                                </span>
-                                <Link v-else :path="getPath(item.media)">
-                                  {{ getFileName(item.media) }}
-                                </Link>
-                              </td>
-                              <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">{{ formatDate(item.media.updatedAt) }}</td>
-                              <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">{{ getFileSize(item.media) }}</td>
-                              <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
-                                  {{
-                                    item.media?.owner?.firstName || item.media?.owner?.lastName
-                                      ? `${item.media.owner.firstName || ''} ${item.media.owner.lastName || ''}`.trim()
-                                      : '-'
-                                  }}
-                              </td>
-                              <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
-                                <Toggle v-if="item.media.type === TYPE_IMAGE" v-model="isMainImageMap[item.id]" @@update:model-value="handleMainImageChange(item)" />
-                              </td>
-                              <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
-                                <Flex>
-                                  <FlexCell v-if="item.media.type === TYPE_IMAGE" class="mr-2">
-                                  </FlexCell>
-                                  <FlexCell>
-                                    <ApolloAlertMutation :mutation="deleteMediaProductThroughMutation" :mutation-variables="{id: item.id}" @done="handleDeleteSuccess">
-                                      <template v-slot="{ loading, confirmAndMutate }">
-                                        <Button @click="confirmAndMutate">
-                                          <Icon name="trash" />
-                                        </Button>
-                                      </template>
-                                    </ApolloAlertMutation>
-                                  </FlexCell>
-                                </Flex>
-                              </td>
-                            </tr>
-                        </VueDraggableNext>
-                    </table>
-                </div>
-            </div>
+      <FlexCell grow></FlexCell>
+      <FlexCell>
+        <div class="bg-gray-100 px-2 py-1 rounded-lg">
+          <Button class="mr-2" @click="viewType = 'table'" :class="{ 'text-blue-500': viewType === 'table' }">
+            <Icon name="table" />
+          </Button>
+          <Button @click="viewType = 'gallery'" :class="{ 'text-blue-500': viewType === 'gallery' }">
+            <Icon name="images" />
+          </Button>
         </div>
-        <div v-else>
-          <VueDraggableNext :list="items"  @end="handleEnd" class="dragArea gallery grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4 p-4">
-            <div v-for="item in items" :key="item.media.id" class="file-entry relative">
-                <template v-if="item.media.type === TYPE_IMAGE">
-                  <Link :path="getPath(item.media)">
-                    <div class="w-56 h-48 rounded-md overflow-hidden flex items-center justify-center">
-                      <Image :source="item.media.imageWebUrl" :alt="t('media.media.labels.fileThumbnail')" class="w-full h-full object-contain" />
-                    </div>
-                  </Link>
-                </template>
-                <template v-else-if="item.media.type === TYPE_VIDEO">
-                  <Link :path="getPath(item.media)">
-                      <VideoListingPreview :video-url="item.media.videoUrl" />
-                  </Link>
-                </template>
-                <template v-else-if="item.media.type === TYPE_DOCUMENT">
-                    <div class="flex justify-center items-center h-48 bg-gray-200 px-28 rounded-md">
-                        <Icon name="file-text" size="2xl" class="text-gray-600"/>
-                    </div>
-                </template>
-
-                <div class="overlay-info absolute bottom-0 left-0 right-0 bg-gray-700 bg-opacity-50 text-white p-2 text-md font-medium hidden">
-                  <Flex>
-                    <FlexCell grow center>
-                      {{ getFileName(item.media) }} {{ getFileSize(item.media) }}
-                    </FlexCell>
-                    <FlexCell v-if="item.media.type === TYPE_IMAGE" center class="mr-2">
-                      <Toggle v-model="isMainImageMap[item.id]" @update:model-value="handleMainImageChange(item)" />
-                    </FlexCell>
-                    <FlexCell center>
-                      <ApolloAlertMutation :mutation="deleteMediaProductThroughMutation" :mutation-variables="{id: item.id}" @done="handleDeleteSuccess">
-                        <template v-slot="{ loading, confirmAndMutate }">
-                          <Button @click="confirmAndMutate">
-                            <Icon size="xl" name="trash" />
-                          </Button>
-                        </template>
-                      </ApolloAlertMutation>
-                    </FlexCell>
-                  </Flex>
-                </div>
-            </div>
-        </VueDraggableNext>
+      </FlexCell>
+    </Flex>
+    <div>
+      <div
+        v-if="isChannelInherited"
+        class="mb-4 rounded border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700"
+      >
+        {{ t('products.media.messages.inheritedFromDefault') }}
+      </div>
+      <div v-if="viewType === 'table'" class="overflow-x-auto" :class="{ 'opacity-60': isChannelInherited }">
+        <div class="inline-block min-w-full align-middle">
+          <div class="overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-600">
+              <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr class="text-gray-800 dark:text-gray-300">
+                  <th scope="col" class="p-3.5 text-sm text-start font-semibold">
+                    {{ t('media.media.labels.fileName') }}
+                  </th>
+                  <th scope="col" class="p-3.5 text-sm text-start font-semibold">
+                    {{ t('media.media.labels.lastModified') }}
+                  </th>
+                  <th scope="col" class="p-3.5 text-sm text-start font-semibold">
+                    {{ t('media.media.labels.fileSize') }}
+                  </th>
+                  <th scope="col" class="p-3.5 text-sm text-start font-semibold">
+                    {{ t('media.media.labels.owner') }}
+                  </th>
+                  <th scope="col" class="p-3.5 text-sm text-start font-semibold">
+                    {{ t('media.media.labels.isMainImage') }}
+                  </th>
+                  <th scope="col" class="p-3.5 text-sm text-start font-semibold">
+                    {{ t('shared.labels.actions') }}
+                  </th>
+                </tr>
+              </thead>
+              <VueDraggableNext
+                tag="tbody"
+                :list="items"
+                class="dragArea divide-y divide-gray-200 dark:divide-gray-600"
+                @end="handleEnd"
+              >
+                <tr v-for="item in items" :key="item.id">
+                  <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
+                    <span v-if="item.media.type === TYPE_DOCUMENT">
+                      {{ getFileName(item.media) }}
+                    </span>
+                    <Link v-else :path="getPath(item.media)">
+                      {{ getFileName(item.media) }}
+                    </Link>
+                  </td>
+                  <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
+                    {{ formatDate(item.media.updatedAt) }}
+                  </td>
+                  <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
+                    {{ getFileSize(item.media) }}
+                  </td>
+                  <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
+                    {{
+                      item.media?.owner?.firstName || item.media?.owner?.lastName
+                        ? `${item.media.owner?.firstName || ''} ${item.media.owner?.lastName || ''}`.trim()
+                        : '-'
+                    }}
+                  </td>
+                  <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
+                    <Toggle
+                      v-if="item.media.type === TYPE_IMAGE"
+                      v-model="isMainImageMap[item.media.id]"
+                      @update:modelValue="handleMainImageChange(item)"
+                    />
+                  </td>
+                  <td class="p-3.5 text-sm text-gray-700 dark:text-gray-400">
+                    <Flex>
+                      <FlexCell v-if="item.media.type === TYPE_IMAGE" class="mr-2"></FlexCell>
+                      <FlexCell>
+                        <ApolloAlertMutation
+                          :mutation="deleteMediaProductThroughMutation"
+                          :mutation-variables="deleteVariables[item.media.id] ?? { id: item.id }"
+                          @done="handleDeleteSuccess"
+                        >
+                          <template #default="{ confirmAndMutate }">
+                            <Button @click="() => prepareDelete(item, confirmAndMutate)">
+                              <Icon name="trash" />
+                            </Button>
+                          </template>
+                        </ApolloAlertMutation>
+                      </FlexCell>
+                    </Flex>
+                  </td>
+                </tr>
+              </VueDraggableNext>
+            </table>
+          </div>
         </div>
       </div>
+      <div v-else>
+        <VueDraggableNext
+          :list="items"
+          class="dragArea gallery grid grid-cols-1 gap-4 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
+          :class="{ 'opacity-60': isChannelInherited }"
+          @end="handleEnd"
+        >
+          <div v-for="item in items" :key="item.media.id" class="file-entry relative">
+            <template v-if="item.media.type === TYPE_IMAGE">
+              <Link :path="getPath(item.media)">
+                <div class="flex h-48 w-56 items-center justify-center overflow-hidden rounded-md">
+                  <Image
+                    :source="item.media.imageWebUrl"
+                    :alt="t('media.media.labels.fileThumbnail')"
+                    class="h-full w-full object-contain"
+                  />
+                </div>
+              </Link>
+            </template>
+            <template v-else-if="item.media.type === TYPE_VIDEO">
+              <Link :path="getPath(item.media)">
+                <VideoListingPreview :video-url="item.media.videoUrl" />
+              </Link>
+            </template>
+            <template v-else-if="item.media.type === TYPE_DOCUMENT">
+              <div class="flex h-48 items-center justify-center rounded-md bg-gray-200 px-28">
+                <Icon name="file-text" size="2xl" class="text-gray-600" />
+              </div>
+            </template>
+
+            <div class="overlay-info absolute bottom-0 left-0 right-0 hidden bg-gray-700 bg-opacity-50 p-2 text-md font-medium text-white">
+              <Flex>
+                <FlexCell center grow>
+                  {{ getFileName(item.media) }} {{ getFileSize(item.media) }}
+                </FlexCell>
+                <FlexCell v-if="item.media.type === TYPE_IMAGE" center class="mr-2">
+                  <Toggle
+                    v-model="isMainImageMap[item.media.id]"
+                    @update:modelValue="handleMainImageChange(item)"
+                  />
+                </FlexCell>
+                <FlexCell center>
+                  <ApolloAlertMutation
+                    :mutation="deleteMediaProductThroughMutation"
+                    :mutation-variables="deleteVariables[item.media.id] ?? { id: item.id }"
+                    @done="handleDeleteSuccess"
+                  >
+                    <template #default="{ confirmAndMutate }">
+                      <Button @click="() => prepareDelete(item, confirmAndMutate)">
+                        <Icon size="xl" name="trash" />
+                      </Button>
+                    </template>
+                  </ApolloAlertMutation>
+                </FlexCell>
+              </Flex>
+            </div>
+          </div>
+        </VueDraggableNext>
+      </div>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .gallery .file-entry:hover .overlay-info {
-    display: block;
+  display: block;
 }
 
 .gallery {
-    display: grid;
-    grid-gap: 4px;
-    padding: 4px;
+  display: grid;
+  grid-gap: 4px;
+  padding: 4px;
 }
 
 .file-entry {
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 </style>

--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
@@ -187,8 +187,6 @@ const ensureChannelSpecificSet = async (): Promise<boolean> => {
         salesChannel: { id: props.salesChannelId },
         sortOrder: index,
         isMainImage: item.isMainImage,
-        active: item.active,
-        productType: item.productType
       }))
     }
   });

--- a/src/core/products/products/product-show/containers/tabs/media/containers/upload-media-modal/UploadMediaModal.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/upload-media-modal/UploadMediaModal.vue
@@ -13,7 +13,7 @@ import { Toast } from "../../../../../../../../../shared/modules/toast";
 
 
 const props = withDefaults(
-  defineProps<{ modelValue: boolean; productId?: string; ids?: any[]; linkOnSelect?: boolean }>(),
+  defineProps<{ modelValue: boolean; productId?: string; ids?: any[]; linkOnSelect?: boolean; salesChannelId?: string }>(),
   {
     ids: () => [],
     linkOnSelect: true,
@@ -50,10 +50,13 @@ const handleMediaAssign = async (media) => {
     return;
   }
 
-  const variables = {
+  const variables: any = {
     product: { id: props.productId},
     media: { id: media.id},
   };
+  if (props.salesChannelId) {
+    variables.salesChannel = { id: props.salesChannelId };
+  }
   try {
     const {data} = await apolloClient.mutate({
       mutation: createMediaProductThroughMutation,

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -192,6 +192,21 @@
           }
         }
       },
+      "media": {
+        "messages": {
+          "inheritedFromDefault": ""
+        },
+        "preview": {
+          "channelHeading": "",
+          "channelFallback": "",
+          "description": "",
+          "mainImageAlt": "",
+          "thumbnailAlt": "",
+          "noImages": "",
+          "unsupported": "",
+          "untitledProduct": ""
+        }
+      },
       "properties": {
         "searchPlaceholder": "Eigenschaften suchen",
         "typePlaceholder": "Nach Typ filtern"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1091,6 +1091,21 @@
           },
           "optionLabel": "{name} ({rate}%)"
         },
+        "media": {
+          "messages": {
+            "inheritedFromDefault": "These images are currently inherited from the default channel. Making changes will create a dedicated gallery for this channel."
+          },
+          "preview": {
+            "channelHeading": "Preview for {channel}",
+            "channelFallback": "this channel",
+            "description": "See how your media gallery appears on the selected channel.",
+            "mainImageAlt": "Main product image preview",
+            "thumbnailAlt": "Gallery thumbnail",
+            "noImages": "No images available for this product yet.",
+            "unsupported": "Preview unavailable",
+            "untitledProduct": "Unnamed product"
+          }
+        },
         "prices": {
           "columns": {
             "rrp": "RRP ({currency})",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -189,6 +189,21 @@
           }
         }
       },
+      "media": {
+        "messages": {
+          "inheritedFromDefault": ""
+        },
+        "preview": {
+          "channelHeading": "",
+          "channelFallback": "",
+          "description": "",
+          "mainImageAlt": "",
+          "thumbnailAlt": "",
+          "noImages": "",
+          "unsupported": "",
+          "untitledProduct": ""
+        }
+      },
       "properties": {
         "searchPlaceholder": "Rechercher des propriétés",
         "typePlaceholder": "Filtrer par type"

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -768,6 +768,21 @@
           }
         }
       },
+      "media": {
+        "messages": {
+          "inheritedFromDefault": ""
+        },
+        "preview": {
+          "channelHeading": "",
+          "channelFallback": "",
+          "description": "",
+          "mainImageAlt": "",
+          "thumbnailAlt": "",
+          "noImages": "",
+          "unsupported": "",
+          "untitledProduct": ""
+        }
+      },
         "properties": {
           "searchPlaceholder": "Zoek eigenschappen",
           "typePlaceholder": "Filter op type"

--- a/src/shared/api/queries/media.js
+++ b/src/shared/api/queries/media.js
@@ -200,6 +200,12 @@ export const mediaProductThroughQuery = gql`
         node {
           id
           productId
+          salesChannel {
+            id
+            type
+            hostname
+            name
+          }
           isMainImage
           active
           productType

--- a/src/shared/api/queries/media.js
+++ b/src/shared/api/queries/media.js
@@ -204,7 +204,6 @@ export const mediaProductThroughQuery = gql`
             id
             type
             hostname
-            name
           }
           isMainImage
           active

--- a/src/shared/components/molecules/sales-channel-tabs/SalesChannelTabs.vue
+++ b/src/shared/components/molecules/sales-channel-tabs/SalesChannelTabs.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { IntegrationTypes } from '../../../../../../integrations/integrations/integrations';
-import { Icon } from '../../../../../../../shared/components/atoms/icon';
 import { useI18n } from 'vue-i18n';
-import magentoIcon from "../../../../../../../assets/images/integration-types/icons/magento.svg";
-import shopifyIcon from "../../../../../../../assets/images/integration-types/icons/shopify.svg";
-import woocommerceIcon from "../../../../../../../assets/images/integration-types/icons/woocommerce.svg";
-import amazonIcon from "../../../../../../../assets/images/integration-types/icons/amazon.svg";
-import ebayIcon from "../../../../../../../assets/images/integration-types/icons/ebay.svg";
+import { IntegrationTypes } from '../../../../core/integrations/integrations/integrations';
+import { Icon } from '../../atoms/icon';
+import magentoIcon from '../../../../assets/images/integration-types/icons/magento.svg';
+import shopifyIcon from '../../../../assets/images/integration-types/icons/shopify.svg';
+import woocommerceIcon from '../../../../assets/images/integration-types/icons/woocommerce.svg';
+import amazonIcon from '../../../../assets/images/integration-types/icons/amazon.svg';
+import ebayIcon from '../../../../assets/images/integration-types/icons/ebay.svg';
 
 const props = defineProps<{ channels: any[]; modelValue: string }>();
 const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>();
@@ -26,7 +26,7 @@ const cleanHostname = (hostname: string, type: string) => {
   }
 };
 
-const integrationTypeIcons = {
+const integrationTypeIcons: Record<string, string> = {
   magento: magentoIcon,
   shopify: shopifyIcon,
   woocommerce: woocommerceIcon,
@@ -34,6 +34,11 @@ const integrationTypeIcons = {
   ebay: ebayIcon
 };
 
+
+const resolveLabel = (channel: any) => {
+  if (!channel) return '';
+  return channel.name || cleanHostname(channel.hostname, channel.type);
+};
 
 const select = (val: string) => emit('update:modelValue', val);
 
@@ -70,7 +75,7 @@ const select = (val: string) => emit('update:modelValue', val);
           :src="integrationTypeIcons[channel.type]"
           :alt="channel.type"
         />
-        {{ cleanHostname(channel.hostname, channel.type) }}
+        {{ resolveLabel(channel) }}
       </div>
     </div>
   </div>

--- a/src/shared/components/molecules/sales-channel-tabs/index.ts
+++ b/src/shared/components/molecules/sales-channel-tabs/index.ts
@@ -1,0 +1,1 @@
+export { default as SalesChannelTabs } from './SalesChannelTabs.vue';


### PR DESCRIPTION
## Summary
- move the sales channel tabs component into the shared library and reuse it in the product content tab
- overhaul the product media tab with channel-aware duplication, selection, and a gallery preview component
- thread the sales channel context through media creation flows and extend media translations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3e632d8e4832eb377b574c28532d3

## Summary by Sourcery

Implement channel-aware product media management by introducing sales channel selection tabs, duplicating default media assets per channel, threading the salesChannelId through all media operations, and providing a live preview panel for each channel's media.

New Features:
- Add sales channel tabs for switching product media contexts
- Enable inheritance and duplication of default media items into channel-specific lists
- Thread sales channel ID through media creation, update, and deletion operations
- Introduce ProductMediaPreview component to display a channel-aware media preview

Enhancements:
- Migrate SalesChannelTabs component into shared library and update imports
- Refactor media listing to support table and gallery views with inheritance notices and opacity controls
- Update GraphQL queries and mutations to include salesChannel in filters and payloads
- Extend media creation modals and upload components to accept salesChannelId
- Add filter-building utilities and state management for channel-specific media flows

Documentation:
- Add localization entries for channel inheritance messages and media preview labels

Chores:
- Export SalesChannelTabs from a new index for shared components