### PR TITLE
Add manual gallery creation workflow for sales channels

### DIFF
--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-create/MediaCreate.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-create/MediaCreate.vue
@@ -17,7 +17,7 @@ const props = defineProps<{
   product: Product;
   mediaIds: string[];
   salesChannelId?: string | 'default';
-  ensureSalesChannelSet?: () => Promise<void>;
+  disabled?: boolean;
 }>();
 const imagesModalVisible = ref(false);
 const videosModalVisible = ref(false);
@@ -34,14 +34,10 @@ const handleEntryAdded = () => {
   emit('media-added')
 };
 
-const ensureBeforeAction = async () => {
-  if (resolvedSalesChannelId.value) {
-    await props.ensureSalesChannelSet?.();
-  }
-};
-
 const openModal = async (modalType: string, close: any) => {
-  await ensureBeforeAction();
+  if (props.disabled) {
+    return;
+  }
   if (modalType === TYPE_IMAGE) {
     imagesModalVisible.value = true;
   } else if (modalType === TYPE_VIDEO) {
@@ -60,7 +56,7 @@ const openModal = async (modalType: string, close: any) => {
 <template>
   <div>
     <Popper :placement="'bottom-end'" offsetDistance="8" class="!block">
-        <Button class="btn btn-primary">
+        <Button class="btn btn-primary" :disabled="disabled">
           <Icon class="mr-2" name="plus" />
           {{ t('shared.button.add') }}
         </Button>

--- a/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
+++ b/src/core/products/products/product-show/containers/tabs/media/containers/media-list/MediaList.vue
@@ -64,6 +64,7 @@ const props = defineProps<{
   product: Product;
   refetchNeeded: boolean;
   salesChannelId: string;
+  readonlyMode: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -83,6 +84,7 @@ const deleteVariables = reactive<Record<string, { id: string }>>({});
 
 const isDefaultChannel = computed(() => props.salesChannelId === 'default');
 const isChannelInherited = computed(() => !isDefaultChannel.value && inheritedFromDefault.value);
+const isReadOnly = computed(() => props.readonlyMode);
 
 const extractNodes = (connection: any): Item[] => {
   if (!connection?.edges?.length) {
@@ -245,6 +247,10 @@ const persistSortOrder = async (orderedMediaIds: string[]) => {
 };
 
 const handleEnd = async () => {
+  if (isReadOnly.value) {
+    return;
+  }
+
   const orderedMediaIds = items.value.map((entry) => entry.media.id);
 
   if (!isDefaultChannel.value && inheritedFromDefault.value) {
@@ -272,6 +278,10 @@ const updateMainImage = async (target: Item) => {
 };
 
 const handleMainImageChange = async (item: Item) => {
+  if (isReadOnly.value) {
+    return;
+  }
+
   let target = item;
 
   if (!isDefaultChannel.value && inheritedFromDefault.value) {
@@ -286,6 +296,10 @@ const handleMainImageChange = async (item: Item) => {
 };
 
 const prepareDelete = async (item: Item, confirm: () => Promise<void>) => {
+  if (isReadOnly.value) {
+    return;
+  }
+
   let target = item;
 
   if (!isDefaultChannel.value && inheritedFromDefault.value) {
@@ -354,6 +368,7 @@ const prepareDelete = async (item: Item, confirm: () => Promise<void>) => {
                 tag="tbody"
                 :list="items"
                 class="dragArea divide-y divide-gray-200 dark:divide-gray-600"
+                :disabled="isReadOnly"
                 @end="handleEnd"
               >
                 <tr v-for="item in items" :key="item.id">
@@ -382,6 +397,7 @@ const prepareDelete = async (item: Item, confirm: () => Promise<void>) => {
                     <Toggle
                       v-if="item.media.type === TYPE_IMAGE"
                       v-model="isMainImageMap[item.media.id]"
+                      :disabled="isReadOnly"
                       @update:modelValue="handleMainImageChange(item)"
                     />
                   </td>
@@ -395,7 +411,7 @@ const prepareDelete = async (item: Item, confirm: () => Promise<void>) => {
                           @done="handleDeleteSuccess"
                         >
                           <template #default="{ confirmAndMutate }">
-                            <Button @click="() => prepareDelete(item, confirmAndMutate)">
+                            <Button :disabled="isReadOnly" @click="() => prepareDelete(item, confirmAndMutate)">
                               <Icon name="trash" />
                             </Button>
                           </template>
@@ -414,6 +430,7 @@ const prepareDelete = async (item: Item, confirm: () => Promise<void>) => {
           :list="items"
           class="dragArea gallery grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-3"
           :class="{ 'opacity-60': isChannelInherited }"
+          :disabled="isReadOnly"
           @end="handleEnd"
         >
           <div v-for="item in items" :key="item.media.id" class="file-entry relative">
@@ -447,6 +464,7 @@ const prepareDelete = async (item: Item, confirm: () => Promise<void>) => {
                 <FlexCell v-if="item.media.type === TYPE_IMAGE" center class="mr-2">
                   <Toggle
                     v-model="isMainImageMap[item.media.id]"
+                    :disabled="isReadOnly"
                     @update:modelValue="handleMainImageChange(item)"
                   />
                 </FlexCell>
@@ -457,7 +475,7 @@ const prepareDelete = async (item: Item, confirm: () => Promise<void>) => {
                     @done="handleDeleteSuccess"
                   >
                     <template #default="{ confirmAndMutate }">
-                      <Button @click="() => prepareDelete(item, confirmAndMutate)">
+                      <Button :disabled="isReadOnly" @click="() => prepareDelete(item, confirmAndMutate)">
                         <Icon size="xl" name="trash" />
                       </Button>
                     </template>

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -196,6 +196,9 @@
         "messages": {
           "inheritedFromDefault": ""
         },
+        "actions": {
+          "createChannelGallery": ""
+        },
         "preview": {
           "channelHeading": "",
           "channelFallback": "",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1093,7 +1093,10 @@
         },
         "media": {
           "messages": {
-            "inheritedFromDefault": "These images are currently inherited from the default channel. Making changes will create a dedicated gallery for this channel."
+            "inheritedFromDefault": "These images are currently inherited from the default channel. Click \"Create gallery\" to create a dedicated gallery for this channel."
+          },
+          "actions": {
+            "createChannelGallery": "Create gallery"
           },
           "preview": {
             "channelHeading": "Preview for {channel}",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -193,6 +193,9 @@
         "messages": {
           "inheritedFromDefault": ""
         },
+        "actions": {
+          "createChannelGallery": ""
+        },
         "preview": {
           "channelHeading": "",
           "channelFallback": "",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -772,6 +772,9 @@
         "messages": {
           "inheritedFromDefault": ""
         },
+        "actions": {
+          "createChannelGallery": ""
+        },
         "preview": {
           "channelHeading": "",
           "channelFallback": "",


### PR DESCRIPTION
## Summary
- add a dedicated button to create sales-channel-specific galleries instead of auto-triggering duplication
- keep inherited galleries read-only until the user creates a channel gallery and disable media creation controls during that state
- add translations for the new action label and update the inheritance helper copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5396ed568832ea958e7c158fefec0

## Summary by Sourcery

Introduce a manual workflow for creating sales-channel-specific galleries, enforce read-only mode on inherited galleries until a channel gallery is created, and add corresponding i18n text.

New Features:
- Add manual 'Create channel gallery' button to trigger sales-channel-specific media duplication

Enhancements:
- Disable media creation, deletion, sorting, and main-image toggles when viewing inherited galleries
- Refactor media components to respect a read-only state and remove automatic channel-set triggering

Documentation:
- Add translations for the new action label and update the inheritance helper copy