### PR TITLE
Refactor MCP and improve Mirakl and Shein

### DIFF
--- a/src/core/imports_exports/ai-imports/ai-import-show/AIImportShowController.vue
+++ b/src/core/imports_exports/ai-imports/ai-import-show/AIImportShowController.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+import GeneralTemplate from '../../../../shared/templates/GeneralTemplate.vue';
+import { Breadcrumbs } from '../../../../shared/components/molecules/breadcrumbs';
+import { Card } from '../../../../shared/components/atoms/card';
+import { Tabs } from '../../../../shared/components/molecules/tabs';
+import { Link } from '../../../../shared/components/atoms/link';
+import { Button } from '../../../../shared/components/atoms/button';
+import { Badge } from '../../../../shared/components/atoms/badge';
+import { Loader } from '../../../../shared/components/atoms/loader';
+import { ProgressBar } from '../../../../shared/components/molecules/progress-bar';
+import ImportBrokenRecordsTab from '../../components/ImportBrokenRecordsTab.vue';
+import StructuredDataSection from '../../components/StructuredDataSection.vue';
+import { getMcpToolLabel, getStatusBadgeMap } from '../../configs';
+import { mcpToolRunQuery } from '../../../../shared/api/queries/mcpToolRuns.js';
+
+const { t } = useI18n();
+const route = useRoute();
+const id = ref(String(route.params.id));
+
+const tabs = computed(() => [
+  { name: 'overview', label: t('importsExports.aiImports.tabs.overview'), icon: 'circle-info', alwaysRender: true },
+  { name: 'brokenRecords', label: t('importsExports.aiImports.tabs.brokenRecords'), icon: 'triangle-exclamation', alwaysRender: true },
+]);
+
+const statusBadgeMap = getStatusBadgeMap(t);
+
+const getProgressColor = (percentageColor?: string | null) => {
+  switch (String(percentageColor || '').toUpperCase()) {
+    case 'RED':
+      return { labelColor: 'text-red-600', barColor: 'bg-red-500' };
+    case 'GREEN':
+      return { labelColor: 'text-green-600', barColor: 'bg-green-500' };
+    default:
+      return { labelColor: 'text-orange-500', barColor: 'bg-orange-400' };
+  }
+};
+
+const formatDate = (value?: string | null) => {
+  if (!value) {
+    return '-';
+  }
+
+  return new Intl.DateTimeFormat('en-GB', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(value));
+};
+
+const getAssignedViews = (node: any) => node?.assignedViews?.filter(Boolean) || [];
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template #breadcrumbs>
+      <Breadcrumbs
+        :links="[
+          { path: { name: 'importsExports.aiImports.list' }, name: t('importsExports.aiImports.title') },
+          { path: { name: 'importsExports.aiImports.show', params: { id } }, name: t('importsExports.aiImports.show.title') },
+        ]"
+      />
+    </template>
+
+    <template #content>
+      <ApolloQuery :query="mcpToolRunQuery" :variables="{ id }" fetch-policy="cache-and-network">
+        <template v-slot="{ result: { loading, data } }">
+          <Loader :loading="loading" />
+
+          <Card v-if="data?.mcpToolRun" class="border border-slate-200 shadow-sm">
+            <Tabs :tabs="tabs">
+              <template #overview>
+                <div class="p-4">
+                  <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                    <ProgressBar
+                      :progress="data.mcpToolRun.percentage ?? 0"
+                      :label="statusBadgeMap[data.mcpToolRun.status]?.text || data.mcpToolRun.status || ''"
+                      :label-color="getProgressColor(data.mcpToolRun.percentageColor).labelColor"
+                      :bar-color="getProgressColor(data.mcpToolRun.percentageColor).barColor"
+                    />
+                  </div>
+
+                  <div class="mt-4 divide-y divide-gray-200">
+                    <div class="flex items-center py-3">
+                      <span class="w-1/3 font-medium">{{ t('shared.labels.name') }}</span>
+                      <span>{{ data.mcpToolRun.name || '-' }}</span>
+                    </div>
+                    <div class="flex items-center py-3">
+                      <span class="w-1/3 font-medium">{{ t('importsExports.aiImports.fields.tool') }}</span>
+                      <Badge
+                        color="indigo"
+                        :text="getMcpToolLabel(t, data.mcpToolRun.tool, data.mcpToolRun.toolName)"
+                      />
+                    </div>
+                    <div class="flex items-center py-3">
+                      <span class="w-1/3 font-medium">{{ t('importsExports.aiImports.fields.toolName') }}</span>
+                      <span>{{ data.mcpToolRun.toolName || '-' }}</span>
+                    </div>
+                    <div class="flex items-center py-3">
+                      <span class="w-1/3 font-medium">{{ t('shared.labels.status') }}</span>
+                      <Badge
+                        :color="statusBadgeMap[data.mcpToolRun.status]?.color"
+                        :text="statusBadgeMap[data.mcpToolRun.status]?.text || data.mcpToolRun.status"
+                      />
+                    </div>
+                    <div class="flex items-center py-3">
+                      <span class="w-1/3 font-medium">{{ t('importsExports.fields.totalRecords') }}</span>
+                      <span>{{ data.mcpToolRun.totalRecords ?? 0 }}</span>
+                    </div>
+                    <div class="flex items-center py-3">
+                      <span class="w-1/3 font-medium">{{ t('importsExports.fields.processedRecords') }}</span>
+                      <span>{{ data.mcpToolRun.processedRecords ?? 0 }}</span>
+                    </div>
+                    <div class="items-start py-3 sm:flex">
+                      <span class="w-1/3 pt-1 font-medium">{{ t('importsExports.aiImports.fields.assignedViews') }}</span>
+                      <div class="mt-2 flex flex-wrap gap-2 sm:mt-0">
+                        <template v-if="getAssignedViews(data.mcpToolRun).length">
+                          <template v-for="view in getAssignedViews(data.mcpToolRun)" :key="view.id">
+                            <Link v-if="view.url" external :path="view.url">
+                              <span class="inline-flex rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
+                                {{ view.name || view.id }}
+                              </span>
+                            </Link>
+                            <span v-else class="inline-flex rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
+                              {{ view.name || view.id }}
+                            </span>
+                          </template>
+                        </template>
+                        <span v-else class="text-sm text-slate-500">
+                          {{ t('importsExports.aiImports.empty.assignedViews') }}
+                        </span>
+                      </div>
+                    </div>
+                    <div class="flex items-center py-3">
+                      <span class="w-1/3 font-medium">{{ t('shared.labels.createdAt') }}</span>
+                      <span>{{ formatDate(data.mcpToolRun.createdAt) }}</span>
+                    </div>
+                    <div v-if="data.mcpToolRun.errorTraceback" class="py-3">
+                      <span class="block font-medium">{{ t('importsExports.fields.errorTraceback') }}</span>
+                      <pre class="mt-2 whitespace-pre-wrap rounded-md bg-red-50 p-3 text-xs text-red-900">{{ data.mcpToolRun.errorTraceback }}</pre>
+                    </div>
+                    <StructuredDataSection
+                      :title="t('importsExports.aiImports.sections.payloadContent')"
+                      :value="data.mcpToolRun.payloadContent"
+                      :start-expanded="true"
+                    />
+                    <StructuredDataSection
+                      :title="t('importsExports.aiImports.sections.responseContent')"
+                      :value="data.mcpToolRun.responseContent"
+                      :start-expanded="true"
+                    />
+                  </div>
+                </div>
+              </template>
+
+              <template #brokenRecords>
+                <div class="p-4">
+                  <ImportBrokenRecordsTab :import-process-id="data.mcpToolRun.proxyId || data.mcpToolRun.id" />
+                </div>
+              </template>
+            </Tabs>
+
+            <div class="flex items-center justify-end gap-x-3 border-t border-gray-900/10 px-4 py-4 sm:px-8">
+              <Link :path="{ name: 'importsExports.aiImports.list' }">
+                <Button type="button" class="button rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm btn-dark">
+                  {{ t('shared.button.back') }}
+                </Button>
+              </Link>
+            </div>
+          </Card>
+        </template>
+      </ApolloQuery>
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/imports_exports/ai-imports/ai-imports-list/AIImportsListController.vue
+++ b/src/core/imports_exports/ai-imports/ai-imports-list/AIImportsListController.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import GeneralTemplate from '../../../../shared/templates/GeneralTemplate.vue';
+import { Breadcrumbs } from '../../../../shared/components/molecules/breadcrumbs';
+import { GeneralListing } from '../../../../shared/components/organisms/general-listing';
+import {
+  MCP_TOOL_RUNS_LISTING_QUERY,
+  MCP_TOOL_RUNS_LISTING_QUERY_KEY,
+  aiImportsListingConfigConstructor,
+  aiImportsSearchConfigConstructor,
+} from '../../configs';
+
+const { t } = useI18n();
+const searchConfig = aiImportsSearchConfigConstructor(t);
+const listingConfig = aiImportsListingConfigConstructor(t);
+</script>
+
+<template>
+  <GeneralTemplate>
+    <template #breadcrumbs>
+      <Breadcrumbs :links="[{ path: { name: 'importsExports.aiImports.list' }, name: t('importsExports.aiImports.title') }]" />
+    </template>
+
+    <template #content>
+      <GeneralListing
+        :search-config="searchConfig"
+        :config="listingConfig"
+        :query="MCP_TOOL_RUNS_LISTING_QUERY"
+        :query-key="MCP_TOOL_RUNS_LISTING_QUERY_KEY"
+      />
+    </template>
+  </GeneralTemplate>
+</template>

--- a/src/core/imports_exports/components/ImportBrokenRecordsTab.vue
+++ b/src/core/imports_exports/components/ImportBrokenRecordsTab.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { GeneralListing } from '../../../shared/components/organisms/general-listing';
+import JsonPreviewModal from './JsonPreviewModal.vue';
+import { Button } from '../../../shared/components/atoms/button';
+import { Icon } from '../../../shared/components/atoms/icon';
+import {
+  brokenRecordsListingConfigConstructor,
+  brokenRecordsSearchConfigConstructor,
+  IMPORT_BROKEN_RECORDS_QUERY,
+  IMPORT_BROKEN_RECORDS_QUERY_KEY,
+} from '../configs';
+
+defineProps<{
+  importProcessId: string;
+}>();
+
+const { t } = useI18n();
+const searchConfig = brokenRecordsSearchConfigConstructor(t);
+const listingConfig = brokenRecordsListingConfigConstructor(t);
+
+const selectedRecord = ref<unknown | null>(null);
+const isModalOpen = ref(false);
+
+const openRecord = (record: unknown) => {
+  selectedRecord.value = record;
+  isModalOpen.value = true;
+};
+</script>
+
+<template>
+  <div>
+    <GeneralListing
+      :search-config="searchConfig"
+      :config="listingConfig"
+      :query="IMPORT_BROKEN_RECORDS_QUERY"
+      :query-key="IMPORT_BROKEN_RECORDS_QUERY_KEY"
+      :fixed-filter-variables="{ importProcess: { id: { exact: importProcessId } } }"
+    >
+      <template #additionalButtons="{ item }">
+        <Button type="button" :title="t('shared.button.show')" @click="openRecord(item.node.record)">
+          <Icon name="eye" size="lg" class="text-slate-500" />
+        </Button>
+      </template>
+    </GeneralListing>
+
+    <JsonPreviewModal
+      v-model="isModalOpen"
+      :title="t('importsExports.mappedImports.brokenRecords.modalTitle')"
+      :value="selectedRecord"
+    />
+  </div>
+</template>

--- a/src/core/imports_exports/components/JsonPreviewModal.vue
+++ b/src/core/imports_exports/components/JsonPreviewModal.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Modal } from '../../../shared/components/atoms/modal';
 import { Card } from '../../../shared/components/atoms/card';
 import { SecondaryButton } from '../../../shared/components/atoms/button-secondary';
+import { RecursiveAccordion } from '../../../shared/components/molecules/recursive-accordion';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -13,14 +13,6 @@ const props = defineProps<{
 
 const emit = defineEmits(['update:modelValue']);
 const { t } = useI18n();
-
-const formattedValue = computed(() => {
-  try {
-    return JSON.stringify(props.value ?? {}, null, 2);
-  } catch (_error) {
-    return String(props.value ?? '');
-  }
-});
 </script>
 
 <template>
@@ -36,7 +28,9 @@ const formattedValue = computed(() => {
         </SecondaryButton>
       </div>
 
-      <pre class="mt-4 max-h-[65vh] overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-100">{{ formattedValue }}</pre>
+      <div class="mt-4 max-h-[65vh] overflow-auto rounded-xl bg-slate-50 p-4">
+        <RecursiveAccordion :value="value" :start-expanded="true" />
+      </div>
     </Card>
   </Modal>
 </template>

--- a/src/core/imports_exports/components/StructuredDataSection.vue
+++ b/src/core/imports_exports/components/StructuredDataSection.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { RecursiveAccordion } from '../../../shared/components/molecules/recursive-accordion';
+
+defineProps<{
+  title: string;
+  value: unknown;
+  startExpanded?: boolean;
+}>();
+</script>
+
+<template>
+  <div class="py-3">
+    <span class="block font-medium">{{ title }}</span>
+    <div class="mt-3">
+      <RecursiveAccordion :value="value" :start-expanded="startExpanded" />
+    </div>
+  </div>
+</template>

--- a/src/core/imports_exports/configs.ts
+++ b/src/core/imports_exports/configs.ts
@@ -526,10 +526,10 @@ export const aiImportsListingConfigConstructor = (t: Function): ListingConfig =>
       name: 'tool',
       type: FieldType.Badge,
       badgeMap: getMcpToolBadgeMap(t),
-      accessor: (node) => node.tool || {
+      accessor: (node) => ({
         text: getMcpToolLabel(t, node.tool, node.toolName),
         color: 'indigo',
-      },
+      }),
     },
     { name: 'percentage', type: FieldType.Text, accessor: (node) => `${node.percentage ?? 0}%` },
     { name: 'totalRecords', type: FieldType.Text },

--- a/src/core/imports_exports/configs.ts
+++ b/src/core/imports_exports/configs.ts
@@ -3,6 +3,7 @@ import type { ListingConfig } from '../../shared/components/organisms/general-li
 import type { SearchConfig } from '../../shared/components/organisms/general-search/searchConfig';
 import { companyLanguagesQuery } from '../../shared/api/queries/languages.js';
 import { mappedImportsQuery, exportsQuery, importBrokenRecordsQuery } from '../../shared/api/queries/importsExports.js';
+import { mcpToolRunsQuery } from '../../shared/api/queries/mcpToolRuns.js';
 import {
   deleteExportMutation,
   deleteExportsMutation,
@@ -19,6 +20,22 @@ export const MAPPED_IMPORT_TYPES = [
 ] as const;
 
 export const EXPORT_TYPES = ['json_feed', 'json', 'csv', 'excel'] as const;
+export const MCP_TOOL_TYPES = [
+  'GET_COMPANY_DETAILS',
+  'SEARCH_PRODUCTS',
+  'GET_PRODUCT',
+  'SEARCH_SALES_CHANNELS',
+  'CREATE_PRODUCT',
+  'UPSERT_PRODUCT',
+  'SEARCH_PROPERTIES',
+  'GET_PROPERTY',
+  'SEARCH_PROPERTY_SELECT_VALUES',
+  'GET_PROPERTY_SELECT_VALUE',
+  'CREATE_PROPERTY',
+  'EDIT_PROPERTY',
+  'CREATE_PROPERTY_SELECT_VALUE',
+  'EDIT_PROPERTY_SELECT_VALUE',
+] as const;
 
 export const EXPORT_KINDS = [
   'products',
@@ -38,6 +55,7 @@ export const EXPORT_KINDS = [
 export type MappedImportType = typeof MAPPED_IMPORT_TYPES[number];
 export type ExportType = typeof EXPORT_TYPES[number];
 export type ExportKind = typeof EXPORT_KINDS[number];
+export type McpToolType = typeof MCP_TOOL_TYPES[number];
 
 export const VISIBLE_EXPORT_KINDS: ExportKind[] = [
   'products',
@@ -136,8 +154,23 @@ export const MAPPED_IMPORT_LISTING_QUERY = mappedImportsQuery;
 export const MAPPED_IMPORT_LISTING_QUERY_KEY = 'mappedImports';
 export const EXPORTS_LISTING_QUERY = exportsQuery;
 export const EXPORTS_LISTING_QUERY_KEY = 'exports';
+export const MCP_TOOL_RUNS_LISTING_QUERY = mcpToolRunsQuery;
+export const MCP_TOOL_RUNS_LISTING_QUERY_KEY = 'mcpToolRuns';
 export const IMPORT_BROKEN_RECORDS_QUERY = importBrokenRecordsQuery;
 export const IMPORT_BROKEN_RECORDS_QUERY_KEY = 'importBrokenRecords';
+
+export const humanizeEnumValue = (value?: string | null) => {
+  if (!value) {
+    return '-';
+  }
+
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+};
 
 const statusText = (t: Function, value: string) => {
   const key = `importsExports.statuses.${value}`;
@@ -174,6 +207,19 @@ export const getPercentageColorBadgeMap = (t: Function) => ({
   GREEN: { text: t('importsExports.progressColors.green'), color: 'green' },
 });
 
+export const getMcpToolLabel = (t: Function, tool?: string | null, toolName?: string | null) => {
+  if (tool) {
+    const key = `importsExports.aiImports.tools.${tool}`;
+    const translated = t(key);
+
+    if (translated !== key) {
+      return translated;
+    }
+  }
+
+  return humanizeEnumValue(toolName || tool);
+};
+
 export const getMappedImportTypeOptions = (t: Function) =>
   MAPPED_IMPORT_TYPES.map((value) => ({
     value,
@@ -185,6 +231,21 @@ export const getExportTypeOptions = (t: Function) =>
     value,
     label: t(`importsExports.exports.types.${value}`),
   }));
+
+export const getMcpToolOptions = (t: Function) =>
+  MCP_TOOL_TYPES.map((value) => ({
+    value,
+    label: getMcpToolLabel(t, value, value.toLowerCase()),
+  }));
+
+export const getMcpToolBadgeMap = (t: Function) =>
+  MCP_TOOL_TYPES.reduce((accumulator, value) => {
+    accumulator[value] = {
+      text: getMcpToolLabel(t, value, value.toLowerCase()),
+      color: 'indigo',
+    };
+    return accumulator;
+  }, {} as Record<string, { text: string; color: string }>);
 
 export const getExportKindOptions = (t: Function) =>
   VISIBLE_EXPORT_KINDS.map((value) => ({
@@ -346,6 +407,39 @@ export const exportsSearchConfigConstructor = (t: Function): SearchConfig => ({
   orders: [],
 });
 
+export const aiImportsSearchConfigConstructor = (t: Function): SearchConfig => ({
+  search: true,
+  orderKey: 'sort',
+  filters: [
+    {
+      type: FieldType.Choice,
+      name: 'status',
+      label: t('shared.labels.status'),
+      options: Object.keys(getStatusBadgeMap(t)).filter((value) => value === value.toUpperCase()).map((value) => ({
+        label: statusText(t, value),
+        value,
+      })),
+      labelBy: 'label',
+      valueBy: 'value',
+      filterable: true,
+      multiple: true,
+      removable: true,
+    },
+    {
+      type: FieldType.Choice,
+      name: 'tool',
+      label: t('importsExports.aiImports.fields.tool'),
+      options: getMcpToolOptions(t),
+      labelBy: 'label',
+      valueBy: 'value',
+      filterable: true,
+      multiple: true,
+      removable: true,
+    },
+  ],
+  orders: [],
+});
+
 export const mappedImportsListingConfigConstructor = (t: Function): ListingConfig => ({
   headers: [
     t('shared.labels.name'),
@@ -416,6 +510,39 @@ export const exportsListingConfigConstructor = (t: Function): ListingConfig => (
   bulkDeleteMutation: deleteExportsMutation,
   bulkDeleteSuccessAlert: t('importsExports.exports.alerts.bulkDeleteSuccess'),
   bulkDeleteErrorAlert: t('importsExports.exports.alerts.bulkDeleteError'),
+});
+
+export const aiImportsListingConfigConstructor = (t: Function): ListingConfig => ({
+  headers: [
+    t('shared.labels.name'),
+    t('importsExports.aiImports.fields.tool'),
+    t('importsExports.fields.progressState'),
+    t('importsExports.fields.totalRecords'),
+    t('shared.labels.createdAt'),
+  ],
+  fields: [
+    { name: 'name', type: FieldType.Text },
+    {
+      name: 'tool',
+      type: FieldType.Badge,
+      badgeMap: getMcpToolBadgeMap(t),
+      accessor: (node) => node.tool || {
+        text: getMcpToolLabel(t, node.tool, node.toolName),
+        color: 'indigo',
+      },
+    },
+    { name: 'percentage', type: FieldType.Text, accessor: (node) => `${node.percentage ?? 0}%` },
+    { name: 'totalRecords', type: FieldType.Text },
+    { name: 'createdAt', type: FieldType.Date },
+  ],
+  identifierKey: 'id',
+  addActions: true,
+  addEdit: false,
+  addShow: true,
+  showUrlName: 'importsExports.aiImports.show',
+  addDelete: false,
+  addPagination: true,
+  isMainPage: true,
 });
 
 export const brokenRecordsSearchConfigConstructor = (_t: Function): SearchConfig => ({

--- a/src/core/imports_exports/configs.ts
+++ b/src/core/imports_exports/configs.ts
@@ -516,7 +516,7 @@ export const aiImportsListingConfigConstructor = (t: Function): ListingConfig =>
   headers: [
     t('shared.labels.name'),
     t('importsExports.aiImports.fields.tool'),
-    t('importsExports.fields.progressState'),
+    t('importsExports.aiImports.fields.userFullName'),
     t('importsExports.fields.totalRecords'),
     t('shared.labels.createdAt'),
   ],
@@ -531,7 +531,7 @@ export const aiImportsListingConfigConstructor = (t: Function): ListingConfig =>
         color: 'indigo',
       }),
     },
-    { name: 'percentage', type: FieldType.Text, accessor: (node) => `${node.percentage ?? 0}%` },
+    { name: 'userFullName', type: FieldType.Text, accessor: (node) => node.userFullName || '-' },
     { name: 'totalRecords', type: FieldType.Text },
     { name: 'createdAt', type: FieldType.Date },
   ],

--- a/src/core/imports_exports/mapped-imports/components/MappedImportBrokenRecordsTab.vue
+++ b/src/core/imports_exports/mapped-imports/components/MappedImportBrokenRecordsTab.vue
@@ -1,54 +1,11 @@
 <script setup lang="ts">
-import { ref } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { GeneralListing } from '../../../../shared/components/organisms/general-listing';
-import JsonPreviewModal from '../../components/JsonPreviewModal.vue';
-import { Button } from '../../../../shared/components/atoms/button';
-import { Icon } from '../../../../shared/components/atoms/icon';
-import {
-  brokenRecordsListingConfigConstructor,
-  brokenRecordsSearchConfigConstructor,
-  IMPORT_BROKEN_RECORDS_QUERY,
-  IMPORT_BROKEN_RECORDS_QUERY_KEY,
-} from '../../configs';
+import ImportBrokenRecordsTab from '../../components/ImportBrokenRecordsTab.vue';
 
 defineProps<{
   importProcessId: string;
 }>();
-
-const { t } = useI18n();
-const searchConfig = brokenRecordsSearchConfigConstructor(t);
-const listingConfig = brokenRecordsListingConfigConstructor(t);
-
-const selectedRecord = ref<unknown | null>(null);
-const isModalOpen = ref(false);
-
-const openRecord = (record: unknown) => {
-  selectedRecord.value = record;
-  isModalOpen.value = true;
-};
 </script>
 
 <template>
-  <div>
-    <GeneralListing
-      :search-config="searchConfig"
-      :config="listingConfig"
-      :query="IMPORT_BROKEN_RECORDS_QUERY"
-      :query-key="IMPORT_BROKEN_RECORDS_QUERY_KEY"
-      :fixed-filter-variables="{ importProcess: { id: { exact: importProcessId } } }"
-    >
-      <template #additionalButtons="{ item }">
-        <Button type="button" :title="t('shared.button.show')" @click="openRecord(item.node.record)">
-          <Icon name="eye" size="lg" class="text-slate-500" />
-        </Button>
-      </template>
-    </GeneralListing>
-
-    <JsonPreviewModal
-      v-model="isModalOpen"
-      :title="t('importsExports.mappedImports.brokenRecords.modalTitle')"
-      :value="selectedRecord"
-    />
-  </div>
+  <ImportBrokenRecordsTab :import-process-id="importProcessId" />
 </template>

--- a/src/core/imports_exports/mapped-imports/mapped-import-show/MappedImportShowController.vue
+++ b/src/core/imports_exports/mapped-imports/mapped-import-show/MappedImportShowController.vue
@@ -24,7 +24,7 @@ import { Toast } from '../../../../shared/modules/toast';
 import { getLanguageLabel, getStatusBadgeMap } from '../../configs';
 import { mappedImportSubscription } from '../../../../shared/api/subscriptions/importsExports.js';
 import { deleteMappedImportMutation, resyncMappedImportMutation } from '../../../../shared/api/mutations/importsExports.js';
-import MappedImportBrokenRecordsTab from '../components/MappedImportBrokenRecordsTab.vue';
+import ImportBrokenRecordsTab from '../../components/ImportBrokenRecordsTab.vue';
 
 const { t } = useI18n();
 const route = useRoute();
@@ -215,7 +215,7 @@ onMounted(async () => {
 
               <template #brokenRecords>
                 <div class="p-4">
-                  <MappedImportBrokenRecordsTab :import-process-id="getMappedImportNode(result).proxyId" />
+                  <ImportBrokenRecordsTab :import-process-id="getMappedImportNode(result).proxyId" />
                 </div>
               </template>
             </Tabs>

--- a/src/core/imports_exports/routes.ts
+++ b/src/core/imports_exports/routes.ts
@@ -1,5 +1,17 @@
 export const routes = [
   {
+    path: '/imports_exports/ai-imports',
+    name: 'importsExports.aiImports.list',
+    meta: { title: 'importsExports.aiImports.title' },
+    component: () => import('./ai-imports/ai-imports-list/AIImportsListController.vue'),
+  },
+  {
+    path: '/imports_exports/ai-imports/:id',
+    name: 'importsExports.aiImports.show',
+    meta: { title: 'importsExports.aiImports.show.title' },
+    component: () => import('./ai-imports/ai-import-show/AIImportShowController.vue'),
+  },
+  {
     path: '/imports_exports/mapped-imports',
     name: 'importsExports.mappedImports.list',
     meta: { title: 'importsExports.mappedImports.title' },

--- a/src/core/integrations/integrations/integrations-show/containers/products/configs.ts
+++ b/src/core/integrations/integrations/integrations-show/containers/products/configs.ts
@@ -19,19 +19,21 @@ const getStatusBadgeMap = (t: Function) => ({
   PENDING_CREATION: { text: t('shared.labels.pendingCreation'), color: 'blue' },
   PARTIALLY_LISTED: { text: t('integrations.show.products.statuses.partiallyListed'), color: 'orange' },
   PENDING_APPROVAL: { text: t('integrations.show.products.statuses.pendingApproval'), color: 'yellow' },
-  STATUS_PENDING_EXTERNAL_DOCUMENTS: { text: t('integrations.show.products.statuses.pendingExternalDocuments'), color: 'orange' },
+  PENDING_EXTERNAL_DOCUMENTS: { text: t('integrations.show.products.statuses.pendingExternalDocuments'), color: 'orange' },
   APPROVAL_REJECTED: { text: t('integrations.show.products.statuses.approvalRejected'), color: 'red' },
 });
 
 const getAssignStatus = (node: any) => {
+  const remoteStatus = node.remoteProduct?.status;
+
   if (node.status === 'PENDING_CREATION') {
-    if (node.remoteProduct?.status === 'FAILED') {
+    if (remoteStatus === 'FAILED') {
       return 'FAILED';
     }
-    return node.remoteProduct?.status || 'PENDING_CREATION';
+    return remoteStatus || 'PENDING_CREATION';
   }
-  if (node.remoteProduct?.status) {
-    return node.remoteProduct.status;
+  if (remoteStatus) {
+    return remoteStatus;
   }
   if (node.remoteProduct?.hasErrors) {
     return 'FAILED';
@@ -95,7 +97,7 @@ export const productsSearchConfigConstructor = (t: Function, salesChannelId: str
         { label: t('shared.labels.pendingCreation'), value: 'PENDING_CREATION' },
         { label: t('integrations.show.products.statuses.partiallyListed'), value: 'PARTIALLY_LISTED' },
         { label: t('integrations.show.products.statuses.pendingApproval'), value: 'PENDING_APPROVAL' },
-        { label: t('integrations.show.products.statuses.pendingExternalDocuments'), value: 'STATUS_PENDING_EXTERNAL_DOCUMENTS' },
+        { label: t('integrations.show.products.statuses.pendingExternalDocuments'), value: 'PENDING_EXTERNAL_DOCUMENTS' },
         { label: t('integrations.show.products.statuses.approvalRejected'), value: 'APPROVAL_REJECTED' },
       ],
       removable: true,

--- a/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
+++ b/src/core/products/products/product-show/containers/tabs/websites/containers/assigns-list/WebsitesList.vue
@@ -46,14 +46,16 @@ const modalColsed = () => {
 }
 
 const getAssignStatus = (item: any) => {
+  const remoteStatus = item.remoteProduct?.status;
+
   if (item.status === 'PENDING_CREATION') {
-    if (item.remoteProduct?.status === 'FAILED') {
+    if (remoteStatus === 'FAILED') {
       return 'FAILED';
     }
-    return item.remoteProduct?.status || 'PENDING_CREATION';
+    return remoteStatus || 'PENDING_CREATION';
   }
-  if (item.remoteProduct?.status) {
-    return item.remoteProduct.status;
+  if (remoteStatus) {
+    return remoteStatus;
   }
   if (item.remoteProduct?.hasErrors) {
     return 'FAILED';

--- a/src/core/profile/company/CompanyProfileController.vue
+++ b/src/core/profile/company/CompanyProfileController.vue
@@ -4,7 +4,6 @@ import CompanyProfileTemplate from "./CompanyProfileTemplate.vue";
 import { ShowCompanyProfile } from './containers/show-company-profile';
 import { CompanyProfileEditForm } from "./containers/company-profile-edit-form";
 import { CompanyMembersList } from "./containers/company-members-list";
-import McpApiKeyPanel from "./containers/mcp-api-key-panel/McpApiKeyPanel.vue";
 import { Button } from "../../../shared/components/atoms/button";
 import { ApolloSubscription } from "./../../../shared/components/molecules/apollo-subscription";
 import { meCompanySubscription } from "./../../../shared/api/subscriptions/me.js";
@@ -101,11 +100,6 @@ const getUsers = (result) => {
                                             @update-complete="handleUpdateComplete"/>
                   </div>
               </div>
-              <McpApiKeyPanel
-                class="mt-3"
-                :company-data="getCompany(result)"
-                @refresh-requested="handleRefreshRequested"
-              />
               <div class="panel mt-3">
                 <CompanyMembersList :members="getUsers(result)" :language="getLanguage(result)" @refresh-requested="handleRefreshRequested" />
               </div>

--- a/src/core/profile/company/containers/mcp-api-key-panel/McpApiKeyInfoModal.vue
+++ b/src/core/profile/company/containers/mcp-api-key-panel/McpApiKeyInfoModal.vue
@@ -16,12 +16,12 @@ const { t } = useI18n();
 const activeInfoTab = ref<'claude' | 'exportFeed'>('claude');
 const activeClaudeRequirementTab = ref<'mac' | 'windows'>('mac');
 const infoTabs = computed<{ name: 'claude' | 'exportFeed'; label: string }[]>(() => [
-  { name: 'claude', label: t('companyProfile.mcpApiKey.info.tabs.claude') },
-  { name: 'exportFeed', label: t('companyProfile.mcpApiKey.info.tabs.exportFeed') },
+  { name: 'claude', label: t('profile.mcpApiKey.info.tabs.claude') },
+  { name: 'exportFeed', label: t('profile.mcpApiKey.info.tabs.exportFeed') },
 ]);
 const claudeRequirementTabs = computed<{ name: 'mac' | 'windows'; label: string }[]>(() => [
-  { name: 'mac', label: t('companyProfile.mcpApiKey.info.claude.requirements.tabs.mac') },
-  { name: 'windows', label: t('companyProfile.mcpApiKey.info.claude.requirements.tabs.windows') },
+  { name: 'mac', label: t('profile.mcpApiKey.info.claude.requirements.tabs.mac') },
+  { name: 'windows', label: t('profile.mcpApiKey.info.claude.requirements.tabs.windows') },
 ]);
 const codeBlockClass = 'mt-3 max-h-80 overflow-auto rounded-2xl border border-slate-200 bg-slate-950 p-4 text-xs leading-5 text-slate-100 dark:border-slate-700';
 const appOrigin = computed(() => (typeof window !== 'undefined' ? window.location.origin : 'https://hostname'));
@@ -59,21 +59,21 @@ const nodeVersionSnippet = `node --version
 npm --version
 npx --version`;
 const macRequirementSteps = computed(() => [
-  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.openTerminal'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.runArchitectureCommand'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.chooseArchitecture'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.downloadInstaller'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.runInstaller'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.verifyAgain'),
+  t('profile.mcpApiKey.info.claude.requirements.mac.steps.openTerminal'),
+  t('profile.mcpApiKey.info.claude.requirements.mac.steps.runArchitectureCommand'),
+  t('profile.mcpApiKey.info.claude.requirements.mac.steps.chooseArchitecture'),
+  t('profile.mcpApiKey.info.claude.requirements.mac.steps.downloadInstaller'),
+  t('profile.mcpApiKey.info.claude.requirements.mac.steps.runInstaller'),
+  t('profile.mcpApiKey.info.claude.requirements.mac.steps.verifyAgain'),
 ]);
 const windowsRequirementSteps = computed(() => [
-  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.openCommandPrompt'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.openSettings'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.openAbout'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.chooseInstaller'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.downloadInstaller'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.runInstaller'),
-  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.verifyAgain'),
+  t('profile.mcpApiKey.info.claude.requirements.windows.steps.openCommandPrompt'),
+  t('profile.mcpApiKey.info.claude.requirements.windows.steps.openSettings'),
+  t('profile.mcpApiKey.info.claude.requirements.windows.steps.openAbout'),
+  t('profile.mcpApiKey.info.claude.requirements.windows.steps.chooseInstaller'),
+  t('profile.mcpApiKey.info.claude.requirements.windows.steps.downloadInstaller'),
+  t('profile.mcpApiKey.info.claude.requirements.windows.steps.runInstaller'),
+  t('profile.mcpApiKey.info.claude.requirements.windows.steps.verifyAgain'),
 ]);
 const curlExportFeedSnippet = computed(() => `curl \\
   -H "Authorization: ${bearerToken.value}" \\
@@ -124,13 +124,13 @@ const close = () => emit('close');
   <div class="w-[min(62rem,calc(100vw-2rem))] rounded-3xl bg-white p-6 shadow-xl dark:bg-slate-900 sm:p-8">
     <div class="min-w-0">
       <p class="text-sm font-semibold uppercase text-primary">
-        {{ t('companyProfile.mcpApiKey.info.eyebrow') }}
+        {{ t('profile.mcpApiKey.info.eyebrow') }}
       </p>
       <h2 class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white-light">
-        {{ t('companyProfile.mcpApiKey.info.title') }}
+        {{ t('profile.mcpApiKey.info.title') }}
       </h2>
       <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
-        {{ t('companyProfile.mcpApiKey.info.description') }}
+        {{ t('profile.mcpApiKey.info.description') }}
       </p>
     </div>
 
@@ -153,20 +153,20 @@ const close = () => emit('close');
       <div v-if="activeInfoTab === 'claude'" class="space-y-5">
         <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
           <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-            {{ t('companyProfile.mcpApiKey.info.claude.requirements.title') }}
+            {{ t('profile.mcpApiKey.info.claude.requirements.title') }}
           </h3>
           <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
-            {{ t('companyProfile.mcpApiKey.info.claude.requirements.description') }}
+            {{ t('profile.mcpApiKey.info.claude.requirements.description') }}
           </p>
           <h4 class="mt-5 text-sm font-semibold text-slate-900 dark:text-white-light">
-            {{ t('companyProfile.mcpApiKey.info.claude.requirements.checkFirstTitle') }}
+            {{ t('profile.mcpApiKey.info.claude.requirements.checkFirstTitle') }}
           </h4>
           <p class="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-300">
-            {{ t('companyProfile.mcpApiKey.info.claude.requirements.checkFirstDescription') }}
+            {{ t('profile.mcpApiKey.info.claude.requirements.checkFirstDescription') }}
           </p>
           <pre :class="codeBlockClass"><code>{{ nodeVersionSnippet }}</code></pre>
           <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
-            {{ t('companyProfile.mcpApiKey.info.claude.requirements.skipIfVersions') }}
+            {{ t('profile.mcpApiKey.info.claude.requirements.skipIfVersions') }}
           </p>
 
           <div class="mt-5 border-b border-slate-200 dark:border-slate-700">
@@ -186,7 +186,7 @@ const close = () => emit('close');
 
           <div v-if="activeClaudeRequirementTab === 'mac'" class="mt-5">
             <h4 class="text-base font-semibold text-slate-900 dark:text-white-light">
-              {{ t('companyProfile.mcpApiKey.info.claude.requirements.mac.title') }}
+              {{ t('profile.mcpApiKey.info.claude.requirements.mac.title') }}
             </h4>
             <ol class="mt-3 list-decimal space-y-3 pl-5 text-sm leading-6 text-slate-500 dark:text-slate-300">
               <li
@@ -198,11 +198,11 @@ const close = () => emit('close');
             </ol>
             <pre :class="codeBlockClass"><code>{{ macArchitectureSnippet }}</code></pre>
             <ul class="mt-4 space-y-2 text-sm leading-6 text-slate-500 dark:text-slate-300">
-              <li>{{ t('companyProfile.mcpApiKey.info.claude.requirements.mac.appleSilicon') }}</li>
-              <li>{{ t('companyProfile.mcpApiKey.info.claude.requirements.mac.intel') }}</li>
+              <li>{{ t('profile.mcpApiKey.info.claude.requirements.mac.appleSilicon') }}</li>
+              <li>{{ t('profile.mcpApiKey.info.claude.requirements.mac.intel') }}</li>
             </ul>
             <p class="mt-4 text-sm leading-6 text-slate-500 dark:text-slate-300">
-              {{ t('companyProfile.mcpApiKey.info.claude.requirements.nodeDownloadLabel') }}
+              {{ t('profile.mcpApiKey.info.claude.requirements.nodeDownloadLabel') }}
               <a
                 class="font-semibold text-primary underline-offset-4 hover:underline"
                 href="https://nodejs.org/en/download"
@@ -217,7 +217,7 @@ const close = () => emit('close');
 
           <div v-else class="mt-5">
             <h4 class="text-base font-semibold text-slate-900 dark:text-white-light">
-              {{ t('companyProfile.mcpApiKey.info.claude.requirements.windows.title') }}
+              {{ t('profile.mcpApiKey.info.claude.requirements.windows.title') }}
             </h4>
             <ol class="mt-3 list-decimal space-y-3 pl-5 text-sm leading-6 text-slate-500 dark:text-slate-300">
               <li
@@ -228,7 +228,7 @@ const close = () => emit('close');
               </li>
             </ol>
             <p class="mt-4 text-sm leading-6 text-slate-500 dark:text-slate-300">
-              {{ t('companyProfile.mcpApiKey.info.claude.requirements.nodeDownloadLabel') }}
+              {{ t('profile.mcpApiKey.info.claude.requirements.nodeDownloadLabel') }}
               <a
                 class="font-semibold text-primary underline-offset-4 hover:underline"
                 href="https://nodejs.org/en/download"
@@ -244,20 +244,20 @@ const close = () => emit('close');
 
         <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
           <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-            {{ t('companyProfile.mcpApiKey.info.claude.title') }}
+            {{ t('profile.mcpApiKey.info.claude.title') }}
           </h3>
           <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
-            {{ t('companyProfile.mcpApiKey.info.claude.instructions') }}
+            {{ t('profile.mcpApiKey.info.claude.instructions') }}
           </p>
           <pre :class="codeBlockClass"><code>{{ claudeServerSnippet }}</code></pre>
         </section>
 
         <section class="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
           <h3 class="text-lg font-semibold">
-            {{ t('companyProfile.mcpApiKey.info.claude.fullExampleTitle') }}
+            {{ t('profile.mcpApiKey.info.claude.fullExampleTitle') }}
           </h3>
           <p class="mt-3 text-sm leading-6">
-            {{ t('companyProfile.mcpApiKey.info.claude.fullExampleDisclaimer') }}
+            {{ t('profile.mcpApiKey.info.claude.fullExampleDisclaimer') }}
           </p>
           <pre :class="codeBlockClass"><code>{{ claudeFullConfigSnippet }}</code></pre>
         </section>
@@ -266,30 +266,30 @@ const close = () => emit('close');
       <div v-else class="space-y-5">
         <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
           <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-            {{ t('companyProfile.mcpApiKey.info.exportFeed.title') }}
+            {{ t('profile.mcpApiKey.info.exportFeed.title') }}
           </h3>
           <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
-            {{ t('companyProfile.mcpApiKey.info.exportFeed.description') }}
+            {{ t('profile.mcpApiKey.info.exportFeed.description') }}
           </p>
         </section>
 
         <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
           <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-            {{ t('companyProfile.mcpApiKey.info.exportFeed.curlTitle') }}
+            {{ t('profile.mcpApiKey.info.exportFeed.curlTitle') }}
           </h3>
           <pre :class="codeBlockClass"><code>{{ curlExportFeedSnippet }}</code></pre>
         </section>
 
         <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
           <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-            {{ t('companyProfile.mcpApiKey.info.exportFeed.pythonTitle') }}
+            {{ t('profile.mcpApiKey.info.exportFeed.pythonTitle') }}
           </h3>
           <pre :class="codeBlockClass"><code>{{ pythonExportFeedSnippet }}</code></pre>
         </section>
 
         <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
           <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-            {{ t('companyProfile.mcpApiKey.info.exportFeed.phpTitle') }}
+            {{ t('profile.mcpApiKey.info.exportFeed.phpTitle') }}
           </h3>
           <pre :class="codeBlockClass"><code>{{ phpExportFeedSnippet }}</code></pre>
         </section>

--- a/src/core/profile/company/containers/mcp-api-key-panel/McpApiKeyInfoModal.vue
+++ b/src/core/profile/company/containers/mcp-api-key-panel/McpApiKeyInfoModal.vue
@@ -1,0 +1,305 @@
+<script lang="ts" setup>
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Button } from '../../../../../shared/components/atoms/button';
+
+const props = defineProps<{
+  apiKey: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+}>();
+
+const { t } = useI18n();
+
+const activeInfoTab = ref<'claude' | 'exportFeed'>('claude');
+const activeClaudeRequirementTab = ref<'mac' | 'windows'>('mac');
+const infoTabs = computed<{ name: 'claude' | 'exportFeed'; label: string }[]>(() => [
+  { name: 'claude', label: t('companyProfile.mcpApiKey.info.tabs.claude') },
+  { name: 'exportFeed', label: t('companyProfile.mcpApiKey.info.tabs.exportFeed') },
+]);
+const claudeRequirementTabs = computed<{ name: 'mac' | 'windows'; label: string }[]>(() => [
+  { name: 'mac', label: t('companyProfile.mcpApiKey.info.claude.requirements.tabs.mac') },
+  { name: 'windows', label: t('companyProfile.mcpApiKey.info.claude.requirements.tabs.windows') },
+]);
+const codeBlockClass = 'mt-3 max-h-80 overflow-auto rounded-2xl border border-slate-200 bg-slate-950 p-4 text-xs leading-5 text-slate-100 dark:border-slate-700';
+const appOrigin = computed(() => (typeof window !== 'undefined' ? window.location.origin : 'https://hostname'));
+const exportFeedUrl = 'https://hostname/path/to/feed/feed_key';
+const bearerToken = computed(() => `Bearer ${props.apiKey}`);
+const mcpServerConfig = computed(() => ({
+  command: 'npx',
+  args: [
+    'mcp-remote',
+    `${appOrigin.value}/mcp/`,
+    '--header',
+    'Authorization:${MCP_AUTH_TOKEN}',
+  ],
+  env: {
+    MCP_AUTH_TOKEN: bearerToken.value,
+  },
+}));
+const claudeServerSnippet = computed(() => JSON.stringify(mcpServerConfig.value, null, 2)
+  .split('\n')
+  .map((line, index) => (index === 0 ? `"onesila": ${line}` : line))
+  .join('\n'));
+const claudeFullConfigSnippet = computed(() => JSON.stringify({
+  mcpServers: {
+    onesila: mcpServerConfig.value,
+  },
+  preferences: {
+    coworkScheduledTasksEnabled: true,
+    ccdScheduledTasksEnabled: true,
+    sidebarMode: 'chat',
+    coworkWebSearchEnabled: true,
+  },
+}, null, 2));
+const macArchitectureSnippet = `uname -m`;
+const nodeVersionSnippet = `node --version
+npm --version
+npx --version`;
+const macRequirementSteps = computed(() => [
+  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.openTerminal'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.runArchitectureCommand'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.chooseArchitecture'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.downloadInstaller'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.runInstaller'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.mac.steps.verifyAgain'),
+]);
+const windowsRequirementSteps = computed(() => [
+  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.openCommandPrompt'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.openSettings'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.openAbout'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.chooseInstaller'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.downloadInstaller'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.runInstaller'),
+  t('companyProfile.mcpApiKey.info.claude.requirements.windows.steps.verifyAgain'),
+]);
+const curlExportFeedSnippet = computed(() => `curl \\
+  -H "Authorization: ${bearerToken.value}" \\
+  "${exportFeedUrl}"`);
+const pythonExportFeedSnippet = computed(() => `import requests
+
+feed_url = "${exportFeedUrl}"
+api_token = "${props.apiKey}"
+
+response = requests.get(
+    feed_url,
+    headers={"Authorization": f"Bearer {api_token}"},
+    timeout=30,
+)
+response.raise_for_status()
+
+data = response.json()
+print(data)`);
+const phpExportFeedSnippet = computed(() => `<?php
+
+$feedUrl = '${exportFeedUrl}';
+$apiToken = '${props.apiKey}';
+
+$ch = curl_init($feedUrl);
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => [
+        'Authorization: Bearer ' . $apiToken,
+    ],
+]);
+
+$response = curl_exec($ch);
+$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+if ($response === false || $statusCode >= 400) {
+    throw new RuntimeException(curl_error($ch) ?: 'Export feed request failed.');
+}
+
+curl_close($ch);
+
+$data = json_decode($response, true);
+print_r($data);`);
+
+const close = () => emit('close');
+</script>
+
+<template>
+  <div class="w-[min(62rem,calc(100vw-2rem))] rounded-3xl bg-white p-6 shadow-xl dark:bg-slate-900 sm:p-8">
+    <div class="min-w-0">
+      <p class="text-sm font-semibold uppercase text-primary">
+        {{ t('companyProfile.mcpApiKey.info.eyebrow') }}
+      </p>
+      <h2 class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white-light">
+        {{ t('companyProfile.mcpApiKey.info.title') }}
+      </h2>
+      <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
+        {{ t('companyProfile.mcpApiKey.info.description') }}
+      </p>
+    </div>
+
+    <div class="mt-6 border-b border-slate-200 dark:border-slate-700">
+      <div class="flex gap-2 overflow-x-auto">
+        <button
+          v-for="tab in infoTabs"
+          :key="tab.name"
+          type="button"
+          class="border-b-2 px-4 py-3 text-sm font-semibold transition"
+          :class="activeInfoTab === tab.name ? 'border-primary text-primary' : 'border-transparent text-slate-500 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white-light'"
+          @click="activeInfoTab = tab.name"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+    </div>
+
+    <div class="mt-6 max-h-[65vh] overflow-y-auto pr-1">
+      <div v-if="activeInfoTab === 'claude'" class="space-y-5">
+        <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
+            {{ t('companyProfile.mcpApiKey.info.claude.requirements.title') }}
+          </h3>
+          <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
+            {{ t('companyProfile.mcpApiKey.info.claude.requirements.description') }}
+          </p>
+          <h4 class="mt-5 text-sm font-semibold text-slate-900 dark:text-white-light">
+            {{ t('companyProfile.mcpApiKey.info.claude.requirements.checkFirstTitle') }}
+          </h4>
+          <p class="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-300">
+            {{ t('companyProfile.mcpApiKey.info.claude.requirements.checkFirstDescription') }}
+          </p>
+          <pre :class="codeBlockClass"><code>{{ nodeVersionSnippet }}</code></pre>
+          <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
+            {{ t('companyProfile.mcpApiKey.info.claude.requirements.skipIfVersions') }}
+          </p>
+
+          <div class="mt-5 border-b border-slate-200 dark:border-slate-700">
+            <div class="flex gap-2 overflow-x-auto">
+              <button
+                v-for="tab in claudeRequirementTabs"
+                :key="tab.name"
+                type="button"
+                class="border-b-2 px-4 py-3 text-sm font-semibold transition"
+                :class="activeClaudeRequirementTab === tab.name ? 'border-primary text-primary' : 'border-transparent text-slate-500 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white-light'"
+                @click="activeClaudeRequirementTab = tab.name"
+              >
+                {{ tab.label }}
+              </button>
+            </div>
+          </div>
+
+          <div v-if="activeClaudeRequirementTab === 'mac'" class="mt-5">
+            <h4 class="text-base font-semibold text-slate-900 dark:text-white-light">
+              {{ t('companyProfile.mcpApiKey.info.claude.requirements.mac.title') }}
+            </h4>
+            <ol class="mt-3 list-decimal space-y-3 pl-5 text-sm leading-6 text-slate-500 dark:text-slate-300">
+              <li
+                v-for="(step, index) in macRequirementSteps"
+                :key="index"
+              >
+                {{ step }}
+              </li>
+            </ol>
+            <pre :class="codeBlockClass"><code>{{ macArchitectureSnippet }}</code></pre>
+            <ul class="mt-4 space-y-2 text-sm leading-6 text-slate-500 dark:text-slate-300">
+              <li>{{ t('companyProfile.mcpApiKey.info.claude.requirements.mac.appleSilicon') }}</li>
+              <li>{{ t('companyProfile.mcpApiKey.info.claude.requirements.mac.intel') }}</li>
+            </ul>
+            <p class="mt-4 text-sm leading-6 text-slate-500 dark:text-slate-300">
+              {{ t('companyProfile.mcpApiKey.info.claude.requirements.nodeDownloadLabel') }}
+              <a
+                class="font-semibold text-primary underline-offset-4 hover:underline"
+                href="https://nodejs.org/en/download"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                https://nodejs.org/en/download
+              </a>
+            </p>
+            <pre :class="codeBlockClass"><code>{{ nodeVersionSnippet }}</code></pre>
+          </div>
+
+          <div v-else class="mt-5">
+            <h4 class="text-base font-semibold text-slate-900 dark:text-white-light">
+              {{ t('companyProfile.mcpApiKey.info.claude.requirements.windows.title') }}
+            </h4>
+            <ol class="mt-3 list-decimal space-y-3 pl-5 text-sm leading-6 text-slate-500 dark:text-slate-300">
+              <li
+                v-for="(step, index) in windowsRequirementSteps"
+                :key="index"
+              >
+                {{ step }}
+              </li>
+            </ol>
+            <p class="mt-4 text-sm leading-6 text-slate-500 dark:text-slate-300">
+              {{ t('companyProfile.mcpApiKey.info.claude.requirements.nodeDownloadLabel') }}
+              <a
+                class="font-semibold text-primary underline-offset-4 hover:underline"
+                href="https://nodejs.org/en/download"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                https://nodejs.org/en/download
+              </a>
+            </p>
+            <pre :class="codeBlockClass"><code>{{ nodeVersionSnippet }}</code></pre>
+          </div>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
+            {{ t('companyProfile.mcpApiKey.info.claude.title') }}
+          </h3>
+          <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
+            {{ t('companyProfile.mcpApiKey.info.claude.instructions') }}
+          </p>
+          <pre :class="codeBlockClass"><code>{{ claudeServerSnippet }}</code></pre>
+        </section>
+
+        <section class="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+          <h3 class="text-lg font-semibold">
+            {{ t('companyProfile.mcpApiKey.info.claude.fullExampleTitle') }}
+          </h3>
+          <p class="mt-3 text-sm leading-6">
+            {{ t('companyProfile.mcpApiKey.info.claude.fullExampleDisclaimer') }}
+          </p>
+          <pre :class="codeBlockClass"><code>{{ claudeFullConfigSnippet }}</code></pre>
+        </section>
+      </div>
+
+      <div v-else class="space-y-5">
+        <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
+            {{ t('companyProfile.mcpApiKey.info.exportFeed.title') }}
+          </h3>
+          <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
+            {{ t('companyProfile.mcpApiKey.info.exportFeed.description') }}
+          </p>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
+            {{ t('companyProfile.mcpApiKey.info.exportFeed.curlTitle') }}
+          </h3>
+          <pre :class="codeBlockClass"><code>{{ curlExportFeedSnippet }}</code></pre>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
+            {{ t('companyProfile.mcpApiKey.info.exportFeed.pythonTitle') }}
+          </h3>
+          <pre :class="codeBlockClass"><code>{{ pythonExportFeedSnippet }}</code></pre>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
+          <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
+            {{ t('companyProfile.mcpApiKey.info.exportFeed.phpTitle') }}
+          </h3>
+          <pre :class="codeBlockClass"><code>{{ phpExportFeedSnippet }}</code></pre>
+        </section>
+      </div>
+    </div>
+
+    <div class="mt-8 flex justify-end">
+      <Button class="btn btn-outline-dark" @click="close">
+        {{ t('shared.button.cancel') }}
+      </Button>
+    </div>
+  </div>
+</template>

--- a/src/core/profile/company/containers/mcp-api-key-panel/McpApiKeyPanel.vue
+++ b/src/core/profile/company/containers/mcp-api-key-panel/McpApiKeyPanel.vue
@@ -2,7 +2,7 @@
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import apolloClient from '../../../../../../apollo-client';
-import { MeCompanyData } from '../../meCompanyData';
+import { MeData } from '../../../user/meData';
 import { Icon } from '../../../../../shared/components/atoms/icon';
 import { TextInput } from '../../../../../shared/components/atoms/input-text';
 import { Button } from '../../../../../shared/components/atoms/button';
@@ -24,7 +24,7 @@ interface McpApiKeyMutationResponse {
   isActive: boolean;
 }
 
-const props = defineProps<{ companyData: MeCompanyData }>();
+const props = defineProps<{ meData: MeData }>();
 
 const emit = defineEmits<{
   (e: 'refreshRequested'): void;
@@ -35,10 +35,10 @@ const { t } = useI18n();
 const isSubmitting = ref(false);
 const showInfoModal = ref(false);
 const rawKey = ref<string | null>(null);
-const localApiKey = ref(props.companyData.mcpApiKey ? { ...props.companyData.mcpApiKey } : null);
+const localApiKey = ref(props.meData.mcpApiKey ? { ...props.meData.mcpApiKey } : null);
 
 watch(
-  () => props.companyData.mcpApiKey,
+  () => props.meData.mcpApiKey,
   (nextValue) => {
     localApiKey.value = nextValue ? { ...nextValue } : null;
   },
@@ -51,8 +51,8 @@ const hasRawKey = computed(() => Boolean(rawKey.value));
 const isActive = computed(() => Boolean(localApiKey.value?.isActive));
 const keyStatusLabel = computed(() => (
   isActive.value
-    ? t('companyProfile.mcpApiKey.status.active')
-    : t('companyProfile.mcpApiKey.status.inactive')
+    ? t('profile.mcpApiKey.status.active')
+    : t('profile.mcpApiKey.status.inactive')
 ));
 const neutralActionClass = 'inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-white-light dark:hover:bg-slate-800';
 const primaryActionClass = 'inline-flex items-center justify-center rounded-2xl border border-slate-900 bg-slate-900 px-3 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200';
@@ -73,15 +73,15 @@ const syncLocalState = (response?: McpApiKeyMutationResponse | null) => {
 
 const copyKey = async () => {
   if (!rawKey.value) {
-    Toast.error(t('companyProfile.mcpApiKey.messages.copyUnavailable'));
+    Toast.error(t('profile.mcpApiKey.messages.copyUnavailable'));
     return;
   }
 
   try {
     await navigator.clipboard.writeText(rawKey.value);
-    Toast.success(t('companyProfile.mcpApiKey.messages.copySuccess'));
+    Toast.success(t('profile.mcpApiKey.messages.copySuccess'));
   } catch {
-    Toast.error(t('companyProfile.mcpApiKey.messages.copyError'));
+    Toast.error(t('profile.mcpApiKey.messages.copyError'));
   }
 };
 
@@ -116,17 +116,17 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
           <div class="max-w-2xl">
             <div class="flex flex-wrap items-center gap-3">
               <h5 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-                {{ t('companyProfile.mcpApiKey.title') }}
+                {{ t('profile.mcpApiKey.title') }}
               </h5>
               <span
                 class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold"
                 :class="isActive ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300' : 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'"
               >
-                {{ hasKey ? keyStatusLabel : t('companyProfile.mcpApiKey.status.notCreated') }}
+                {{ hasKey ? keyStatusLabel : t('profile.mcpApiKey.status.notCreated') }}
               </span>
             </div>
             <p class="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-300">
-              {{ t('companyProfile.mcpApiKey.description') }}
+              {{ t('profile.mcpApiKey.description') }}
             </p>
           </div>
         </div>
@@ -138,7 +138,7 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
           <span class="mr-2">
             <Icon name="info-circle" class="h-4 w-4" />
           </span>
-          {{ t('companyProfile.mcpApiKey.actions.whatIsThisUsedFor') }}
+          {{ t('profile.mcpApiKey.actions.whatIsThisUsedFor') }}
         </Button>
       </div>
     </div>
@@ -150,14 +150,14 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
             <div>
               <div class="flex items-center gap-2">
                 <p class="text-sm font-semibold text-slate-900 dark:text-white-light">
-                  {{ t('companyProfile.mcpApiKey.labels.apiKey') }}
+                  {{ t('profile.mcpApiKey.labels.apiKey') }}
                 </p>
                 <span class="text-xs font-medium text-slate-400">
                   {{ keyStatusLabel }}
                 </span>
               </div>
               <p class="mt-1 text-sm text-slate-500 dark:text-slate-300">
-                {{ hasRawKey ? t('companyProfile.mcpApiKey.help.rawKeyAvailable') : t('companyProfile.mcpApiKey.help.rawKeyUnavailable') }}
+                {{ hasRawKey ? t('profile.mcpApiKey.help.rawKeyAvailable') : t('profile.mcpApiKey.help.rawKeyUnavailable') }}
               </p>
               <div class="mt-3">
                 <TextInput
@@ -165,7 +165,7 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
                   :secret="hasRawKey"
                   disabled
                   class="w-full"
-                  :placeholder="t('companyProfile.mcpApiKey.placeholders.key')"
+                  :placeholder="t('profile.mcpApiKey.placeholders.key')"
                 />
               </div>
             </div>
@@ -179,16 +179,16 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
                 <span class="mr-2">
                   <Icon name="clipboard" class="h-4 w-4" />
                 </span>
-                {{ t('companyProfile.mcpApiKey.actions.copy') }}
+                {{ t('profile.mcpApiKey.actions.copy') }}
               </Button>
 
               <Button
                 :loading="isSubmitting"
                 :disabled="isSubmitting"
                 :custom-class="neutralActionClass"
-                @click="runMutation(regenerateMcpApiKeyMutation, 'regenerateMcpApiKey', t('companyProfile.mcpApiKey.messages.regenerateSuccess'))"
+                @click="runMutation(regenerateMcpApiKeyMutation, 'regenerateMcpApiKey', t('profile.mcpApiKey.messages.regenerateSuccess'))"
               >
-                {{ t('companyProfile.mcpApiKey.actions.regenerate') }}
+                {{ t('profile.mcpApiKey.actions.regenerate') }}
               </Button>
 
               <Button
@@ -196,9 +196,9 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
                 :loading="isSubmitting"
                 :disabled="isSubmitting"
                 :custom-class="primaryActionClass"
-                @click="runMutation(activateMcpApiKeyMutation, 'activateMcpApiKey', t('companyProfile.mcpApiKey.messages.activateSuccess'))"
+                @click="runMutation(activateMcpApiKeyMutation, 'activateMcpApiKey', t('profile.mcpApiKey.messages.activateSuccess'))"
               >
-                {{ t('companyProfile.mcpApiKey.actions.activate') }}
+                {{ t('profile.mcpApiKey.actions.activate') }}
               </Button>
 
               <Button
@@ -206,16 +206,16 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
                 :loading="isSubmitting"
                 :disabled="isSubmitting"
                 :custom-class="dangerActionClass"
-                @click="runMutation(deactivateMcpApiKeyMutation, 'deactivateMcpApiKey', t('companyProfile.mcpApiKey.messages.deactivateSuccess'))"
+                @click="runMutation(deactivateMcpApiKeyMutation, 'deactivateMcpApiKey', t('profile.mcpApiKey.messages.deactivateSuccess'))"
               >
-                {{ t('companyProfile.mcpApiKey.actions.deactivate') }}
+                {{ t('profile.mcpApiKey.actions.deactivate') }}
               </Button>
             </div>
           </div>
         </div>
 
         <div v-if="hasRawKey" class="rounded-2xl border border-emerald-200 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200">
-          {{ t('companyProfile.mcpApiKey.help.copyNow') }}
+          {{ t('profile.mcpApiKey.help.copyNow') }}
         </div>
       </template>
 
@@ -224,10 +224,10 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
           <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div class="max-w-2xl">
               <p class="text-sm font-semibold text-slate-900 dark:text-white-light">
-                {{ t('companyProfile.mcpApiKey.empty.title') }}
+                {{ t('profile.mcpApiKey.empty.title') }}
               </p>
               <p class="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-300">
-                {{ t('companyProfile.mcpApiKey.empty.description') }}
+                {{ t('profile.mcpApiKey.empty.description') }}
               </p>
             </div>
 
@@ -235,9 +235,9 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
               :loading="isSubmitting"
               :disabled="isSubmitting"
               :custom-class="primaryActionClass"
-              @click="runMutation(createMcpApiKeyMutation, 'createMcpApiKey', t('companyProfile.mcpApiKey.messages.createSuccess'))"
+              @click="runMutation(createMcpApiKeyMutation, 'createMcpApiKey', t('profile.mcpApiKey.messages.createSuccess'))"
             >
-              {{ t('companyProfile.mcpApiKey.actions.create') }}
+              {{ t('profile.mcpApiKey.actions.create') }}
             </Button>
           </div>
         </div>

--- a/src/core/profile/company/containers/mcp-api-key-panel/McpApiKeyPanel.vue
+++ b/src/core/profile/company/containers/mcp-api-key-panel/McpApiKeyPanel.vue
@@ -9,6 +9,7 @@ import { Button } from '../../../../../shared/components/atoms/button';
 import { Modal } from '../../../../../shared/components/atoms/modal';
 import { Toast } from '../../../../../shared/modules/toast';
 import { processGraphQLErrors } from '../../../../../shared/utils';
+import McpApiKeyInfoModal from './McpApiKeyInfoModal.vue';
 import {
   activateMcpApiKeyMutation,
   createMcpApiKeyMutation,
@@ -33,7 +34,6 @@ const { t } = useI18n();
 
 const isSubmitting = ref(false);
 const showInfoModal = ref(false);
-const activeInfoTab = ref<'claude' | 'exportFeed'>('claude');
 const rawKey = ref<string | null>(null);
 const localApiKey = ref(props.companyData.mcpApiKey ? { ...props.companyData.mcpApiKey } : null);
 
@@ -54,82 +54,9 @@ const keyStatusLabel = computed(() => (
     ? t('companyProfile.mcpApiKey.status.active')
     : t('companyProfile.mcpApiKey.status.inactive')
 ));
-const infoTabs = computed<{ name: 'claude' | 'exportFeed'; label: string }[]>(() => [
-  { name: 'claude', label: t('companyProfile.mcpApiKey.info.tabs.claude') },
-  { name: 'exportFeed', label: t('companyProfile.mcpApiKey.info.tabs.exportFeed') },
-]);
 const neutralActionClass = 'inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-white-light dark:hover:bg-slate-800';
 const primaryActionClass = 'inline-flex items-center justify-center rounded-2xl border border-slate-900 bg-slate-900 px-3 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200';
 const dangerActionClass = 'inline-flex items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-semibold text-rose-700 shadow-sm transition hover:border-rose-300 hover:bg-rose-100 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200 dark:hover:bg-rose-500/20';
-const codeBlockClass = 'mt-3 max-h-80 overflow-auto rounded-2xl border border-slate-200 bg-slate-950 p-4 text-xs leading-5 text-slate-100 dark:border-slate-700';
-const appOrigin = computed(() => (typeof window !== 'undefined' ? window.location.origin : 'https://hostname'));
-const sampleApiToken = computed(() => rawKey.value || 'YOUR_API_TOKEN');
-const exportFeedUrl = 'https://hostname/path/to/feed/feed_key';
-const mcpServerConfig = computed(() => ({
-  command: 'npx',
-  args: [
-    'mcp-remote',
-    `${appOrigin.value}/mcp/`,
-    '--header',
-    'Authorization:${MCP_AUTH_TOKEN}',
-  ],
-  env: {
-    MCP_AUTH_TOKEN: `Bearer ${sampleApiToken.value}`,
-  },
-}));
-const claudeServerSnippet = computed(() => JSON.stringify(mcpServerConfig.value, null, 2)
-  .split('\n')
-  .map((line, index) => (index === 0 ? `"onesila": ${line}` : line))
-  .join('\n'));
-const claudeFullConfigSnippet = computed(() => JSON.stringify({
-  mcpServers: {
-    onesila: mcpServerConfig.value,
-  },
-  preferences: {
-    coworkScheduledTasksEnabled: true,
-    ccdScheduledTasksEnabled: true,
-    sidebarMode: 'chat',
-    coworkWebSearchEnabled: true,
-  },
-}, null, 2));
-const pythonExportFeedSnippet = computed(() => `import requests
-
-feed_url = "${exportFeedUrl}"
-api_token = "${sampleApiToken.value}"
-
-response = requests.get(
-    feed_url,
-    headers={"Authorization": f"Bearer {api_token}"},
-    timeout=30,
-)
-response.raise_for_status()
-
-data = response.json()
-print(data)`);
-const phpExportFeedSnippet = computed(() => `<?php
-
-$feedUrl = '${exportFeedUrl}';
-$apiToken = '${sampleApiToken.value}';
-
-$ch = curl_init($feedUrl);
-curl_setopt_array($ch, [
-    CURLOPT_RETURNTRANSFER => true,
-    CURLOPT_HTTPHEADER => [
-        'Authorization: Bearer ' . $apiToken,
-    ],
-]);
-
-$response = curl_exec($ch);
-$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-if ($response === false || $statusCode >= 400) {
-    throw new RuntimeException(curl_error($ch) ?: 'Export feed request failed.');
-}
-
-curl_close($ch);
-
-$data = json_decode($response, true);
-print_r($data);`);
 
 const syncLocalState = (response?: McpApiKeyMutationResponse | null) => {
   if (!response) {
@@ -318,92 +245,7 @@ const runMutation = async (mutation, responseKey: string, successMessage: string
     </div>
 
     <Modal v-if="showInfoModal" v-model="showInfoModal" @closed="showInfoModal = false">
-      <div class="w-[min(62rem,calc(100vw-2rem))] rounded-3xl bg-white p-6 shadow-xl dark:bg-slate-900 sm:p-8">
-        <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div class="min-w-0">
-            <p class="text-sm font-semibold uppercase text-primary">
-              {{ t('companyProfile.mcpApiKey.info.eyebrow') }}
-            </p>
-            <h2 class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white-light">
-              {{ t('companyProfile.mcpApiKey.info.title') }}
-            </h2>
-            <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
-              {{ t('companyProfile.mcpApiKey.info.description') }}
-            </p>
-          </div>
-
-          <Button
-            :custom-class="neutralActionClass"
-            @click="showInfoModal = false"
-          >
-            {{ t('shared.button.cancel') }}
-          </Button>
-        </div>
-
-        <div class="mt-6 border-b border-slate-200 dark:border-slate-700">
-          <div class="flex gap-2 overflow-x-auto">
-            <button
-              v-for="tab in infoTabs"
-              :key="tab.name"
-              type="button"
-              class="border-b-2 px-4 py-3 text-sm font-semibold transition"
-              :class="activeInfoTab === tab.name ? 'border-primary text-primary' : 'border-transparent text-slate-500 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white-light'"
-              @click="activeInfoTab = tab.name"
-            >
-              {{ tab.label }}
-            </button>
-          </div>
-        </div>
-
-        <div class="mt-6 max-h-[65vh] overflow-y-auto pr-1">
-          <div v-if="activeInfoTab === 'claude'" class="space-y-5">
-            <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
-              <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-                {{ t('companyProfile.mcpApiKey.info.claude.title') }}
-              </h3>
-              <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
-                {{ t('companyProfile.mcpApiKey.info.claude.instructions') }}
-              </p>
-              <pre :class="codeBlockClass"><code>{{ claudeServerSnippet }}</code></pre>
-            </section>
-
-            <section class="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
-              <h3 class="text-lg font-semibold">
-                {{ t('companyProfile.mcpApiKey.info.claude.fullExampleTitle') }}
-              </h3>
-              <p class="mt-3 text-sm leading-6">
-                {{ t('companyProfile.mcpApiKey.info.claude.fullExampleDisclaimer') }}
-              </p>
-              <pre :class="codeBlockClass"><code>{{ claudeFullConfigSnippet }}</code></pre>
-            </section>
-          </div>
-
-          <div v-else class="space-y-5">
-            <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
-              <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-                {{ t('companyProfile.mcpApiKey.info.exportFeed.title') }}
-              </h3>
-              <p class="mt-3 text-sm leading-6 text-slate-500 dark:text-slate-300">
-                {{ t('companyProfile.mcpApiKey.info.exportFeed.description') }}
-              </p>
-            </section>
-
-            <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
-              <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-                {{ t('companyProfile.mcpApiKey.info.exportFeed.pythonTitle') }}
-              </h3>
-              <pre :class="codeBlockClass"><code>{{ pythonExportFeedSnippet }}</code></pre>
-            </section>
-
-            <section class="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-900/40">
-              <h3 class="text-lg font-semibold text-slate-900 dark:text-white-light">
-                {{ t('companyProfile.mcpApiKey.info.exportFeed.phpTitle') }}
-              </h3>
-              <pre :class="codeBlockClass"><code>{{ phpExportFeedSnippet }}</code></pre>
-            </section>
-          </div>
-        </div>
-      </div>
+      <McpApiKeyInfoModal :api-key="displayKey" @close="showInfoModal = false" />
     </Modal>
   </div>
 </template>

--- a/src/core/profile/company/meCompanyData.ts
+++ b/src/core/profile/company/meCompanyData.ts
@@ -21,12 +21,6 @@ export interface LanguageDetail {
     name: string;
 }
 
-export interface McpApiKeyData {
-  id: string;
-  maskedKey: string;
-  isActive: boolean;
-}
-
 export interface MeCompanyData {
   name: string;
   language: string;
@@ -43,7 +37,6 @@ export interface MeCompanyData {
   website?: string;
   multitenantuserSet: CompanyUser[];
   languageDetail: LanguageDetail;
-  mcpApiKey?: McpApiKeyData | null;
 }
 
 export interface MeCompanySubscriptionResult {
@@ -59,10 +52,9 @@ export interface MeCompanySubscriptionResult {
     phoneNumber: string;
     vatNumber: string;
     website: string;
-    multitenantuserSet: MultiTenantUser[];
-    languageDetail: LanguageDetail;
-    mcpApiKey?: McpApiKeyData | null;
-  };
+      multitenantuserSet: MultiTenantUser[];
+      languageDetail: LanguageDetail;
+    };
 }
 
 export interface MultiTenantUser {

--- a/src/core/profile/user/UserProfileController.vue
+++ b/src/core/profile/user/UserProfileController.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router';
 import ProfileTemplate from "./ProfileTemplate.vue";
 import { ShowProfile } from './containers/show-profile';
 import { ProfileEdit } from "./containers/profile-edit";
+import McpApiKeyPanel from "../company/containers/mcp-api-key-panel/McpApiKeyPanel.vue";
 import { Button } from "../../../shared/components/atoms/button";
 import { ApolloSubscription } from "./../../../shared/components/molecules/apollo-subscription";
 import { meSubscription } from "../../../shared/api/subscriptions/me.js";
@@ -17,6 +18,7 @@ const route = useRoute();
 const editView = ref(false);
 const unsavedChanges = ref(false);
 const tabItems = ref();
+const apolloSubRef = ref();
 
 interface MeSubscriptionResult {
   me: {
@@ -31,6 +33,11 @@ interface MeSubscriptionResult {
     isActive: boolean;
     dateJoined: string;
     avatarResizedFullUrl: string;
+    mcpApiKey?: {
+      id: string;
+      maskedKey: string;
+      isActive: boolean;
+    } | null;
   };
 }
 
@@ -68,9 +75,15 @@ if (tabItems.value.some(tab => tab.name === tabQueryParam)) {
 }
 
 const getMe = (result) => {
- const r: MeSubscriptionResult = result;
- return r.me;
+  const r: MeSubscriptionResult = result;
+  return r.me;
 }
+
+const handleRefreshRequested = () => {
+  if (apolloSubRef.value && apolloSubRef.value.refresh) {
+    apolloSubRef.value.refresh();
+  }
+};
 
 </script>
 
@@ -103,7 +116,7 @@ const getMe = (result) => {
               </div>
             </div>
 
-            <ApolloSubscription :subscription="meSubscription">
+            <ApolloSubscription :subscription="meSubscription" ref="apolloSubRef">
               <template v-slot:default="{ loading, error, result }">
                 <template v-if="!loading && result">
                   <div v-if="!editView">
@@ -112,6 +125,11 @@ const getMe = (result) => {
                   <div v-else>
                     <ProfileEdit :me-data="getMe(result)" :tabs="tabItems" @unsaved-changes="handleUnsavedChanges" @update-complete="handleUpdateComplete" />
                   </div>
+                  <McpApiKeyPanel
+                    class="mt-3"
+                    :me-data="getMe(result)"
+                    @refresh-requested="handleRefreshRequested"
+                  />
                 </template>
               </template>
             </ApolloSubscription>

--- a/src/core/profile/user/UserProfileController.vue
+++ b/src/core/profile/user/UserProfileController.vue
@@ -1,24 +1,31 @@
 <script lang="ts" setup>
-import { ref, watch, onMounted } from 'vue';
+import { computed, ref, watch, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import ProfileTemplate from "./ProfileTemplate.vue";
 import { ShowProfile } from './containers/show-profile';
 import { ProfileEdit } from "./containers/profile-edit";
 import McpApiKeyPanel from "../company/containers/mcp-api-key-panel/McpApiKeyPanel.vue";
 import { Button } from "../../../shared/components/atoms/button";
+import { Link } from "../../../shared/components/atoms/link";
+import { Icon } from "../../../shared/components/atoms/icon";
 import { ApolloSubscription } from "./../../../shared/components/molecules/apollo-subscription";
 import { meSubscription } from "../../../shared/api/subscriptions/me.js";
 import IconPencilPaper from '../../../shared/components/atoms/icons/icon-pencil-paper.vue';
 import IconX from '../../../shared/components/atoms/icons/icon-x.vue';
 import { useI18n } from 'vue-i18n';
 import LanguageDropdown from "../../../shared/components/molecules/languages-dropdown/LanguageDropdown.vue";
+import { injectAuth } from "../../../shared/modules/auth";
 
 const { t } = useI18n();
 const route = useRoute();
+const auth = injectAuth();
 const editView = ref(false);
 const unsavedChanges = ref(false);
 const tabItems = ref();
 const apolloSubRef = ref();
+const unreadNotificationCount = computed(() =>
+  (auth.user.notifications || []).filter((notification: any) => !notification.opened).length,
+);
 
 interface MeSubscriptionResult {
   me: {
@@ -112,6 +119,20 @@ const handleRefreshRequested = () => {
                     </span>
                   </Button>
                   <LanguageDropdown :show="true" class="w-max"/>
+                  <Link
+                    :path="{ name: 'profile.notifications' }"
+                    :aria-label="t('profile.notifications.actions.viewAll')"
+                    :title="t('profile.notifications.actions.viewAll')"
+                    class="relative inline-flex h-[46px] w-[46px] items-center justify-center rounded-2xl border border-slate-200 bg-white text-slate-600 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 hover:text-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:ring-offset-2 dark:border-slate-700 dark:bg-slate-900 dark:text-white-light dark:hover:bg-slate-800"
+                  >
+                    <Icon name="bell" class="h-5 w-5" />
+                    <span
+                      v-if="unreadNotificationCount"
+                      class="absolute -right-1 -top-1 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-bold leading-none text-white ring-2 ring-white dark:ring-slate-900"
+                    >
+                      {{ unreadNotificationCount }}
+                    </span>
+                  </Link>
                 </div>
               </div>
             </div>

--- a/src/core/profile/user/meData.ts
+++ b/src/core/profile/user/meData.ts
@@ -9,4 +9,11 @@ export interface MeData {
   timezone: string;
   isMultiTenantCompanyOwner: boolean;
   avatarResizedFullUrl?: string;
+  mcpApiKey?: McpApiKeyData | null;
+}
+
+export interface McpApiKeyData {
+  id: string;
+  maskedKey: string;
+  isActive: boolean;
 }

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -3470,7 +3470,11 @@
       "none": "",
       "unnamed": "",
       "source": "",
-      "jsonViewerHint": ""
+      "jsonViewerHint": "",
+      "emptyValue": "",
+      "emptyArray": "",
+      "emptyObject": "",
+      "item": ""
     },
     "placeholders": {
       "intervalHours": "",
@@ -3602,6 +3606,44 @@
         "resyncError": "",
         "bulkDeleteSuccess": "",
         "bulkDeleteError": ""
+      }
+    },
+    "aiImports": {
+      "title": "",
+      "show": {
+        "title": ""
+      },
+      "tabs": {
+        "overview": "",
+        "brokenRecords": ""
+      },
+      "fields": {
+        "tool": "",
+        "toolName": "",
+        "assignedViews": ""
+      },
+      "sections": {
+        "payloadContent": "",
+        "responseContent": ""
+      },
+      "empty": {
+        "assignedViews": ""
+      },
+      "tools": {
+        "GET_COMPANY_DETAILS": "",
+        "SEARCH_PRODUCTS": "",
+        "GET_PRODUCT": "",
+        "SEARCH_SALES_CHANNELS": "",
+        "CREATE_PRODUCT": "",
+        "UPSERT_PRODUCT": "",
+        "SEARCH_PROPERTIES": "",
+        "GET_PROPERTY": "",
+        "SEARCH_PROPERTY_SELECT_VALUES": "",
+        "GET_PROPERTY_SELECT_VALUE": "",
+        "CREATE_PROPERTY": "",
+        "EDIT_PROPERTY": "",
+        "CREATE_PROPERTY_SELECT_VALUE": "",
+        "EDIT_PROPERTY_SELECT_VALUE": ""
       }
     },
     "exports": {

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -3309,6 +3309,43 @@
           "exportFeed": ""
         },
         "claude": {
+          "requirements": {
+            "title": "",
+            "description": "",
+            "checkFirstTitle": "",
+            "checkFirstDescription": "",
+            "skipIfVersions": "",
+            "nodeDownloadLabel": "",
+            "tabs": {
+              "mac": "",
+              "windows": ""
+            },
+            "mac": {
+              "title": "",
+              "steps": {
+                "openTerminal": "",
+                "runArchitectureCommand": "",
+                "chooseArchitecture": "",
+                "downloadInstaller": "",
+                "runInstaller": "",
+                "verifyAgain": ""
+              },
+              "appleSilicon": "",
+              "intel": ""
+            },
+            "windows": {
+              "title": "",
+              "steps": {
+                "openCommandPrompt": "",
+                "openSettings": "",
+                "openAbout": "",
+                "chooseInstaller": "",
+                "downloadInstaller": "",
+                "runInstaller": "",
+                "verifyAgain": ""
+              }
+            }
+          },
           "title": "",
           "instructions": "",
           "fullExampleTitle": "",
@@ -3317,6 +3354,7 @@
         "exportFeed": {
           "title": "",
           "description": "",
+          "curlTitle": "",
           "pythonTitle": "",
           "phpTitle": ""
         }

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -3234,6 +3234,56 @@
     "changesMade": "",
     "messages": {
       "changePasswordMatch": ""
+    },
+    "mcpApiKey": {
+      "title": "",
+      "description": "",
+      "labels": {
+        "apiKey": "",
+        "status": "",
+        "accessControl": ""
+      },
+      "actions": {
+        "create": "",
+        "copy": "",
+        "regenerate": "",
+        "activate": "",
+        "deactivate": "",
+        "whatIsThisUsedFor": ""
+      },
+      "status": {
+        "active": "",
+        "inactive": "",
+        "notCreated": ""
+      },
+      "help": {
+        "rawKeyAvailable": "",
+        "rawKeyUnavailable": "",
+        "active": "",
+        "inactive": "",
+        "copyNow": ""
+      },
+      "placeholders": {
+        "key": ""
+      },
+      "empty": {
+        "title": "",
+        "description": ""
+      },
+      "messages": {
+        "createSuccess": "",
+        "regenerateSuccess": "",
+        "activateSuccess": "",
+        "deactivateSuccess": "",
+        "copySuccess": "",
+        "copyError": "",
+        "copyUnavailable": ""
+      },
+      "info": {
+        "eyebrow": "",
+        "title": "",
+        "description": ""
+      }
     }
   },
   "companyProfile": {
@@ -3620,7 +3670,8 @@
       "fields": {
         "tool": "",
         "toolName": "",
-        "assignedViews": ""
+        "assignedViews": "",
+        "userFullName": ""
       },
       "sections": {
         "payloadContent": "",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1044,6 +1044,110 @@
     "changesMade": "Changes were made",
     "messages": {
       "changePasswordMatch": "The passwords should match in order to update!"
+    },
+    "mcpApiKey": {
+      "title": "Personal API token",
+      "description": "Manage your personal API token used to authenticate both MCP clients and feed exports.",
+      "labels": {
+        "apiKey": "API token",
+        "status": "Status",
+        "accessControl": "Access control"
+      },
+      "actions": {
+        "create": "Create key",
+        "copy": "Copy key",
+        "regenerate": "Regenerate key",
+        "activate": "Activate key",
+        "deactivate": "Deactivate key",
+        "whatIsThisUsedFor": "What is this used for?"
+      },
+      "status": {
+        "active": "Active",
+        "inactive": "Inactive",
+        "notCreated": "Not created"
+      },
+      "help": {
+        "rawKeyAvailable": "This is the real key returned by the latest create or regenerate action. Store it now because you will not be able to see it again later.",
+        "rawKeyUnavailable": "For security, the real key is only shown once when you create or regenerate it. After that, only the masked key remains visible here.",
+        "active": "The token currently accepts requests from MCP clients and feed export consumers.",
+        "inactive": "The token is stored, but requests using it for MCP clients and feed exports are blocked until you activate it again.",
+        "copyNow": "Copy and store this key now. If you lose it, the only way to get a new real key is to regenerate it."
+      },
+      "placeholders": {
+        "key": "No key available"
+      },
+      "empty": {
+        "title": "No personal API token created yet",
+        "description": "Create a personal API token to allow MCP-enabled tools and feed exports to authenticate against your account."
+      },
+      "messages": {
+        "createSuccess": "API token created successfully.",
+        "regenerateSuccess": "API token regenerated successfully.",
+        "activateSuccess": "API token activated successfully.",
+        "deactivateSuccess": "API token deactivated successfully.",
+        "copySuccess": "API token copied to clipboard.",
+        "copyError": "We could not copy the API token. Please try again.",
+        "copyUnavailable": "The real key is only available immediately after create or regenerate. Regenerate the key if you need a new copy."
+      },
+      "info": {
+        "eyebrow": "API token",
+        "title": "What is this used for?",
+        "description": "Use this token as a bearer token when connecting external MCP clients or protected JSON export feeds to your account.",
+        "tabs": {
+          "claude": "Claude",
+          "exportFeed": "Export Feed"
+        },
+        "claude": {
+          "requirements": {
+            "title": "Before you set up Claude",
+            "description": "Claude needs Node.js on your computer before it can use the OneSila connection. Start with the quick check below.",
+            "checkFirstTitle": "First, check if you already have it",
+            "checkFirstDescription": "On a Mac, press Command + Space, type Terminal, and press Enter. On Windows, click Start, type Command Prompt, and press Enter. Then copy and paste these commands one at a time.",
+            "skipIfVersions": "If all three commands show version numbers, you can skip the install steps and continue with the Claude setup below.",
+            "nodeDownloadLabel": "Open the Node.js download page here:",
+            "tabs": {
+              "mac": "MacBook",
+              "windows": "Windows"
+            },
+            "mac": {
+              "title": "Install Node.js on a MacBook",
+              "steps": {
+                "openTerminal": "Open Terminal: press Command + Space on your keyboard, type Terminal, then press Enter.",
+                "runArchitectureCommand": "Run the command below to check your Mac type.",
+                "chooseArchitecture": "If it says arm64, choose Apple Silicon. If it says x86_64, choose Intel.",
+                "downloadInstaller": "Go to the Node.js download page, choose macOS, choose Installer, and select the architecture that matches your Mac.",
+                "runInstaller": "After the download finishes, open the installer file and follow the steps on screen.",
+                "verifyAgain": "When the installer is done, open Terminal again with Command + Space, type Terminal, press Enter, and run the three version commands to check that it worked."
+              },
+              "appleSilicon": "arm64 means your Mac uses Apple Silicon.",
+              "intel": "x86_64 means your Mac uses Intel."
+            },
+            "windows": {
+              "title": "Install Node.js on Windows",
+              "steps": {
+                "openCommandPrompt": "Open Command Prompt first: click the Start button at the bottom of the screen, type Command Prompt, then press Enter.",
+                "openSettings": "Open Settings from the Start menu.",
+                "openAbout": "Go to System, then About, and look for System type.",
+                "chooseInstaller": "If System type says ARM-based processor or ARM64, choose Windows ARM64 Installer. Otherwise, choose Windows x64 Installer.",
+                "downloadInstaller": "Go to the Node.js download page and download the correct Windows Installer (.msi).",
+                "runInstaller": "Open the downloaded .msi file and follow the steps on screen.",
+                "verifyAgain": "After installation, open Command Prompt: click Start, type Command Prompt, press Enter, and run the three version commands to check that it worked."
+              }
+            }
+          },
+          "title": "Claude Desktop MCP setup",
+          "instructions": "Open Settings > Developer > Edit Config, then add this section under the mcpServers key.",
+          "fullExampleTitle": "Full config example",
+          "fullExampleDisclaimer": "This full example can overwrite existing Claude settings. Merge it into your current config instead of replacing the whole file unless that is intentional."
+        },
+        "exportFeed": {
+          "title": "JSON export feed requests",
+          "description": "Export feed URLs require an Authorization header with this token as a bearer token. Replace the feed URL placeholder with the Feed URL from the export page.",
+          "curlTitle": "cURL example",
+          "pythonTitle": "Python example",
+          "phpTitle": "PHP example"
+        }
+      }
     }
   },
   "collaboration": {
@@ -6259,7 +6363,8 @@
       "fields": {
         "tool": "Tool",
         "toolName": "Tool name",
-        "assignedViews": "Assigned views"
+        "assignedViews": "Assigned views",
+        "userFullName": "User full name"
       },
       "sections": {
         "payloadContent": "Payload Content",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -6109,7 +6109,11 @@
       "none": "None",
       "unnamed": "Unnamed",
       "source": "Source",
-      "jsonViewerHint": "Structured values are shown as formatted JSON for easier review."
+      "jsonViewerHint": "Structured values are shown in expandable sections for easier review.",
+      "emptyValue": "Empty value",
+      "emptyArray": "No items",
+      "emptyObject": "No fields",
+      "item": "Item"
     },
     "placeholders": {
       "intervalHours": "e.g. 24",
@@ -6241,6 +6245,44 @@
         "resyncError": "Failed to resync mapped import.",
         "bulkDeleteSuccess": "Mapped imports deleted.",
         "bulkDeleteError": "Failed to delete mapped imports."
+      }
+    },
+    "aiImports": {
+      "title": "AI Imports",
+      "show": {
+        "title": "AI Import Details"
+      },
+      "tabs": {
+        "overview": "Overview",
+        "brokenRecords": "Broken Records"
+      },
+      "fields": {
+        "tool": "Tool",
+        "toolName": "Tool name",
+        "assignedViews": "Assigned views"
+      },
+      "sections": {
+        "payloadContent": "Payload Content",
+        "responseContent": "Response Content"
+      },
+      "empty": {
+        "assignedViews": "No assigned views"
+      },
+      "tools": {
+        "GET_COMPANY_DETAILS": "Get company details",
+        "SEARCH_PRODUCTS": "Search products",
+        "GET_PRODUCT": "Get product",
+        "SEARCH_SALES_CHANNELS": "Search sales channels",
+        "CREATE_PRODUCT": "Create product",
+        "UPSERT_PRODUCT": "Upsert product",
+        "SEARCH_PROPERTIES": "Search properties",
+        "GET_PROPERTY": "Get property",
+        "SEARCH_PROPERTY_SELECT_VALUES": "Search property select values",
+        "GET_PROPERTY_SELECT_VALUE": "Get property select value",
+        "CREATE_PROPERTY": "Create property",
+        "EDIT_PROPERTY": "Edit property",
+        "CREATE_PROPERTY_SELECT_VALUE": "Create property select value",
+        "EDIT_PROPERTY_SELECT_VALUE": "Edit property select value"
       }
     },
     "exports": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1193,6 +1193,43 @@
           "exportFeed": "Export Feed"
         },
         "claude": {
+          "requirements": {
+            "title": "Before you set up Claude",
+            "description": "Claude needs Node.js on your computer before it can use the OneSila connection. Start with the quick check below.",
+            "checkFirstTitle": "First, check if you already have it",
+            "checkFirstDescription": "On a Mac, press Command + Space, type Terminal, and press Enter. On Windows, click Start, type Command Prompt, and press Enter. Then copy and paste these commands one at a time.",
+            "skipIfVersions": "If all three commands show version numbers, you can skip the install steps and continue with the Claude setup below.",
+            "nodeDownloadLabel": "Open the Node.js download page here:",
+            "tabs": {
+              "mac": "MacBook",
+              "windows": "Windows"
+            },
+            "mac": {
+              "title": "Install Node.js on a MacBook",
+              "steps": {
+                "openTerminal": "Open Terminal: press Command + Space on your keyboard, type Terminal, then press Enter.",
+                "runArchitectureCommand": "Run the command below to check your Mac type.",
+                "chooseArchitecture": "If it says arm64, choose Apple Silicon. If it says x86_64, choose Intel.",
+                "downloadInstaller": "Go to the Node.js download page, choose macOS, choose Installer, and select the architecture that matches your Mac.",
+                "runInstaller": "After the download finishes, open the installer file and follow the steps on screen.",
+                "verifyAgain": "When the installer is done, open Terminal again with Command + Space, type Terminal, press Enter, and run the three version commands to check that it worked."
+              },
+              "appleSilicon": "arm64 means your Mac uses Apple Silicon.",
+              "intel": "x86_64 means your Mac uses Intel."
+            },
+            "windows": {
+              "title": "Install Node.js on Windows",
+              "steps": {
+                "openCommandPrompt": "Open Command Prompt first: click the Start button at the bottom of the screen, type Command Prompt, then press Enter.",
+                "openSettings": "Open Settings from the Start menu.",
+                "openAbout": "Go to System, then About, and look for System type.",
+                "chooseInstaller": "If System type says ARM-based processor or ARM64, choose Windows ARM64 Installer. Otherwise, choose Windows x64 Installer.",
+                "downloadInstaller": "Go to the Node.js download page and download the correct Windows Installer (.msi).",
+                "runInstaller": "Open the downloaded .msi file and follow the steps on screen.",
+                "verifyAgain": "After installation, open Command Prompt: click Start, type Command Prompt, press Enter, and run the three version commands to check that it worked."
+              }
+            }
+          },
           "title": "Claude Desktop MCP setup",
           "instructions": "Open Settings > Developer > Edit Config, then add this section under the mcpServers key.",
           "fullExampleTitle": "Full config example",
@@ -1201,6 +1238,7 @@
         "exportFeed": {
           "title": "JSON export feed requests",
           "description": "Export feed URLs require an Authorization header with this token as a bearer token. Replace the feed URL placeholder with the Feed URL from the export page.",
+          "curlTitle": "cURL example",
           "pythonTitle": "Python example",
           "phpTitle": "PHP example"
         }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -3303,6 +3303,43 @@
           "exportFeed": ""
         },
         "claude": {
+          "requirements": {
+            "title": "",
+            "description": "",
+            "checkFirstTitle": "",
+            "checkFirstDescription": "",
+            "skipIfVersions": "",
+            "nodeDownloadLabel": "",
+            "tabs": {
+              "mac": "",
+              "windows": ""
+            },
+            "mac": {
+              "title": "",
+              "steps": {
+                "openTerminal": "",
+                "runArchitectureCommand": "",
+                "chooseArchitecture": "",
+                "downloadInstaller": "",
+                "runInstaller": "",
+                "verifyAgain": ""
+              },
+              "appleSilicon": "",
+              "intel": ""
+            },
+            "windows": {
+              "title": "",
+              "steps": {
+                "openCommandPrompt": "",
+                "openSettings": "",
+                "openAbout": "",
+                "chooseInstaller": "",
+                "downloadInstaller": "",
+                "runInstaller": "",
+                "verifyAgain": ""
+              }
+            }
+          },
           "title": "",
           "instructions": "",
           "fullExampleTitle": "",
@@ -3311,6 +3348,7 @@
         "exportFeed": {
           "title": "",
           "description": "",
+          "curlTitle": "",
           "pythonTitle": "",
           "phpTitle": ""
         }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -3228,6 +3228,56 @@
     "changesMade": "",
     "messages": {
       "changePasswordMatch": ""
+    },
+    "mcpApiKey": {
+      "title": "",
+      "description": "",
+      "labels": {
+        "apiKey": "",
+        "status": "",
+        "accessControl": ""
+      },
+      "actions": {
+        "create": "",
+        "copy": "",
+        "regenerate": "",
+        "activate": "",
+        "deactivate": "",
+        "whatIsThisUsedFor": ""
+      },
+      "status": {
+        "active": "",
+        "inactive": "",
+        "notCreated": ""
+      },
+      "help": {
+        "rawKeyAvailable": "",
+        "rawKeyUnavailable": "",
+        "active": "",
+        "inactive": "",
+        "copyNow": ""
+      },
+      "placeholders": {
+        "key": ""
+      },
+      "empty": {
+        "title": "",
+        "description": ""
+      },
+      "messages": {
+        "createSuccess": "",
+        "regenerateSuccess": "",
+        "activateSuccess": "",
+        "deactivateSuccess": "",
+        "copySuccess": "",
+        "copyError": "",
+        "copyUnavailable": ""
+      },
+      "info": {
+        "eyebrow": "",
+        "title": "",
+        "description": ""
+      }
     }
   },
   "companyProfile": {
@@ -3614,7 +3664,8 @@
       "fields": {
         "tool": "",
         "toolName": "",
-        "assignedViews": ""
+        "assignedViews": "",
+        "userFullName": ""
       },
       "sections": {
         "payloadContent": "",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -3464,7 +3464,11 @@
       "none": "",
       "unnamed": "",
       "source": "",
-      "jsonViewerHint": ""
+      "jsonViewerHint": "",
+      "emptyValue": "",
+      "emptyArray": "",
+      "emptyObject": "",
+      "item": ""
     },
     "placeholders": {
       "intervalHours": "",
@@ -3596,6 +3600,44 @@
         "resyncError": "",
         "bulkDeleteSuccess": "",
         "bulkDeleteError": ""
+      }
+    },
+    "aiImports": {
+      "title": "",
+      "show": {
+        "title": ""
+      },
+      "tabs": {
+        "overview": "",
+        "brokenRecords": ""
+      },
+      "fields": {
+        "tool": "",
+        "toolName": "",
+        "assignedViews": ""
+      },
+      "sections": {
+        "payloadContent": "",
+        "responseContent": ""
+      },
+      "empty": {
+        "assignedViews": ""
+      },
+      "tools": {
+        "GET_COMPANY_DETAILS": "",
+        "SEARCH_PRODUCTS": "",
+        "GET_PRODUCT": "",
+        "SEARCH_SALES_CHANNELS": "",
+        "CREATE_PRODUCT": "",
+        "UPSERT_PRODUCT": "",
+        "SEARCH_PROPERTIES": "",
+        "GET_PROPERTY": "",
+        "SEARCH_PROPERTY_SELECT_VALUES": "",
+        "GET_PROPERTY_SELECT_VALUE": "",
+        "CREATE_PROPERTY": "",
+        "EDIT_PROPERTY": "",
+        "CREATE_PROPERTY_SELECT_VALUE": "",
+        "EDIT_PROPERTY_SELECT_VALUE": ""
       }
     },
     "exports": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -862,6 +862,43 @@
           "exportFeed": ""
         },
         "claude": {
+          "requirements": {
+            "title": "",
+            "description": "",
+            "checkFirstTitle": "",
+            "checkFirstDescription": "",
+            "skipIfVersions": "",
+            "nodeDownloadLabel": "",
+            "tabs": {
+              "mac": "",
+              "windows": ""
+            },
+            "mac": {
+              "title": "",
+              "steps": {
+                "openTerminal": "",
+                "runArchitectureCommand": "",
+                "chooseArchitecture": "",
+                "downloadInstaller": "",
+                "runInstaller": "",
+                "verifyAgain": ""
+              },
+              "appleSilicon": "",
+              "intel": ""
+            },
+            "windows": {
+              "title": "",
+              "steps": {
+                "openCommandPrompt": "",
+                "openSettings": "",
+                "openAbout": "",
+                "chooseInstaller": "",
+                "downloadInstaller": "",
+                "runInstaller": "",
+                "verifyAgain": ""
+              }
+            }
+          },
           "title": "",
           "instructions": "",
           "fullExampleTitle": "",
@@ -870,6 +907,7 @@
         "exportFeed": {
           "title": "",
           "description": "",
+          "curlTitle": "",
           "pythonTitle": "",
           "phpTitle": ""
         }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -715,7 +715,57 @@
       "confirmNewPassword": "Bevestig uw nieuw wachtwoord"
     },
     "unsavedChanges": "U heeft niet opgeslagen wijzigingen.  Zeker dat u verder wilt gaan?",
-    "changesMade": "Er zijn veranderingen"
+    "changesMade": "Er zijn veranderingen",
+    "mcpApiKey": {
+      "title": "",
+      "description": "",
+      "labels": {
+        "apiKey": "",
+        "status": "",
+        "accessControl": ""
+      },
+      "actions": {
+        "create": "",
+        "copy": "",
+        "regenerate": "",
+        "activate": "",
+        "deactivate": "",
+        "whatIsThisUsedFor": ""
+      },
+      "status": {
+        "active": "",
+        "inactive": "",
+        "notCreated": ""
+      },
+      "help": {
+        "rawKeyAvailable": "",
+        "rawKeyUnavailable": "",
+        "active": "",
+        "inactive": "",
+        "copyNow": ""
+      },
+      "placeholders": {
+        "key": ""
+      },
+      "empty": {
+        "title": "",
+        "description": ""
+      },
+      "messages": {
+        "createSuccess": "",
+        "regenerateSuccess": "",
+        "activateSuccess": "",
+        "deactivateSuccess": "",
+        "copySuccess": "",
+        "copyError": "",
+        "copyUnavailable": ""
+      },
+      "info": {
+        "eyebrow": "",
+        "title": "",
+        "description": ""
+      }
+    }
   },
   "collaboration": {
     "title": "",
@@ -5333,7 +5383,8 @@
       "fields": {
         "tool": "",
         "toolName": "",
-        "assignedViews": ""
+        "assignedViews": "",
+        "userFullName": ""
       },
       "sections": {
         "payloadContent": "",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -5183,7 +5183,11 @@
       "none": "",
       "unnamed": "",
       "source": "",
-      "jsonViewerHint": ""
+      "jsonViewerHint": "",
+      "emptyValue": "",
+      "emptyArray": "",
+      "emptyObject": "",
+      "item": ""
     },
     "placeholders": {
       "intervalHours": "",
@@ -5315,6 +5319,44 @@
         "resyncError": "",
         "bulkDeleteSuccess": "",
         "bulkDeleteError": ""
+      }
+    },
+    "aiImports": {
+      "title": "",
+      "show": {
+        "title": ""
+      },
+      "tabs": {
+        "overview": "",
+        "brokenRecords": ""
+      },
+      "fields": {
+        "tool": "",
+        "toolName": "",
+        "assignedViews": ""
+      },
+      "sections": {
+        "payloadContent": "",
+        "responseContent": ""
+      },
+      "empty": {
+        "assignedViews": ""
+      },
+      "tools": {
+        "GET_COMPANY_DETAILS": "",
+        "SEARCH_PRODUCTS": "",
+        "GET_PRODUCT": "",
+        "SEARCH_SALES_CHANNELS": "",
+        "CREATE_PRODUCT": "",
+        "UPSERT_PRODUCT": "",
+        "SEARCH_PROPERTIES": "",
+        "GET_PROPERTY": "",
+        "SEARCH_PROPERTY_SELECT_VALUES": "",
+        "GET_PROPERTY_SELECT_VALUE": "",
+        "CREATE_PROPERTY": "",
+        "EDIT_PROPERTY": "",
+        "CREATE_PROPERTY_SELECT_VALUE": "",
+        "EDIT_PROPERTY_SELECT_VALUE": ""
       }
     },
     "exports": {

--- a/src/shared/api/queries/mcpToolRuns.js
+++ b/src/shared/api/queries/mcpToolRuns.js
@@ -1,0 +1,64 @@
+import { gql } from 'graphql-tag';
+
+const assignedViewFields = `
+  assignedViews {
+    id
+    name
+    url
+  }
+`;
+
+const mcpToolRunListFields = `
+  id
+  proxyId
+  name
+  toolName
+  tool
+  percentage
+  totalRecords
+  createdAt
+`;
+
+const mcpToolRunDetailFields = `
+  ${mcpToolRunListFields}
+  percentageColor
+  payloadContent
+  responseContent
+  errorTraceback
+  ${assignedViewFields}
+`;
+
+export const mcpToolRunsQuery = gql`
+  query McpToolRuns(
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
+    $order: McpToolRunOrder
+    $filter: McpToolRunFilter
+  ) {
+    mcpToolRuns(first: $first, last: $last, after: $after, before: $before, order: $order, filters: $filter) {
+      edges {
+        node {
+          ${mcpToolRunListFields}
+        }
+        cursor
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      }
+    }
+  }
+`;
+
+export const mcpToolRunQuery = gql`
+  query McpToolRun($id: GlobalID!) {
+    mcpToolRun(id: $id) {
+      ${mcpToolRunDetailFields}
+    }
+  }
+`;

--- a/src/shared/api/queries/mcpToolRuns.js
+++ b/src/shared/api/queries/mcpToolRuns.js
@@ -12,15 +12,16 @@ const mcpToolRunListFields = `
   id
   proxyId
   name
+  userFullName
   toolName
   tool
-  percentage
   totalRecords
   createdAt
 `;
 
 const mcpToolRunDetailFields = `
   ${mcpToolRunListFields}
+  percentage
   percentageColor
   payloadContent
   responseContent

--- a/src/shared/api/queries/me.js
+++ b/src/shared/api/queries/me.js
@@ -44,11 +44,6 @@ export const myMultiTenantCompanyQuery = gql`
     myMultiTenantCompany {
       id
       name
-      mcpApiKey {
-        id
-        maskedKey
-        isActive
-      }
       multitenantuserSet {
         id
         firstName

--- a/src/shared/api/subscriptions/me.js
+++ b/src/shared/api/subscriptions/me.js
@@ -15,6 +15,11 @@ export const meSubscription = gql`
         isActive
         dateJoined
         avatarResizedFullUrl
+        mcpApiKey {
+          id
+          maskedKey
+          isActive
+        }
         notifications {
           id
           type
@@ -49,11 +54,6 @@ export const meCompanySubscription = gql`
       languageDetail {
          code
          name
-      }
-      mcpApiKey {
-        id
-        maskedKey
-        isActive
       }
       languages
       multitenantuserSet {

--- a/src/shared/components/molecules/recursive-accordion/RecursiveAccordion.vue
+++ b/src/shared/components/molecules/recursive-accordion/RecursiveAccordion.vue
@@ -1,9 +1,159 @@
 <script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { Accordion } from '../../atoms/accordion';
 
+defineOptions({
+  name: 'RecursiveAccordion',
+});
+
+const props = withDefaults(defineProps<{
+  value: unknown;
+  depth?: number;
+  startExpanded?: boolean;
+}>(), {
+  depth: 0,
+  startExpanded: false,
+});
+
+const { t } = useI18n();
+
+const isPrimitive = (value: unknown) =>
+  value === null || ['string', 'number', 'boolean'].includes(typeof value);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const humanizeKey = (value: string) =>
+  value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+
+const formatPrimitive = (value: unknown) => {
+  if (value === null || value === undefined || value === '') {
+    return t('importsExports.shared.emptyValue');
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  return String(value);
+};
+
+const arrayValue = computed(() => (Array.isArray(props.value) ? props.value : []));
+const objectEntries = computed(() =>
+  isPlainObject(props.value)
+    ? Object.entries(props.value).map(([key, value]) => ({
+      key,
+      label: humanizeKey(key),
+      value,
+    }))
+    : [],
+);
+
+const getArrayItemLabel = (value: unknown, index: number) => {
+  const itemLabel = t('importsExports.shared.item');
+  const prefix = `${itemLabel} ${index + 1}`;
+
+  if (isPrimitive(value)) {
+    const formatted = formatPrimitive(value);
+    return formatted === t('importsExports.shared.emptyValue') ? prefix : `${prefix}: ${formatted}`;
+  }
+
+  if (isPlainObject(value)) {
+    const candidateKeys = ['name', 'title', 'label', 'value', 'id'];
+    const match = candidateKeys.find((key) => isPrimitive(value[key]) && value[key] !== null && value[key] !== '');
+
+    if (match) {
+      return `${prefix}: ${formatPrimitive(value[match])}`;
+    }
+  }
+
+  return prefix;
+};
+
+const accordionItems = computed(() =>
+  arrayValue.value.map((item, index) => ({
+    name: `item-${index}`,
+    label: getArrayItemLabel(item, index),
+  })),
+);
+
+const defaultActiveItem = computed(() => {
+  if (!props.startExpanded || !accordionItems.value.length) {
+    return null;
+  }
+
+  return accordionItems.value[0].name;
+});
 </script>
 
 <template>
-<div>
-  TO BE IMPLEMENTED
-</div>
+  <div class="space-y-3">
+    <div v-if="isPrimitive(value)" class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 break-words">
+      {{ formatPrimitive(value) }}
+    </div>
+
+    <div v-else-if="Array.isArray(value)">
+      <div
+        v-if="!arrayValue.length"
+        class="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500"
+      >
+        {{ t('importsExports.shared.emptyArray') }}
+      </div>
+
+      <Accordion v-else :items="accordionItems" :default-active="defaultActiveItem">
+        <template
+          v-for="(item, index) in arrayValue"
+          :key="`array-item-${depth}-${index}`"
+          #[`item-${index}`]
+        >
+          <div class="space-y-3">
+            <div
+              v-if="isPrimitive(item)"
+              class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 break-words"
+            >
+              {{ formatPrimitive(item) }}
+            </div>
+            <RecursiveAccordion v-else :value="item" :depth="depth + 1" />
+          </div>
+        </template>
+      </Accordion>
+    </div>
+
+    <div v-else>
+      <div
+        v-if="!objectEntries.length"
+        class="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-500"
+      >
+        {{ t('importsExports.shared.emptyObject') }}
+      </div>
+
+      <div v-else class="space-y-3">
+        <section
+          v-for="entry in objectEntries"
+          :key="`${depth}-${entry.key}`"
+          class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+        >
+          <div class="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            {{ entry.label }}
+          </div>
+
+          <div class="mt-3">
+            <div
+              v-if="isPrimitive(entry.value)"
+              class="rounded-lg bg-slate-50 px-4 py-3 text-sm text-slate-700 break-words"
+            >
+              {{ formatPrimitive(entry.value) }}
+            </div>
+            <RecursiveAccordion v-else :value="entry.value" :depth="depth + 1" />
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
 </template>

--- a/src/shared/components/organisms/nav-bar/navItems.ts
+++ b/src/shared/components/organisms/nav-bar/navItems.ts
@@ -80,6 +80,10 @@ export const navSections: NavSection[] = [
                         route: { name: 'importsExports.exports.list' },
                         title: 'importsExports.exports.title',
                     },
+                    {
+                        route: { name: 'importsExports.aiImports.list' },
+                        title: 'importsExports.aiImports.title',
+                    },
                 ]
             },
         ]

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -293,7 +293,7 @@ export const PROGRESS_BAR_UI_BY_STATUS: Record<string, ProgressBarUi> = {
     labelColor: 'text-yellow-500',
     barColor: 'bg-yellow-400',
   },
-  STATUS_PENDING_EXTERNAL_DOCUMENTS: {
+  PENDING_EXTERNAL_DOCUMENTS: {
     labelKey: 'integrations.show.products.statuses.pendingExternalDocuments',
     labelColor: 'text-orange-600',
     barColor: 'bg-orange-500',


### PR DESCRIPTION
## Summary by Sourcery

Move MCP API key management to the user profile, introduce AI imports (MCP tool runs) listing and detail views with reusable broken-records handling, and improve structured JSON inspection and integration status handling.

New Features:
- Add MCP API key info modal with detailed Claude and export feed setup guidance and integrate MCP key panel into the user profile with notification badge.
- Introduce AI imports pages (list and show) backed by MCP tool run queries, including filters, badges, progress display, assigned views, and navigation entry.
- Implement a recursive accordion component and structured data section for exploring nested JSON/objects in the UI.

Bug Fixes:
- Fix status mapping and progress bar constants to use the correct PENDING_EXTERNAL_DOCUMENTS status value across integrations and product website listings.

Enhancements:
- Refactor broken records UI into a shared ImportBrokenRecordsTab used by mapped imports and AI imports.
- Switch MCP API key i18n namespace from company profile to generic profile and adjust data models to store the key on the user instead of the company.
- Improve JSON preview modal to render structured data via the recursive accordion instead of raw JSON text.
- Align Mirakl/Sales Channel product status handling to use unified remote status logic and updated PENDING_EXTERNAL_DOCUMENTS key.